### PR TITLE
fix: make userMessageDisplay opt-in to prevent CC 2.1.6+ input bug

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -731,6 +731,7 @@ export const DEFAULT_SETTINGS: Settings = {
     reverseMirror: true,
   },
   userMessageDisplay: {
+    enabled: false,
     format: ' > {} ',
     styling: [],
     foregroundColor: 'default',

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -540,27 +540,42 @@ export const applyCustomization = async (
   if ((result = writeThinkerSymbolMirrorOption(content, config.settings.thinkingStyle.reverseMirror)))
     content = result;
 
-  // Apply user message display customization
-  if (config.settings.userMessageDisplay) {
+  // Apply user message display customization (opt-in only due to CC 2.1.6+ compatibility issues)
+  const displayConfig = config.settings.userMessageDisplay;
+  if (displayConfig?.enabled === true) {
     if (
       (result = writeUserMessageDisplay(
         content,
-        config.settings.userMessageDisplay.format,
-        config.settings.userMessageDisplay.foregroundColor,
-        config.settings.userMessageDisplay.backgroundColor,
-        config.settings.userMessageDisplay.styling.includes('bold'),
-        config.settings.userMessageDisplay.styling.includes('italic'),
-        config.settings.userMessageDisplay.styling.includes('underline'),
-        config.settings.userMessageDisplay.styling.includes('strikethrough'),
-        config.settings.userMessageDisplay.styling.includes('inverse'),
-        config.settings.userMessageDisplay.borderStyle,
-        config.settings.userMessageDisplay.borderColor,
-        config.settings.userMessageDisplay.paddingX,
-        config.settings.userMessageDisplay.paddingY,
-        config.settings.userMessageDisplay.fitBoxToContent
+        displayConfig.format,
+        displayConfig.foregroundColor,
+        displayConfig.backgroundColor,
+        displayConfig.styling.includes('bold'),
+        displayConfig.styling.includes('italic'),
+        displayConfig.styling.includes('underline'),
+        displayConfig.styling.includes('strikethrough'),
+        displayConfig.styling.includes('inverse'),
+        displayConfig.borderStyle,
+        displayConfig.borderColor,
+        displayConfig.paddingX,
+        displayConfig.paddingY,
+        displayConfig.fitBoxToContent
       ))
     ) {
       content = result;
+    }
+  } else if (displayConfig) {
+    // Warn users who may have had custom styling that it's now disabled by default
+    const hasCustomStyling =
+      displayConfig.format !== ' > {} ' ||
+      (displayConfig.styling?.length ?? 0) > 0 ||
+      displayConfig.foregroundColor !== 'default' ||
+      displayConfig.backgroundColor !== null ||
+      displayConfig.borderStyle !== 'none';
+    if (hasCustomStyling) {
+      console.log(
+        'Note: User message display customization is disabled by default due to compatibility issues with Claude Code 2.1.6+. ' +
+          'Set "enabled": true in your userMessageDisplay config to re-enable (use at your own risk).'
+      );
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export interface ThinkingStyleConfig {
 }
 
 export interface UserMessageDisplayConfig {
+  enabled?: boolean;
   format: string;
   styling: string[];
   foregroundColor: string | 'default';


### PR DESCRIPTION
   1 ## Summary
   2 
   3 The `userMessageDisplay` patch causes an "insta-ESC" bug on Claude Code 2.1.6 where user input is immediately cancelled/escaped. This makes Claude Code completely unusable when the patch is applied.
   4 
   5 ### Root Cause
   6 
   7 The patch modifies the component structure for rendering user messages (wrapping in a Box component, changing the React element tree). This structural change appears to interfere with input handling in CC 2.1.6+.
   8 
   9 ### The Fix
  10 
  11 Make `userMessageDisplay` **opt-in** instead of always-on:
  12 
  13 - Add `enabled?: boolean` field to `UserMessageDisplayConfig` type
  14 - Default to `enabled: false` in `DEFAULT_SETTINGS`
  15 - Only apply the patch when `enabled === true` (strict equality check)
  16 - Show a helpful migration warning for users who have custom styling configured but haven't explicitly enabled the feature
  17 
  18 This allows users to continue using all other tweakcc features (themes, thinking verbs, etc.) safely, while making `userMessageDisplay` opt-in for those willing to test it on their CC version.
  19 
  20 ### Why `enabled === true` (not `!== false`)
  21 
  22 Existing user configs won't have the `enabled` key, so:
  23 - `undefined !== false` → `true` ❌ would still apply broken patch
  24 - `undefined === true` → `false` ✅ safely skips the patch
  25 
  26 ## Test Plan
  27 
  28 - [x] TypeScript compiles without errors
  29 - [x] All existing tests pass (132 passed)
  30 - [x] Tested on Claude Code 2.1.6 - confirmed working
  31 - [x] Other tweakcc features (themes, thinking verbs) still work correctly
  32 - [x] Migration warning displays for users with custom styling
  33 
  34 ## Files Changed
  35 
  36 - `src/types.ts` - Added `enabled?: boolean` to `UserMessageDisplayConfig`
  37 - `src/defaultSettings.ts` - Set `enabled: false` as default
  38 - `src/patches/index.ts` - Check for explicit opt-in + migration warning
  39 
  40 ---
  41 
  42 🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User message display customization is now disabled by default to improve compatibility. Enable it explicitly in settings if custom styling is needed.

* **Improvements**
  * Added warning notifications alerting users when message customization is configured but disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->