### PR TITLE
feat: add worktree mode patch to force-enable EnterWorktree tool

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -712,6 +712,7 @@ export const DEFAULT_SETTINGS: Settings = {
     allowBypassPermissionsInSudo: false,
     suppressNativeInstallerWarning: false,
     filterScrollEscapeSequences: false,
+    enableWorktreeMode: true,
   },
   toolsets: [],
   defaultToolset: null,

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -70,6 +70,7 @@ import { writeAutoAcceptPlanMode } from './autoAcceptPlanMode';
 import { writeAllowBypassPermsInSudo } from './allowBypassPermsInSudo';
 import { writeSuppressNativeInstallerWarning } from './suppressNativeInstallerWarning';
 import { writeScrollEscapeSequenceFilter } from './scrollEscapeSequenceFilter';
+import { writeWorktreeMode } from './worktreeMode';
 import {
   restoreNativeBinaryFromBackup,
   restoreClijsFromBackup,
@@ -361,6 +362,13 @@ const PATCH_DEFINITIONS = [
     name: 'Swarm mode',
     group: PatchGroup.FEATURES,
     description: 'Enable SWARM MODE in Claude Code',
+  },
+  {
+    id: 'worktree-mode',
+    name: 'Worktree mode',
+    group: PatchGroup.FEATURES,
+    description:
+      'Enable the EnterWorktree tool for isolated git worktree sessions',
   },
   {
     id: 'session-memory',
@@ -788,6 +796,10 @@ export const applyCustomization = async (
     'swarm-mode': {
       fn: c => writeSwarmMode(c),
       condition: !!config.settings.misc?.enableSwarmMode,
+    },
+    'worktree-mode': {
+      fn: c => writeWorktreeMode(c),
+      condition: !!config.settings.misc?.enableWorktreeMode,
     },
     'session-memory': {
       fn: c => writeSessionMemory(c),

--- a/src/patches/worktreeMode.ts
+++ b/src/patches/worktreeMode.ts
@@ -1,0 +1,42 @@
+// Please see the note about writing patches in ./index
+//
+// Worktree Mode Patch - Force-enable the EnterWorktree tool in Claude Code
+//
+// The EnterWorktree tool creates a new git worktree and switches the session
+// into it for isolated work. It's gated by the `tengu_worktree_mode` GrowthBook
+// feature flag (default false) checked via `isWorktreeModeEnabled()`.
+//
+// This module patches the gate function to bypass the flag and force-enable the tool.
+//
+// CC 2.1.42:
+// ```diff
+//  function ef6() {
+// +  return true;
+//    return r8("tengu_worktree_mode", !1);
+//  }
+// ```
+
+import { showDiff } from './index';
+
+export const writeWorktreeMode = (oldFile: string): string | null => {
+  const pattern = /function [$\w]+\(\)\{return [$\w]+\("tengu_worktree_mode"/;
+
+  const match = oldFile.match(pattern);
+
+  if (!match || match.index === undefined) {
+    console.error(
+      'patch: worktreeMode: failed to find worktree gate function pattern'
+    );
+    return null;
+  }
+
+  const insertIndex = match.index + match[0].indexOf('{') + 1;
+  const insertion = 'return !0;';
+
+  const newFile =
+    oldFile.slice(0, insertIndex) + insertion + oldFile.slice(insertIndex);
+
+  showDiff(oldFile, newFile, insertion, insertIndex, insertIndex);
+
+  return newFile;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,7 @@ export interface MiscConfig {
   allowBypassPermissionsInSudo: boolean | null;
   suppressNativeInstallerWarning: boolean;
   filterScrollEscapeSequences: boolean;
+  enableWorktreeMode: boolean;
 }
 
 export interface InputPatternHighlighter {

--- a/src/ui/components/MiscView.tsx
+++ b/src/ui/components/MiscView.tsx
@@ -78,6 +78,7 @@ export function MiscView({ onSubmit }: MiscViewProps) {
     allowBypassPermissionsInSudo: false,
     suppressNativeInstallerWarning: false,
     filterScrollEscapeSequences: false,
+    enableWorktreeMode: true,
   };
 
   const ensureMisc = () => {
@@ -382,6 +383,20 @@ export function MiscView({ onSubmit }: MiscViewProps) {
           updateSettings(settings => {
             ensureMisc();
             settings.misc!.enableSwarmMode = !settings.misc!.enableSwarmMode;
+          });
+        },
+      },
+      {
+        id: 'enableWorktreeMode',
+        title: 'Enable worktree mode (EnterWorktree tool)',
+        description:
+          'Force-enable the EnterWorktree tool for isolated git worktree sessions by bypassing the tengu_worktree_mode feature flag.',
+        getValue: () => settings.misc?.enableWorktreeMode ?? true,
+        toggle: () => {
+          updateSettings(settings => {
+            ensureMisc();
+            settings.misc!.enableWorktreeMode =
+              !settings.misc!.enableWorktreeMode;
           });
         },
       },


### PR DESCRIPTION
Bypasses the `tengu_worktree_mode` feature flag by inserting `return !0` before the `return r8("tengu_worktree_mode",!1)`;

Default: on. Toggleable in Misc settings UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Worktree mode feature to enable the EnterWorktree tool for isolated git worktree sessions, providing improved workflow isolation capabilities.
  * Added a new user-configurable toggle setting in the UI to control Worktree mode activation, enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->