### PR TITLE
Fix `? for shortcuts [undefined]` when no toolset is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix `? for shortcuts [undefined]` when no toolset is active (#544) - @bl-ue
+
 ## [v4.0.7](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.0.7) - 2026-02-23
 
 - Fix tool call patching typo (#542) - @bl-ue

--- a/src/patches/toolsets.ts
+++ b/src/patches/toolsets.ts
@@ -579,7 +579,7 @@ export const appendToolsetToModeDisplay = (oldFile: string): string | null => {
   // Replace with the new pattern that includes toolset
   const oldText = match[0];
   // insertShiftTabAppStateVar provides the definition for currentToolset.
-  const newText = `${tlFunction}(${modeVar}).toLowerCase()," on [",currentToolset||"undefined","]"`;
+  const newText = `${tlFunction}(${modeVar}).toLowerCase(),currentToolset?\` on [\${currentToolset}]\`:""`;
 
   const newFile = oldFile.replace(oldText, newText);
 
@@ -621,7 +621,7 @@ export const appendToolsetToShortcutsDisplay = (
 
   // Replace with the new pattern that includes toolset
   const oldText = match[0];
-  const newText = `"? for shortcuts [",currentToolset||"undefined","]"`;
+  const newText = `currentToolset?\`? for shortcuts [\${currentToolset}]\`:"? for shortcuts"`;
 
   const newFile = oldFile.replace(oldText, newText);
   if (newFile === oldFile) {


### PR DESCRIPTION
https://github.com/Piebald-AI/tweakcc/issues/534#issuecomment-3946645290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display of "undefined" text appearing in shortcuts and mode information when no active toolset is selected.

* **Documentation**
  * Updated changelog to document the toolset display fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->