### PR TITLE
Handle missing node sandboxing support gracefully

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -312,6 +312,10 @@ const main = async () => {
       '--confirm-possible-dangerous-patch',
       'skip diff preview and apply immediately'
     )
+    .option(
+      '--dangerous-no-script-sandbox',
+      'run --script without the Node.js permission sandbox (use if Node < 20)'
+    )
     .action(
       async (options: {
         string?: string[];
@@ -320,6 +324,7 @@ const main = async () => {
         index?: number;
         path?: string;
         confirmPossibleDangerousPatch?: boolean;
+        dangerousNoScriptSandbox?: boolean;
       }) => {
         await handleAdhocPatch(options);
         process.exit(0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dangerous-no-script-sandbox` CLI flag to optionally bypass script sandbox execution.

* **Improvements**
  * Enhanced compatibility with Node.js versions 20 and above for sandbox permission flags.
  * Improved error handling with clearer messages when sandbox permissions are unavailable.
  * Better runtime detection of Node version capabilities with graceful fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->