### PR TITLE
Add fnm multishell path to the search dirs

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -996,6 +996,7 @@ const getClijsSearchPathsWithInfo = (): SearchPathInfo[] => {
 
     // fnm (https://github.com/Schniz/fnm)
     addPath(`${home}/.fnm/node-versions/*/installation/lib/${mod}`, true);
+    addPath(`${home}/.local/state/fnm_multishells/*/lib/${mod}`, true);
 
     // nvm (https://github.com/nvm-sh/nvm) - system & user
     addPath(`/usr/local/nvm/versions/node/*/lib/${mod}`, true);


### PR DESCRIPTION
FNM users may have claude paths that resolve to something like `/Users/me/.local/state/fnm_multishells/83926_1761897468974/bin/claude`.