### PR TITLE
feat: add welcome message customization to replace 'Claude Code' with custom text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **New:** Add welcome message customization - replaces "Claude Code" with custom text in the welcome message when customText is defined
+
 ## [v1.1.4](https://github.com/Piebald-AI/tweakcc/releases/tag/v1.1.4) - 2025-08-25
 
 - **New:** `--apply` CLI option to apply stored customizations without interactive UI (#33) - @patrickjaja

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- **New:** Add welcome message customization - replaces "Claude Code" with custom text in the welcome message when customText is defined
 
 ## [v1.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v1.2.0) - 2025-08-25
 
 - **New:** Bring back the token counter and elapsed time metric (#37) - @bl-ue
-- **New:** Add welcome message customization - replaces "Claude Code" with custom text in the welcome message when customText is defined
 
 ## [v1.1.4](https://github.com/Piebald-AI/tweakcc/releases/tag/v1.1.4) - 2025-08-25
 

--- a/src/utils/patching.ts
+++ b/src/utils/patching.ts
@@ -116,7 +116,6 @@ export function writeWelcomeMessage(
     location.endIndex
   );
 
-  console.log('patch: welcome message: replaced successfully');
   return newFile;
 }
 
@@ -738,8 +737,9 @@ export const applyCustomization = async (
       content = result;
 
     // Also apply customText to welcome message if it's defined
-    if (c.customText) {
-      if ((result = writeWelcomeMessage(content, c.customText)))
+    const welcomeMessage = c.method === 'custom' ? c.customText : c.figletText;
+    if (welcomeMessage) {
+      if ((result = writeWelcomeMessage(content, welcomeMessage)))
         content = result;
     }
   }

--- a/src/utils/patching.ts
+++ b/src/utils/patching.ts
@@ -96,7 +96,7 @@ export function writeWelcomeMessage(
 ): string | null {
   const location = getWelcomeMessageLocation(oldFile);
   if (!location) {
-    console.log('patch: welcome message: failed to find location');
+    console.error('patch: welcome message: failed to find location');
     return null;
   }
 


### PR DESCRIPTION
- **New:** Add welcome message customization - replaces "Claude Code" with custom text in the welcome message when customText is defined ("method": "custom")


This time cant find anything that is breaking, so should be fine. if you like you can double check! Thanks

(went defensive approach to replace that welcome text and not replacing all and reverting the api related one)