### PR TITLE
Fix patchesAppliedIndication for CC 2.1.42+ ternary minHeight

### DIFF
--- a/src/patches/patchesAppliedIndication.ts
+++ b/src/patches/patchesAppliedIndication.ts
@@ -67,8 +67,9 @@ const applyIndicatorViewPatch = (
   textComponent: string,
   chalkVar: string
 ): { content: string; closingParenIndex: number } | null => {
-  // 1. Find alignItems:"center",minHeight:9,
-  const alignItemsPattern = /alignItems:"center",minHeight:9,?/;
+  // 1. Find alignItems:"center",minHeight:<value>, where value can be a number or ternary
+  const alignItemsPattern =
+    /alignItems:"center",minHeight:([$\w]+\?\d+:\d+|\d+),?/;
   const alignItemsMatch = fileContents.match(alignItemsPattern);
   if (!alignItemsMatch || alignItemsMatch.index === undefined) {
     console.error(
@@ -77,10 +78,11 @@ const applyIndicatorViewPatch = (
     return null;
   }
 
-  // 2. Replace alignItems:"center",minHeight:9, with just minHeight:9,
+  // 2. Replace alignItems:"center",minHeight:<value>, with just minHeight:<value>,
+  const minHeightValue = alignItemsMatch[1];
   let content =
     fileContents.slice(0, alignItemsMatch.index) +
-    'minHeight:9,' +
+    `minHeight:${minHeightValue},` +
     fileContents.slice(alignItemsMatch.index + alignItemsMatch[0].length);
 
   // 3. Go back 200 chars from the alignItems location
@@ -449,8 +451,9 @@ export const writePatchesAppliedIndication = (
   if (showPatchesApplied) {
     // If patch 4 wasn't applied, we need to find the insertion point
     if (patch4ClosingParenIndex === -1) {
-      // Find alignItems:"center",minHeight:9, to use as reference point
-      const alignItemsPattern = /alignItems:"center",minHeight:9,?/;
+      // Find alignItems:"center",minHeight:<value>, to use as reference point
+      const alignItemsPattern =
+        /alignItems:"center",minHeight:([$\w]+\?\d+:\d+|\d+),?/;
       const alignItemsMatch = content.match(alignItemsPattern);
       if (!alignItemsMatch || alignItemsMatch.index === undefined) {
         console.error(


### PR DESCRIPTION
## Summary
- Claude Code 2.1.42 changed `minHeight:9` to a ternary `minHeight:X?13:9` in the header component
- The hardcoded regex `minHeight:9` in PATCH 4 and PATCH 5 no longer matches, causing `patchesAppliedIndication` to fail
- Updated both regexes to handle ternary expressions (`VAR?NUM:NUM`) as well as plain numbers
- Preserved the original minHeight value dynamically in the replacement instead of hardcoding `9`

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` passes  
- [x] `pnpm test` — all 162 tests pass
- [x] Tested `--apply` on Claude Code 2.1.42 — `patchesAppliedIndication` now shows ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed layout rendering to properly support dynamic height values in addition to fixed values, ensuring correct display when height is computed rather than static.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->