### PR TITLE
fix: use createRequire for node-lief in ESM context

### DIFF
--- a/src/utils/nativeInstallation.ts
+++ b/src/utils/nativeInstallation.ts
@@ -4,8 +4,12 @@
 
 import fs from 'node:fs';
 import { execSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import type LIEF from 'node-lief';
 import { isDebug } from './misc.js';
+
+// Create a require function that works in ESM context
+const require = createRequire(import.meta.url);
 
 let liefModule: typeof LIEF | null = null;
 
@@ -15,7 +19,6 @@ let liefModule: typeof LIEF | null = null;
  */
 function getLIEF(): typeof LIEF {
   if (liefModule === null) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     liefModule = require('node-lief');
   }
   return liefModule as typeof LIEF;


### PR DESCRIPTION
## Summary
- Fix native installation detection failing in ESM builds due to missing `require` function
- Use `createRequire(import.meta.url)` to create a require function that works in ESM modules

## Problem
When running `tweakcc` with a native Claude Code installation (the standalone binary, not npm package), the extraction fails with:
```
Calling `require` for "node-lief" in an environment that doesn't expose the `require` function.
```

This happens because the Vite/Rolldown build produces an ESM module, but the code uses a bare `require('node-lief')` which doesn't exist in ESM context.

## Solution
Import `createRequire` from `node:module` and use it to create a require function that works in ESM modules.

## Test plan
- [ ] Run `tweakcc --debug` with a native Claude Code installation
- [ ] Verify native binary is detected and claude.js is extracted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)