### PR TITLE
Backfill missing identifiers in 2.1.16-17 from 2.1.18

### DIFF
--- a/data/prompts/prompts-2.1.16.json
+++ b/data/prompts/prompts-2.1.16.json
@@ -813,7 +813,7 @@
         0
       ],
       "identifierMap": {
-        "0": ""
+        "0": "TOOL_NAME"
       },
       "version": "2.1.16"
     },

--- a/data/prompts/prompts-2.1.17.json
+++ b/data/prompts/prompts-2.1.17.json
@@ -813,7 +813,7 @@
         0
       ],
       "identifierMap": {
-        "0": ""
+        "0": "TOOL_NAME"
       },
       "version": "2.1.16"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated identifier mappings in prompt configuration files. Configuration versions 2.1.16 and 2.1.17 have been revised to ensure proper tool identification. The mapping for identifier key "0" has been changed from an empty value to the correct tool identifier, improving consistency in how tools are identified throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->