### PR TITLE
fix(thinkingVisibility): support v2.1.x native binary format

### DIFF
--- a/.claude/current-session
+++ b/.claude/current-session
@@ -1,0 +1,1 @@
+ad0db82b-f95e-4189-b804-edaf9cd6bd80

--- a/src/patches/thinkingVisibility.ts
+++ b/src/patches/thinkingVisibility.ts
@@ -120,12 +120,12 @@ export const writeThinkingVisibility = (oldFile: string): string | null => {
 
   // Patch 1: Case statement visibility
   const caseLocation = getCaseStatementLocation(oldFile);
-  if (caseLocation) {
+  if (caseLocation?.identifiers) {
     let replacement: string;
 
-    if (caseLocation.identifiers!.length === 4) {
+    if (caseLocation.identifiers.length === 4) {
       // Old format: remove if/return and set isTranscriptMode to true
-      replacement = `${caseLocation.identifiers![0]}${caseLocation.identifiers![1]}${caseLocation.identifiers![2]}${caseLocation.identifiers![3]}`;
+      replacement = `${caseLocation.identifiers[0]}${caseLocation.identifiers[1]}${caseLocation.identifiers[2]}${caseLocation.identifiers[3]}`;
     } else {
       // New format: replace variable names with 1
       replacement = `case"thinking":{if(!1&&!1)return null`;
@@ -148,8 +148,8 @@ export const writeThinkingVisibility = (oldFile: string): string | null => {
 
   // Patch 2: FbH collapsed view (use newFile to account for offset changes)
   const fbhLocation = getFbhCollapsedLocation(newFile);
-  if (fbhLocation) {
-    const returnVar = fbhLocation.identifiers![2];
+  if (fbhLocation?.identifiers?.[2]) {
+    const returnVar = fbhLocation.identifiers[2];
     const replacement = `if(!(1||1))return ${returnVar}`;
 
     const patchedFile =
@@ -167,6 +167,11 @@ export const writeThinkingVisibility = (oldFile: string): string | null => {
 
     newFile = patchedFile;
     anyPatched = true;
+  }
+
+  // Warn if only partial patching applied (both patches needed for full visibility)
+  if (anyPatched && (!caseLocation || !fbhLocation)) {
+    console.warn('patch: thinkingVisibility: only partial patching applied');
   }
 
   return anyPatched ? newFile : null;


### PR DESCRIPTION
## Summary

Fixes `thinkingVisibility` patch for Claude Code v2.1.x native binaries.

The current patch fails with:
```
patch: thinkingVisibility: failed to find thinking visibility pattern
```

### Root cause

Two issues:
1. The v2.1.x minified format has an opening brace after `case"thinking":` that the current regex doesn't expect
2. Full visibility requires patching TWO locations, not just one

### Solution

**Patch 1: Case statement** - prevents thinking blocks from being skipped
```javascript
// Original
case"thinking":{if(!J&&!I)return null
// Patched  
case"thinking":{if(!1&&!1)return null
```

**Patch 2: FbH collapsed view** - shows expanded view instead of "(ctrl+o to expand)"
```javascript
// Original
if(!(A||L))return p0H
// Patched
if(!(1||1))return p0H
```

### Key changes

- Add support for new v2.1.x format with opening brace after case
- Add second patch for FbH collapsed view function  
- Use flexible regex to handle variable name changes between versions
- Maintain backwards compatibility with older format
- Patch FIRST occurrence only (binary has duplicate code sections)

## Test plan

- [x] Tested on Claude Code v2.1.2 native binary (Linux x64)
- [x] All existing tests pass
- [x] Build succeeds

## Note

Other patches also need updating for v2.1.x (thinker verbs, context limit, etc.) - those are separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the "thinking visibility" behavior to more reliably reveal thinking content across multiple version formats and patterns.
  * Applies a coordinated two-step update process to expand collapsed views more safely, using incremental changes to preserve correctness.
  * Better error/warning messages when only partial updates can be applied, increasing diagnostic clarity for edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->