### PR TITLE
fix: increase thinkerFormat search window to 1000 chars

### DIFF
--- a/src/patches/thinkerFormat.ts
+++ b/src/patches/thinkerFormat.ts
@@ -12,10 +12,10 @@ const getThinkerFormatLocation = (oldFile: string): LocationResult | null => {
     return null;
   }
 
-  // Search within a range of 600 characters
+  // Search within a range of 1000 characters to support CC 2.0.76+
   const searchSection = oldFile.slice(
     approxAreaMatch.index,
-    approxAreaMatch.index + 600
+    approxAreaMatch.index + 1000
   );
 
   // New nullish format: N=(Y??C?.activeForm??L)+"…"


### PR DESCRIPTION
In Claude Code 2.0.76, the thinker format pattern is ~797 chars from where `approxAreaMatch` starts. The current search window of 600 characters is too small, causing the patch to fail with:

```
patch: thinker format: failed to find formatMatch
```

Fixes #296