### PR TITLE
Only apply the `thinkingBlockStyling` patch in CC version under 2.1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a patch unlocking session memory (#444) - @odysseus0
 - Add a patch to round the token count to the nearest multiple of a specified base (#451) - @bl-ue
 - Add a patch for throttling/pacing of statusline updates (#453) - @bl-ue
-- Extend the `thinkingVerbs` patch to cover past-tense verbs e.g. Baked (#454) - @bl-ue
+- Extend the `thinkingVerbs` patch to cover past-tense verbs e.g. "Baked" (#454) - @bl-ue
+- Only apply the `thinkingBlockStyling` patch in CC version under 2.1.26 (#455) - @bl-ue
 
 ## [v3.4.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v3.4.0) - 2026-01-18
 

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -577,6 +577,9 @@ export const applyCustomization = async (
     },
     'thinking-block-styling': {
       fn: c => writeThinkingBlockStyling(c),
+      condition:
+        ccInstInfo.version == null ||
+        compareVersions(ccInstInfo.version, '2.1.26') < 0,
     },
     'fix-lsp-support': {
       fn: c => writeFixLspSupport(c),


### PR DESCRIPTION
See https://github.com/Piebald-AI/tweakcc/pull/353#issuecomment-3842317444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined version compatibility for thinking block styling patches, now selectively applying updates based on Creative Cloud version (only for versions below 2.1.26).

* **Documentation**
  * Enhanced CHANGELOG documentation with improved formatting in code examples and corrected quotation styling in verb usage examples to ensure accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->