### PR TITLE
Add a fallback for WASMagic when it's not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add a fallback for WASMagic when it's not available (#399) - @signadou
+
 ## [v3.4.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v3.4.0) - 2026-01-18
 
 - Add input pattern highlighters (#387) - @bl-ue


### PR DESCRIPTION
Closes #346 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation detection robustness by adding a graceful fallback when the advanced detection mechanism is unavailable, enabling reliable identification of JavaScript vs native-binary installations on constrained systems.

* **Tests**
  * Added comprehensive tests covering detection failure scenarios, platform-specific binary formats, path precedence, and version extraction to ensure consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->