### PR TITLE
Add a --config-url flag to apply config from a remote URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Add auto-accept plan mode patch (#464) - @irdbl
 - Add a fallback for WASMagic when it's not available (#399) - @signadou
 - Add opusplan[1m] model alias for 1M context support (#404) - @mike1858
 - Add MCP startup optimization settings (#407) - @mike1858
@@ -27,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `subagentModels` patch to not error when nothing was changed (#456) - @bl-ue
 - Enable the builtin `/remember` skill (#457) - @bl-ue
 - AGENTS.md support for Claude Code (#459) - @bl-ue
+- Add auto-accept plan mode patch (#464) - @irdbl
+- Add `--config-url` flag to fetch configuration from a URL (#465) - @bl-ue & @basekevin
 
 ## [v3.4.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v3.4.0) - 2026-01-18
 

--- a/README.md
+++ b/README.md
@@ -571,6 +571,16 @@ Toolsets can be helpful both for using Claude in different modes, e.g. a researc
 
 To create a toolset, run `npx tweakcc`, go to `Toolsets`, and hit `n` to create a new toolset. Set to apply your customizations, and then run `claude`. If you marked a toolset as the default in tweakcc, it will be automatically selected.
 
+## Remote Config
+
+While tweakcc usually works by applying customizations from your local `~/.tweakcc/config.json`, you can optionally pass the `--config-url <http URL>` flag when you use `tweakcc --apply` to have tweakcc fetch config from a remote URL and apply it to your local Claude Code installation.  This is useful for testing someone else's config when shared via a Gist or pastebin, for example.
+
+Example:
+```
+npx tweakcc@latest --apply --config-url https://gist.githubusercontent.com/bl-ue/27323f9bfd4c18aaab51cad11c1148dc/raw/c1b6875c4b3c3adfaf6332bb69eedff02fa04471/config.json
+```
+Your local config will **not** be overwritten; the remote config will be copied into your `config.json` under under `remoteConfig.settings`.
+
 ## Troubleshooting
 
 tweakcc stores a backup of your Claude Code `cli.js`/binary for when you want to revert your customizations and for reapplying patches. Before it applies your customizations, it restores the original `cli.js`/binary so that it can start from a clean slate. Sometimes things can get confused and your `claude` can be corrupted.

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -33,12 +33,14 @@ export interface StartupCheckResult {
  * it's been updated.
  *
  * @param options - Options for installation detection (interactive mode flag)
+ * @param providedConfig - Optional pre-loaded config (e.g., from URL). If not provided, reads from local file.
  * @returns StartupCheckResult with either startupCheckInfo or pendingCandidates for UI selection
  */
 export async function startupCheck(
-  options: FindInstallationOptions
+  options: FindInstallationOptions,
+  providedConfig?: TweakccConfig
 ): Promise<StartupCheckResult> {
-  const config = await readConfigFile();
+  const config = providedConfig ?? (await readConfigFile());
 
   const ccInstInfo = await findClaudeCodeInstallation(config, options);
   if (!ccInstInfo) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,12 @@ export interface Settings {
   claudeMdAltNames: string[] | null;
 }
 
+export interface RemoteConfig {
+  sourceUrl: string;
+  dateFetched: string;
+  settings: Partial<Settings>;
+}
+
 export interface TweakccConfig {
   ccVersion: string;
   ccInstallationDir?: string | null; // Deprecated: only used for migration from old configs
@@ -175,6 +181,7 @@ export interface TweakccConfig {
   changesApplied: boolean;
   settings: Settings;
   hidePiebaldAnnouncement?: boolean;
+  remoteConfig?: RemoteConfig; // Cached remote config from last --config-url usage
 }
 
 export type InstallationKind = 'npm-based' | 'native-binary';

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -54,7 +54,8 @@ export default function App({
   });
   const [showPiebaldAnnouncement, setShowPiebaldAnnouncement] = useState(false);
 
-  // Load the config file.
+  // Load the config file from local storage.
+  // The TUI is for editing local configuration only.
   useEffect(() => {
     const loadConfig = async () => {
       const loadedConfig = await readConfigFile();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--config-url` command-line flag to fetch configuration settings from a remote URL and apply them locally. Remote configuration merges with local settings without overwriting existing values.

* **Documentation**
  * Added Remote Config section to documentation with feature description and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->