### PR TITLE
Fix an unnecessary warning when certain LSP patches aren't patched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix an unnecessary warning when certain LSP patches aren't patched (#535) - @bl-ue
+
 ## [v4.0.4](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.0.4) - 2026-02-21
 
 - Fix patching errors for CC 2.1.50+ and remove the swarm mode patch (#532) - @bl-ue

--- a/src/patches/fixLspSupport.ts
+++ b/src/patches/fixLspSupport.ts
@@ -106,25 +106,13 @@ export const writeFixLspSupport = (oldFile: string): string | null => {
   let content = oldFile;
 
   // Replace first validation
-  const beforeReplace1 = content;
   content = globalReplace(content, validationPattern1, '');
-  if (content === beforeReplace1) {
-    console.warn('patch: fixLspSupport: restartOnCrash validation not found');
-  }
 
   // Replace second validation
-  const beforeReplace2 = content;
   content = globalReplace(content, validationPattern2, '');
-  if (content === beforeReplace2) {
-    console.warn('patch: fixLspSupport: startupTimeout validation not found');
-  }
 
   // Replace third validation
-  const beforeReplace3 = content;
   content = globalReplace(content, validationPattern3, '');
-  if (content === beforeReplace3) {
-    console.warn('patch: fixLspSupport: shutdownTimeout validation not found');
-  }
 
   // Patch 2: Add the openDocument patch
   const location = getOpenDocumentLocation(content);


### PR DESCRIPTION
Closes #534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated unnecessary runtime warnings related to LSP patch operations, providing a cleaner console output when certain patches aren't applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->