### PR TITLE
feat: Add voice mode patch (tengu_amber_quartz + tengu_sotto_voce)

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -716,7 +716,7 @@ export const DEFAULT_SETTINGS: Settings = {
     enableContextLimitOverride: false,
     enableModelCustomizations: true,
     enableVoiceMode: false,
-    enableVoiceSottoVoce: true,
+    enableVoiceConciseOutput: true,
   },
   toolsets: [],
   defaultToolset: null,

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -858,7 +858,10 @@ export const applyCustomization = async (
     },
     'voice-mode': {
       fn: c =>
-        writeVoiceMode(c, config.settings.misc?.enableVoiceSottoVoce ?? true),
+        writeVoiceMode(
+          c,
+          config.settings.misc?.enableVoiceConciseOutput ?? true
+        ),
       condition: !!config.settings.misc?.enableVoiceMode,
     },
   };

--- a/src/patches/voiceMode.test.ts
+++ b/src/patches/voiceMode.test.ts
@@ -16,7 +16,7 @@ describe('voiceMode', () => {
     expect(result).toContain('if(!0)return`# Output efficiency...`');
   });
 
-  it('patches only amber quartz when enableSottoVoce is false', () => {
+  it('patches only amber quartz when enableConciseOutput is false', () => {
     const file =
       'const x=1;' +
       'function qX_(){return A9("tengu_amber_quartz",!1)}' +

--- a/src/patches/voiceMode.ts
+++ b/src/patches/voiceMode.ts
@@ -48,7 +48,7 @@ const patchAmberQuartz = (file: string): string | null => {
   return newFile;
 };
 
-const patchSottoVoce = (file: string): string | null => {
+const patchConciseOutput = (file: string): string | null => {
   const pattern = /if\([$\w]+\("tengu_sotto_voce",!1\)\)/;
   const match = file.match(pattern);
 
@@ -76,13 +76,13 @@ const patchSottoVoce = (file: string): string | null => {
 
 export const writeVoiceMode = (
   file: string,
-  enableSottoVoce: boolean
+  enableConciseOutput: boolean
 ): string | null => {
   let newFile = patchAmberQuartz(file);
   if (!newFile) return null;
 
-  if (enableSottoVoce) {
-    newFile = patchSottoVoce(newFile);
+  if (enableConciseOutput) {
+    newFile = patchConciseOutput(newFile);
     if (!newFile) return null;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,7 @@ export interface MiscConfig {
   enableContextLimitOverride: boolean;
   enableModelCustomizations: boolean;
   enableVoiceMode: boolean;
-  enableVoiceSottoVoce: boolean;
+  enableVoiceConciseOutput: boolean;
 }
 
 export interface InputPatternHighlighter {

--- a/src/ui/components/MiscView.tsx
+++ b/src/ui/components/MiscView.tsx
@@ -82,7 +82,7 @@ export function MiscView({ onSubmit }: MiscViewProps) {
     enableContextLimitOverride: false,
     enableModelCustomizations: true,
     enableVoiceMode: false,
-    enableVoiceSottoVoce: true,
+    enableVoiceConciseOutput: true,
   };
 
   const ensureMisc = () => {
@@ -419,16 +419,16 @@ export function MiscView({ onSubmit }: MiscViewProps) {
         },
       },
       {
-        id: 'enableVoiceSottoVoce',
-        title: 'Enable sotto voce for voice mode',
+        id: 'enableVoiceConciseOutput',
+        title: 'Enable concise output for voice mode',
         description:
           'Enable the concise-output prompt used for voice interactions. Only applies when voice mode is enabled.',
-        getValue: () => settings.misc?.enableVoiceSottoVoce ?? true,
+        getValue: () => settings.misc?.enableVoiceConciseOutput ?? true,
         toggle: () => {
           updateSettings(settings => {
             ensureMisc();
-            settings.misc!.enableVoiceSottoVoce =
-              !settings.misc!.enableVoiceSottoVoce;
+            settings.misc!.enableVoiceConciseOutput =
+              !settings.misc!.enableVoiceConciseOutput;
           });
         },
       },


### PR DESCRIPTION
Force-enable the /voice slash command by bypassing the tengu_amber_quartz feature gate, and optionally enable the tengu_sotto_voce concise output mode for voice interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Voice mode" (accessible via /voice) with two toggles: enableVoiceMode (default off) and enableVoiceSottoVoce (default on).
  * Settings UI updated to control these voice options.
* **Tests**
  * Added automated tests validating voice-mode behavior and gating logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->