### PR TITLE
Show error status for failed patches

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -97,14 +97,20 @@ function printPatchResults(results: PatchResult[]): void {
   for (const group of groupOrder) {
     const groupResults = byGroup.get(group)!;
 
-    // Filter based on --show-unchanged
-    const filtered = groupResults.filter(r => r.applied || isShowUnchanged());
+    // Filter based on --show-unchanged (but always show applied and failed)
+    const filtered = groupResults.filter(
+      r => r.applied || r.failed || isShowUnchanged()
+    );
     if (filtered.length === 0) continue;
 
     console.log(`\n  ${chalk.bold(group)}:`);
 
     for (const result of filtered) {
-      const status = result.applied ? chalk.green('✓') : chalk.dim('○');
+      const status = result.failed
+        ? chalk.red('✗')
+        : result.applied
+          ? chalk.green('✓')
+          : chalk.dim('○');
       const details = result.details ? `: ${result.details}` : '';
       // Show description in gray on the same line for applied patches only
       const description =

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -110,6 +110,7 @@ export interface PatchResult {
   name: string;
   group: PatchGroup;
   applied: boolean;
+  failed?: boolean;
   details?: string;
   description?: string;
 }
@@ -162,9 +163,10 @@ const applyPatches = (
 
     debug(`Applying patch: ${patch.name}`);
     const result = patch.fn(content);
-    const applied = result !== null;
+    const failed = result === null;
+    const applied = !failed && result !== content;
 
-    if (applied) {
+    if (!failed) {
       content = result;
     }
 
@@ -173,6 +175,7 @@ const applyPatches = (
       name: patch.name,
       group: patch.group,
       applied,
+      failed,
       description: patch.description,
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patch filtering now includes failed patches in results.
  * Enhanced status indicators distinguish between failed (red ✗), applied (green ✓), and unchanged (dim ○) patches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->