### PR TITLE
Rework showDiff to use smart diffing; --show-unchanged; system prompt whitespace fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "chalk": "^5.5.0",
     "commander": "^14.0.0",
+    "diff": "^8.0.3",
     "globby": "^14.1.0",
     "gray-matter": "^4.0.3",
     "ink": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.0
+      diff:
+        specifier: ^8.0.3
+        version: 8.0.3
       globby:
         specifier: ^14.1.0
         version: 14.1.0
@@ -909,6 +912,10 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -3021,6 +3028,8 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  diff@8.0.3: {}
 
   doctrine@2.1.0:
     dependencies:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 
 import App from './ui/App';
 import { CONFIG_FILE, readConfigFile } from './config';
-import { enableDebug, enableVerbose } from './utils';
+import { enableDebug, enableVerbose, enableShowUnchanged } from './utils';
 import { applyCustomization } from './patches/index';
 import { preloadStringsFile } from './systemPromptSync';
 import { migrateConfigIfNeeded } from './migration';
@@ -28,6 +28,7 @@ const main = async () => {
     .version('3.4.0')
     .option('-d, --debug', 'enable debug mode')
     .option('-v, --verbose', 'enable verbose debug mode (includes diffs)')
+    .option('--show-unchanged', 'show unchanged diffs (requires --verbose)')
     .option('-a, --apply', 'apply saved customizations without interactive UI');
   program.parse();
   const options = program.opts();
@@ -36,6 +37,10 @@ const main = async () => {
     enableVerbose();
   } else if (options.debug) {
     enableDebug();
+  }
+
+  if (options.showUnchanged) {
+    enableShowUnchanged();
   }
 
   // Migrate old ccInstallationDir config to ccInstallationPath if needed

--- a/src/patches/fixLspSupport.ts
+++ b/src/patches/fixLspSupport.ts
@@ -1,6 +1,6 @@
 // Please see the note about writing patches in ./index
 
-import { escapeIdent, LocationResult, showDiff } from './index';
+import { escapeIdent, globalReplace, LocationResult, showDiff } from './index';
 
 const getOpenDocumentLocation = (oldFile: string): LocationResult | null => {
   // Step 1: Find `ensureServerStarted:[$\w]+`
@@ -107,28 +107,22 @@ export const writeFixLspSupport = (oldFile: string): string | null => {
 
   // Replace first validation
   const beforeReplace1 = content;
-  content = content.replace(validationPattern1, '');
-  if (content !== beforeReplace1) {
-    showDiff(beforeReplace1, content, '', 0, 0);
-  } else {
+  content = globalReplace(content, validationPattern1, '');
+  if (content === beforeReplace1) {
     console.warn('patch: fixLspSupport: restartOnCrash validation not found');
   }
 
   // Replace second validation
   const beforeReplace2 = content;
-  content = content.replace(validationPattern2, '');
-  if (content !== beforeReplace2) {
-    showDiff(beforeReplace2, content, '', 0, 0);
-  } else {
+  content = globalReplace(content, validationPattern2, '');
+  if (content === beforeReplace2) {
     console.warn('patch: fixLspSupport: startupTimeout validation not found');
   }
 
   // Replace third validation
   const beforeReplace3 = content;
-  content = content.replace(validationPattern3, '');
-  if (content !== beforeReplace3) {
-    showDiff(beforeReplace3, content, '', 0, 0);
-  } else {
+  content = globalReplace(content, validationPattern3, '');
+  if (content === beforeReplace3) {
     console.warn('patch: fixLspSupport: shutdownTimeout validation not found');
   }
 

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -1,18 +1,14 @@
 import * as fs from 'node:fs/promises';
 import * as fsSync from 'node:fs';
 import * as path from 'node:path';
+
 import {
   CONFIG_DIR,
   NATIVE_BINARY_BACKUP_FILE,
   updateConfigFile,
 } from '../config';
 import { ClaudeCodeInstallationInfo, TweakccConfig } from '../types';
-import {
-  isVerbose,
-  verbose,
-  debug,
-  replaceFileBreakingHardLinks,
-} from '../utils';
+import { debug, replaceFileBreakingHardLinks } from '../utils';
 import {
   extractClaudeJsFromNativeInstallation,
   repackNativeInstallation,
@@ -74,6 +70,8 @@ import {
 } from '../installationBackup';
 import { compareVersions } from '../systemPromptSync';
 
+export { showDiff, globalReplace } from './patchDiffing';
+
 export interface LocationResult {
   startIndex: number;
   endIndex: number;
@@ -90,62 +88,6 @@ export interface PatchApplied {
   newContent: string;
   items: string[];
 }
-
-// Debug function for showing diffs (requires --verbose flag)
-export const showDiff = (
-  oldFileContents: string,
-  newFileContents: string,
-  injectedText: string,
-  startIndex: number,
-  endIndex: number
-): void => {
-  if (!isVerbose()) {
-    return;
-  }
-
-  const numContextChars = 40;
-
-  const contextStart = Math.max(0, startIndex - numContextChars);
-  const contextEndOld = Math.min(
-    oldFileContents.length,
-    endIndex + numContextChars
-  );
-  const contextEndNew = Math.min(
-    newFileContents.length,
-    startIndex + injectedText.length + numContextChars
-  );
-
-  const oldBefore = oldFileContents.slice(contextStart, startIndex);
-  const oldChanged = oldFileContents.slice(startIndex, endIndex);
-  const oldAfter = oldFileContents.slice(endIndex, contextEndOld);
-
-  const newBefore = newFileContents.slice(contextStart, startIndex);
-  const newChanged = newFileContents.slice(
-    startIndex,
-    startIndex + injectedText.length
-  );
-  const newAfter = newFileContents.slice(
-    startIndex + injectedText.length,
-    contextEndNew
-  );
-
-  if (oldChanged !== newChanged) {
-    verbose('\n--- Diff ---');
-    verbose(
-      `\x1b[31mOLD: \x1b[0;2m${oldBefore}\x1b[0;31;1m${oldChanged}\x1b[0;2m${oldAfter}\x1b[0m`
-    );
-    verbose(
-      `\x1b[32mNEW: \x1b[0;2m${newBefore}\x1b[0;32;1m${newChanged}\x1b[0;2m${newAfter}\x1b[0m`
-    );
-    verbose('--- End Diff ---\n');
-  } else {
-    verbose('\n--- Diff ---');
-    verbose(
-      `\x1b[34mUNCHANGED: \x1b[0;2m${oldBefore}\x1b[0;34;1m${oldChanged}\x1b[0;2m${oldAfter}\x1b[0m`
-    );
-    verbose('--- End Diff ---\n');
-  }
-};
 
 export const escapeIdent = (ident: string): string => {
   return ident.replace(/\$/g, '\\$');

--- a/src/patches/patchDiffing.ts
+++ b/src/patches/patchDiffing.ts
@@ -1,0 +1,281 @@
+import { diffWordsWithSpace } from 'diff';
+import chalk from 'chalk';
+import { isVerbose, isShowUnchanged, verbose } from '../utils';
+
+/**
+ * Converts Unicode escape sequences (e.g., \u2014) back to their actual characters.
+ * This normalizes strings before diffing so that automatic Unicode escaping doesn't
+ * show up as changes.
+ */
+const unescapeUnicode = (str: string): string => {
+  return str.replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) =>
+    String.fromCharCode(parseInt(hex, 16))
+  );
+};
+
+/**
+ * Debug function for showing diffs between old and new file contents.
+ *
+ * Uses the `diff` library to compute character-level differences and displays them with
+ * chalk-styled colors: green background for additions, red background for removals, and
+ * dim text for unchanged portions. Only outputs when --verbose flag is set.
+ *
+ * @param oldFileContents - The original file content before modification
+ * @param newFileContents - The modified file content after patching
+ * @param injectedText - The text that was injected (used to calculate context window)
+ * @param startIndex - The start index where the modification occurred
+ * @param endIndex - The end index of the original content that was replaced
+ *
+ * @example
+ * ```ts
+ * showDiff(originalCode, patchedCode, 'console.log("patched")', 100, 120);
+ * // Outputs:
+ * // --- Diff ---
+ * // ...context...REMOVED_TEXTadded_text...context...
+ * // --- End Diff ---
+ * ```
+ */
+export const showDiff = (
+  oldFileContents: string,
+  newFileContents: string,
+  injectedText: string,
+  startIndex: number,
+  endIndex: number
+): void => {
+  if (!isVerbose()) {
+    return;
+  }
+
+  const numContextChars = 40;
+
+  // Extract the relevant portions with context
+  const contextStart = Math.max(0, startIndex - numContextChars);
+  const contextEndOld = Math.min(
+    oldFileContents.length,
+    endIndex + numContextChars
+  );
+  const contextEndNew = Math.min(
+    newFileContents.length,
+    startIndex + injectedText.length + numContextChars
+  );
+
+  const oldSnippet = oldFileContents.slice(contextStart, contextEndOld);
+  const newSnippet = newFileContents.slice(contextStart, contextEndNew);
+
+  // Normalize Unicode escapes before comparing so automatic escaping doesn't show as changes
+  const oldSnippetNormalized = unescapeUnicode(oldSnippet);
+  const newSnippetNormalized = unescapeUnicode(newSnippet);
+
+  // Check if the snippets are identical (after normalization)
+  if (oldSnippetNormalized === newSnippetNormalized) {
+    if (isShowUnchanged()) {
+      verbose('\n--- Diff ---');
+      verbose(chalk.blue('UNCHANGED: ') + chalk.dim(oldSnippetNormalized));
+      verbose('--- End Diff ---\n');
+    }
+    return;
+  }
+
+  // Compute word-level diff (includes whitespace as separate tokens)
+  const changes = diffWordsWithSpace(
+    oldSnippetNormalized,
+    newSnippetNormalized
+  );
+
+  // Find the index range of actual changes in both old and new
+  // We track positions where changes START (after leading unchanged content)
+  // and where changes END (before trailing unchanged content)
+  let oldPos = 0;
+  let newPos = 0;
+  let firstChangeOldPos = -1;
+  let lastChangeOldEnd = -1;
+  let firstChangeNewPos = -1;
+  let lastChangeNewEnd = -1;
+  // Track positions in old/new at the time of the last change (for trailing context)
+  let oldPosAtLastChange = 0;
+  let newPosAtLastChange = 0;
+
+  for (const part of changes) {
+    if (part.added) {
+      if (firstChangeNewPos === -1) {
+        firstChangeNewPos = newPos;
+        firstChangeOldPos = oldPos; // Sync old position at first change
+      }
+      lastChangeNewEnd = newPos + part.value.length;
+      lastChangeOldEnd = oldPos; // Old position at this change point
+      oldPosAtLastChange = oldPos;
+      newPosAtLastChange = newPos + part.value.length;
+      newPos += part.value.length;
+    } else if (part.removed) {
+      if (firstChangeOldPos === -1) {
+        firstChangeOldPos = oldPos;
+        firstChangeNewPos = newPos; // Sync new position at first change
+      }
+      lastChangeOldEnd = oldPos + part.value.length;
+      lastChangeNewEnd = newPos; // New position at this change point
+      oldPosAtLastChange = oldPos + part.value.length;
+      newPosAtLastChange = newPos;
+      oldPos += part.value.length;
+    } else {
+      // Unchanged - advances both, but don't update change positions
+      oldPos += part.value.length;
+      newPos += part.value.length;
+    }
+  }
+
+  // If no changes found, fall back to full snippet
+  if (firstChangeOldPos === -1) firstChangeOldPos = 0;
+  if (firstChangeNewPos === -1) firstChangeNewPos = 0;
+  if (lastChangeOldEnd === -1) lastChangeOldEnd = oldSnippetNormalized.length;
+  if (lastChangeNewEnd === -1) lastChangeNewEnd = newSnippetNormalized.length;
+
+  // Calculate how much trailing unchanged content exists after the last change
+  const trailingOldContext = oldSnippetNormalized.length - oldPosAtLastChange;
+  const trailingNewContext = newSnippetNormalized.length - newPosAtLastChange;
+  const trailingContext = Math.min(
+    trailingOldContext,
+    trailingNewContext,
+    numContextChars
+  );
+
+  // Crop to context around actual changes
+  const cropStartOld = Math.max(0, firstChangeOldPos - numContextChars);
+  const cropEndOld = Math.min(
+    oldSnippetNormalized.length,
+    oldPosAtLastChange + trailingContext
+  );
+  const cropStartNew = Math.max(0, firstChangeNewPos - numContextChars);
+  const cropEndNew = Math.min(
+    newSnippetNormalized.length,
+    newPosAtLastChange + trailingContext
+  );
+
+  // Recompute diff on cropped snippets
+  const croppedOld = oldSnippetNormalized.slice(cropStartOld, cropEndOld);
+  const croppedNew = newSnippetNormalized.slice(cropStartNew, cropEndNew);
+  const croppedChanges = diffWordsWithSpace(croppedOld, croppedNew);
+
+  // Build the highlighted output for OLD (show removed in red, unchanged in dim, skip added)
+  let oldOutput = '';
+  for (const part of croppedChanges) {
+    if (part.added) {
+      // Skip added parts in old line
+    } else if (part.removed) {
+      // Show newlines explicitly so they're visible in the diff
+      if (part.value.includes('\n')) {
+        const partLines = part.value.split('\n');
+        partLines.forEach((partLine, i) => {
+          if (partLine) {
+            oldOutput += chalk.bgRed.white(partLine);
+          }
+          if (i < partLines.length - 1) {
+            oldOutput += chalk.bgRed.dim('\\n') + '\n';
+          }
+        });
+      } else {
+        oldOutput += chalk.bgRed.white(part.value);
+      }
+    } else {
+      oldOutput += chalk.dim(part.value);
+    }
+  }
+
+  // Build the highlighted output for NEW (show added in green, unchanged in dim, skip removed)
+  let newOutput = '';
+  for (const part of croppedChanges) {
+    if (part.added) {
+      // Show newlines explicitly so they're visible in the diff
+      if (part.value.includes('\n')) {
+        const partLines = part.value.split('\n');
+        partLines.forEach((partLine, i) => {
+          if (partLine) {
+            newOutput += chalk.bgGreen.black(partLine);
+          }
+          if (i < partLines.length - 1) {
+            newOutput += chalk.bgGreen.dim('\\n') + '\n';
+          }
+        });
+      } else {
+        newOutput += chalk.bgGreen.black(part.value);
+      }
+    } else if (part.removed) {
+      // Skip removed parts in new line
+    } else {
+      newOutput += chalk.dim(part.value);
+    }
+  }
+
+  verbose('\n--- Diff ---');
+  verbose(chalk.red('OLD: ') + oldOutput);
+  verbose(chalk.green('NEW: ') + newOutput);
+  verbose('--- End Diff ---\n');
+};
+
+/**
+ * Performs a global replace on a string, finding all matches first, then replacing
+ * them in reverse order (to preserve indices), and calling showDiff for each replacement.
+ *
+ * @param content - The string to perform replacements on
+ * @param pattern - The regex pattern to match (should have 'g' flag for multiple matches)
+ * @param replacement - Either a string or a replacer function (same as String.replace)
+ * @returns The modified string with all replacements applied
+ *
+ * @example
+ * ```ts
+ * const result = globalReplace(
+ *   content,
+ *   /throw Error\(`something`\);/g,
+ *   ''
+ * );
+ * ```
+ */
+export const globalReplace = (
+  content: string,
+  pattern: RegExp,
+  replacement: string | ((substring: string, ...args: unknown[]) => string)
+): string => {
+  // Collect all matches with their indices
+  const matches: { index: number; length: number }[] = [];
+
+  // Ensure we have a global regex to find all matches
+  const globalPattern = pattern.global
+    ? pattern
+    : new RegExp(pattern.source, pattern.flags + 'g');
+
+  let match: RegExpExecArray | null;
+  while ((match = globalPattern.exec(content)) !== null) {
+    matches.push({
+      index: match.index,
+      length: match[0].length,
+    });
+  }
+
+  // Create a non-global version for single replacements
+  const singlePattern = new RegExp(
+    pattern.source,
+    pattern.flags.replace('g', '')
+  );
+
+  // Process matches in reverse order to preserve indices
+  let result = content;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const { index, length } = matches[i];
+    const oldContent = result;
+
+    // Extract the matched portion and use native replace for proper $-pattern handling
+    const matchedStr = result.slice(index, index + length);
+    const replacementStr = matchedStr.replace(
+      singlePattern,
+      replacement as string
+    );
+
+    // Perform the replacement
+    result =
+      result.slice(0, index) + replacementStr + result.slice(index + length);
+
+    // Show the diff for this replacement
+    showDiff(oldContent, result, replacementStr, index, index + length);
+  }
+
+  return result;
+};

--- a/src/patches/systemPrompts.ts
+++ b/src/patches/systemPrompts.ts
@@ -126,32 +126,6 @@ export const applySystemPrompts = async (
       totalOriginalChars += originalLength;
       totalNewChars += newLength;
 
-      if (originalLength !== newLength) {
-        verbose(`\n  Character count difference for ${prompt.name}:`);
-        verbose(`    Original baseline: ${originalLength} chars`);
-        verbose(`    User's version: ${newLength} chars`);
-        verbose(`    Difference: ${originalLength - newLength} chars`);
-        if (Math.abs(originalLength - newLength) < 200) {
-          verbose(
-            `\n    Original baseline content:\n${originalBaselineContent}`
-          );
-          verbose(`\n    User's content:\n${prompt.content}`);
-        }
-      }
-
-      verbose(`\nFound match for prompt: ${prompt.name}`);
-      verbose(
-        `  Match location: index ${match.index}, length ${match[0].length}`
-      );
-      verbose(
-        `  Original content (first 100 chars): ${match[0].substring(0, 100)}...`
-      );
-      verbose(
-        `  Replacement content (first 100 chars): ${interpolatedContent.substring(0, 100)}...`
-      );
-      verbose(`  Captured variables: ${match.slice(1).join(', ')}`);
-      verbose(`  Content identical: ${match[0] === interpolatedContent}`);
-
       const oldContent = content;
       const matchLength = match[0].length;
 

--- a/src/tests/systemPromptSync.test.ts
+++ b/src/tests/systemPromptSync.test.ts
@@ -904,7 +904,7 @@ Greet user as \${SETTINGS.preferredName}!`;
             name: 'Test',
             description: 'Test',
             version: '1.0.0',
-            pieces: ['Usage: ${', '()} ms'],
+            pieces: ['\nUsage: ${', '()} ms'],
             identifiers: [1],
             identifierMap: { '1': 'MAX_TIMEOUT' },
           },
@@ -953,7 +953,7 @@ Usage: \${MAX_TIMEOUT()} ms`;
             name: 'Test',
             description: 'Test',
             version: '1.0.0',
-            pieces: ['Version: <<CCVERSION>>, BUILD_TIME:"<<BUILD_TIME>>"'],
+            pieces: ['\nVersion: <<CCVERSION>>, BUILD_TIME:"<<BUILD_TIME>>"'],
             identifiers: [],
             identifierMap: {},
           },
@@ -989,7 +989,7 @@ Version: <<CCVERSION>>, BUILD_TIME:"<<BUILD_TIME>>"`;
 
       // The regex should match the actual content in cli.js
       const testCliContent =
-        'Version: 1.0.0, BUILD_TIME:"2025-12-09T19:43:43Z"';
+        '\nVersion: 1.0.0, BUILD_TIME:"2025-12-09T19:43:43Z"';
       const regex = new RegExp(results[0].regex);
       const match = testCliContent.match(regex);
 
@@ -997,7 +997,7 @@ Version: <<CCVERSION>>, BUILD_TIME:"<<BUILD_TIME>>"`;
 
       // Simulate matching - the interpolated content should have both placeholders replaced
       const matchResult = [
-        'Version: 1.0.0, BUILD_TIME:"2025-12-09T19:43:43Z"',
+        '\nVersion: 1.0.0, BUILD_TIME:"2025-12-09T19:43:43Z"',
       ] as RegExpMatchArray;
       const interpolated = results[0].getInterpolatedContent(matchResult);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ import { CUSTOM_MODELS } from './patches/modelSelector';
 
 let isDebugModeOn = false;
 let isVerboseModeOn = false;
+let isShowUnchangedOn = false;
 
 export const isDebug = (): boolean => {
   return isDebugModeOn;
@@ -16,12 +17,18 @@ export const isDebug = (): boolean => {
 export const isVerbose = (): boolean => {
   return isVerboseModeOn;
 };
+export const isShowUnchanged = (): boolean => {
+  return isShowUnchangedOn;
+};
 export const enableDebug = (): void => {
   isDebugModeOn = true;
 };
 export const enableVerbose = (): void => {
   isVerboseModeOn = true;
   isDebugModeOn = true; // Verbose implies debug
+};
+export const enableShowUnchanged = (): void => {
+  isShowUnchangedOn = true;
 };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const debug = (message: any, ...optionalParams: any[]) => {


### PR DESCRIPTION
- `showDiff` now diffs the old and new input substrings to provide accurate diffing for system prompts, many of which often don't change
- You can now pass `--show-unchanged` to show all patches, even ones where the old and new substring are the same
- `fixLspSupport.ts`'s `showDiff` usage was incorrect.
- Leading and trailing whitespace for system prompts is sourced from original system prompts data instead of the markdown files, making system prompt diffs fewer and cleaner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--show-unchanged` CLI option to display unchanged diffs when used with `--verbose`
  * Enhanced diff visualization with color-coded output (red for removals, green for additions) and contextual previews

* **Improvements**
  * Improved whitespace preservation in system prompt synchronization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->