### PR TITLE
feat: add session-memory patch

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -703,6 +703,7 @@ export const DEFAULT_SETTINGS: Settings = {
     mcpServerBatchSize: null,
     tableFormat: 'default',
     enableSwarmMode: true,
+    enableSessionMemory: true,
   },
   toolsets: [],
   defaultToolset: null,

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -59,6 +59,7 @@ import { writeIncreaseFileReadLimit } from './increaseFileReadLimit';
 import { writeSuppressLineNumbers } from './suppressLineNumbers';
 import { writeSuppressRateLimitOptions } from './suppressRateLimitOptions';
 import { writeSwarmMode } from './swarmMode';
+import { writeSessionMemory } from './sessionMemory';
 import { writeThinkingBlockStyling } from './thinkingBlockStyling';
 import { writeMcpNonBlocking, writeMcpBatchSize } from './mcpStartup';
 import {
@@ -299,6 +300,13 @@ const PATCH_DEFINITIONS = [
     name: 'Swarm mode',
     group: PatchGroup.FEATURES,
     description: 'Enable SWARM MODE in Claude Code',
+  },
+  {
+    id: 'session-memory',
+    name: 'Session memory',
+    group: PatchGroup.FEATURES,
+    description:
+      'Enable session memory (auto-extraction + past session search)',
   },
   {
     id: 'toolsets',
@@ -670,6 +678,10 @@ export const applyCustomization = async (
     'swarm-mode': {
       fn: c => writeSwarmMode(c),
       condition: !!config.settings.misc?.enableSwarmMode,
+    },
+    'session-memory': {
+      fn: c => writeSessionMemory(c),
+      condition: !!config.settings.misc?.enableSessionMemory,
     },
     toolsets: {
       fn: c =>

--- a/src/patches/sessionMemory.ts
+++ b/src/patches/sessionMemory.ts
@@ -1,0 +1,89 @@
+// Session Memory Patch - Force-enable session memory in Claude Code
+//
+// Enables both:
+// 1. Session memory extraction (tengu_session_memory) - auto-extracts notes during conversation
+// 2. Past session search (tengu_coral_fern) - adds system prompt for searching past sessions
+//
+// These are logically one feature - extraction creates session memories, search lets you use them.
+//
+// Extraction pattern (CC 2.1.27):
+// ```diff
+//  function l28() {
+// +  return true;
+//    return $_("tengu_session_memory", !1)
+//  }
+// ```
+//
+// Past sessions pattern (CC 2.1.27):
+// ```diff
+//  function AQ8() {
+// -  if (!$_("tengu_coral_fern", !1)) return null;
+// +  if (false) return null;
+//    return `# Accessing Past Sessions...
+//  }
+// ```
+
+import { showDiff } from './index';
+
+/**
+ * Patch 1: Bypass tengu_session_memory flag check for extraction
+ */
+const patchExtraction = (file: string): string | null => {
+  const pattern = /function [$\w]+\(\)\{return \$_\("tengu_session_memory"/;
+  const match = file.match(pattern);
+
+  if (!match || match.index === undefined) {
+    console.error('patch: sessionMemory: failed to find extraction gate');
+    return null;
+  }
+
+  const insertIndex = match.index + match[0].indexOf('{') + 1;
+  const insertion = 'return true;';
+
+  const newFile =
+    file.slice(0, insertIndex) + insertion + file.slice(insertIndex);
+
+  showDiff(file, newFile, insertion, insertIndex, insertIndex);
+  return newFile;
+};
+
+/**
+ * Patch 2: Bypass tengu_coral_fern flag check for past session search
+ */
+const patchPastSessions = (file: string): string | null => {
+  const pattern = /if\(!\$_\("tengu_coral_fern",!1\)\)return null;/;
+  const match = file.match(pattern);
+
+  if (!match || match.index === undefined) {
+    console.error('patch: sessionMemory: failed to find past sessions gate');
+    return null;
+  }
+
+  const replacement = 'if(false)return null;';
+  const newFile =
+    file.slice(0, match.index) +
+    replacement +
+    file.slice(match.index + match[0].length);
+
+  showDiff(
+    file,
+    newFile,
+    replacement,
+    match.index,
+    match.index + match[0].length
+  );
+  return newFile;
+};
+
+/**
+ * Combined patch - applies both extraction and past sessions
+ */
+export const writeSessionMemory = (oldFile: string): string | null => {
+  console.log('Applying session memory extraction patch...');
+  const afterExtraction = patchExtraction(oldFile);
+  if (!afterExtraction) return null;
+
+  console.log('Applying past sessions search patch...');
+  const afterPastSessions = patchPastSessions(afterExtraction);
+  return afterPastSessions;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,7 @@ export interface MiscConfig {
   mcpServerBatchSize: number | null;
   tableFormat: TableFormat;
   enableSwarmMode: boolean;
+  enableSessionMemory: boolean;
 }
 
 export interface InputPatternHighlighter {

--- a/src/ui/components/MiscView.tsx
+++ b/src/ui/components/MiscView.tsx
@@ -47,6 +47,7 @@ export function MiscView({ onSubmit }: MiscViewProps) {
     mcpServerBatchSize: null as number | null,
     tableFormat: 'default' as TableFormat,
     enableSwarmMode: true,
+    enableSessionMemory: true,
   };
 
   const ensureMisc = () => {
@@ -321,6 +322,20 @@ export function MiscView({ onSubmit }: MiscViewProps) {
           updateSettings(settings => {
             ensureMisc();
             settings.misc!.enableSwarmMode = !settings.misc!.enableSwarmMode;
+          });
+        },
+      },
+      {
+        id: 'enableSessionMemory',
+        title: 'Enable session memory',
+        description:
+          'Force-enable session memory (auto-extraction + past session search) by bypassing the tengu_session_memory and tengu_coral_fern statsig flags.',
+        getValue: () => settings.misc?.enableSessionMemory ?? true,
+        toggle: () => {
+          updateSettings(settings => {
+            ensureMisc();
+            settings.misc!.enableSessionMemory =
+              !settings.misc!.enableSessionMemory;
           });
         },
       },


### PR DESCRIPTION
## Summary

Adds a new patch to enable Claude Code's session memory feature by bypassing two statsig flags:

- **`tengu_session_memory`**: Auto-extracts notes during conversation into `~/.claude/projects/{path}/{session}/session-memory/summary.md`
- **`tengu_coral_fern`**: Adds system prompt section for searching past session memories and transcripts

These are logically one feature - extraction creates session memories, search lets you use them. Combined into a single `session-memory` patch for simplicity.

## Changes

- `src/patches/sessionMemory.ts` - New patch file with two sub-patches
- `src/patches/index.ts` - Register the patch
- `src/types.ts` - Add `enableSessionMemory` to `MiscConfig`
- `src/defaultSettings.ts` - Default to `true`
- `src/ui/components/MiscView.tsx` - Add toggle in UI

## Usage

```bash
tweakcc --apply --patches session-memory
```

Or enable via the TUI under Misc settings.

## Test plan

- [x] TypeScript compiles without errors
- [x] All existing tests pass (173 passed)
- [ ] Manual test: apply patch, start new Claude session, verify session-memory directory created after ~10k tokens

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Enable session memory" setting in the miscellaneous configuration section. Users can now toggle session memory functionality on or off using a dedicated switch in the settings panel. The setting defaults to enabled and provides direct control over session memory configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->