### PR TITLE
Update node-lief

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ink": "^6.1.0",
     "ink-image": "^2.0.0",
     "ink-link": "^4.1.0",
-    "node-lief": "^0.1.7",
+    "node-lief": "^0.1.8",
     "ollama": "^0.6.0",
     "openai": "^6.3.0",
     "react": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(ink@6.1.0(@types/react@18.3.23)(react-devtools-core@4.19.1)(react@19.1.1))
       node-lief:
-        specifier: ^0.1.7
-        version: 0.1.7
+        specifier: ^0.1.8
+        version: 0.1.8
       ollama:
         specifier: ^0.6.0
         version: 0.6.0
@@ -953,8 +953,8 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
-  detect-libc@2.0.4:
-    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   doctrine@2.1.0:
@@ -1664,8 +1664,8 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
-  node-lief@0.1.7:
-    resolution: {integrity: sha512-lNh8oKpBWwXiZOeYK21FR6lj6MDMS4+wfjnghoNlEjzSFZtO78CsYkRVvH+Kl8yJK+HnTbxdAYrXMT5dN3J7KQ==}
+  node-lief@0.1.8:
+    resolution: {integrity: sha512-95zPX/ocV6ahQLkaAAJh6UUIz2s8GUHb2aDDfLAPStfIeI928QDNViNBk2NzJAUrp9bgzSqAXRGofbzyMEVUMA==}
 
   npm-run-path@2.0.2:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
@@ -3211,7 +3211,7 @@ snapshots:
 
   defu@6.1.4: {}
 
-  detect-libc@2.0.4:
+  detect-libc@2.1.2:
     optional: true
 
   doctrine@2.1.0:
@@ -3933,7 +3933,7 @@ snapshots:
 
   lightningcss@1.30.1:
     dependencies:
-      detect-libc: 2.0.4
+      detect-libc: 2.1.2
     optionalDependencies:
       lightningcss-darwin-arm64: 1.30.1
       lightningcss-darwin-x64: 1.30.1
@@ -4027,7 +4027,7 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
-  node-lief@0.1.7:
+  node-lief@0.1.8:
     dependencies:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4


### PR DESCRIPTION
This will make native installation support work on ARM64 for older glibc versions (down to 2.28), which fixes @maxritter's issue in #318.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to maintain compatibility and ensure optimal performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->