### PR TITLE
Add input chevron color patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add input chevron color patch (#634) - @VitalyOstanin
+
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 
 - Fix crash when a system prompt's search regex is too complex to compile, which aborted the entire `--apply` on Node <=22 (#753) - @StreamDemon

--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -687,7 +687,7 @@ export const DEFAULT_SETTINGS: Settings = {
   },
   inputBox: {
     removeBorder: false,
-    chevronIdleColor: null,
+    chevronIdleThemeColor: null,
   },
   misc: {
     showTweakccVersion: true,

--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -687,6 +687,7 @@ export const DEFAULT_SETTINGS: Settings = {
   },
   inputBox: {
     removeBorder: false,
+    chevronIdleColor: null,
   },
   misc: {
     showTweakccVersion: true,

--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -687,7 +687,7 @@ export const DEFAULT_SETTINGS: Settings = {
   },
   inputBox: {
     removeBorder: false,
-    chevronIdleThemeColor: null,
+    chevronIdleThemeColor: 'success',
   },
   misc: {
     showTweakccVersion: true,

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -786,9 +786,15 @@ export const applyCustomization = async (
       ),
     },
     'input-chevron-color': {
-      fn: c =>
-        writeInputChevronColor(c, config.settings.inputBox!.chevronIdleColor!),
-      condition: !!config.settings.inputBox?.chevronIdleColor,
+      fn: c => {
+        const themeColorKey = config.settings.inputBox!.chevronIdleThemeColor!;
+        const theme = config.settings.themes?.[0];
+        const resolved =
+          (theme?.colors as Record<string, string>)?.[themeColorKey] ??
+          themeColorKey;
+        return writeInputChevronColor(c, resolved);
+      },
+      condition: !!config.settings.inputBox?.chevronIdleThemeColor,
     },
     'subagent-models': {
       fn: c => writeSubagentModels(c, config.settings.subagentModels!),

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -33,6 +33,7 @@ import { writeShowMoreItemsInSelectMenus } from './showMoreItemsInSelectMenus';
 import { writeThemes } from './themes';
 import { writeContextLimit } from './contextLimit';
 import { writeInputBoxBorder } from './inputBorderBox';
+import { writeInputChevronColor } from './inputChevronColor';
 import { writeThinkerFormat } from './thinkerFormat';
 import { writeThinkerSymbolMirrorOption } from './thinkerMirrorOption';
 import { writeThinkerSymbolChars } from './thinkerSymbolChars';
@@ -271,6 +272,13 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.MISC_CONFIGURABLE,
     description:
       "Your custom styles to the main input box's border will be applied",
+  },
+  {
+    id: 'input-chevron-color',
+    name: 'Input chevron color',
+    group: PatchGroup.MISC_CONFIGURABLE,
+    description:
+      'The input chevron changes color based on loading state (e.g. green when idle)',
   },
   {
     id: 'subagent-models',
@@ -776,6 +784,11 @@ export const applyCustomization = async (
         config.settings.inputBox.removeBorder !==
           DEFAULT_SETTINGS.inputBox.removeBorder
       ),
+    },
+    'input-chevron-color': {
+      fn: c =>
+        writeInputChevronColor(c, config.settings.inputBox!.chevronIdleColor!),
+      condition: !!config.settings.inputBox?.chevronIdleColor,
     },
     'subagent-models': {
       fn: c => writeSubagentModels(c, config.settings.subagentModels!),

--- a/src/patches/inputChevronColor.test.ts
+++ b/src/patches/inputChevronColor.test.ts
@@ -5,7 +5,7 @@ import { writeInputChevronColor } from './inputChevronColor';
 const chevron =
   ',{isLoading:n,themeColor:r}=e,s=r??void 0,i;' +
   'if(t[0]!==s||t[1]!==n)' +
-  'i=Kne.createElement(w,{"aria-label":"input:",color:s,dimColor:n},et.pointer,"\\xA0")';
+  'i=Kne.jsxs(w,{color:s,dimColor:n,children:[et.pointer,"\\xA0"]})';
 
 const makeInput = () => 'var a=1' + chevron + ',t[2]=i;else i=t[2];return i';
 
@@ -35,7 +35,7 @@ describe('writeInputChevronColor', () => {
     const input =
       'var a=1,{isLoading:X$,themeColor:Y$}=Z$,W$=Y$??void 0,V$;' +
       'if(Q$[0]!==W$||Q$[1]!==X$)' +
-      'V$=R$.createElement(T$,{"aria-label":"input:",color:W$,dimColor:X$},U$.pointer,"\\xA0")';
+      'V$=R$.jsxs(T$,{color:W$,dimColor:X$,children:[U$.pointer,"\\xA0"]})';
     const result = writeInputChevronColor(input, 'blue');
 
     expect(result).not.toBeNull();

--- a/src/patches/inputChevronColor.test.ts
+++ b/src/patches/inputChevronColor.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+
+import { writeInputChevronColor } from './inputChevronColor';
+
+const chevron =
+  ',{isLoading:n,themeColor:r}=e,s=r??void 0,i;' +
+  'if(t[0]!==s||t[1]!==n)' +
+  'i=Kne.createElement(w,{"aria-label":"input:",color:s,dimColor:n},et.pointer,"\\xA0")';
+
+const makeInput = () => 'var a=1' + chevron + ',t[2]=i;else i=t[2];return i';
+
+describe('writeInputChevronColor', () => {
+  it('replaces color/dimColor with conditional resolved color', () => {
+    const result = writeInputChevronColor(makeInput(), 'red');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('color:n?s:"red",dimColor:!1');
+    expect(result).not.toContain('color:s,dimColor:n');
+  });
+
+  it('returns null when pattern not found', () => {
+    const result = writeInputChevronColor('const x=1;', 'red');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when already patched', () => {
+    const patched = writeInputChevronColor(makeInput(), 'red')!;
+    const result = writeInputChevronColor(patched, 'red');
+
+    expect(result).toBeNull();
+  });
+
+  it('works with different identifier names', () => {
+    const input =
+      'var a=1,{isLoading:X$,themeColor:Y$}=Z$,W$=Y$??void 0,V$;' +
+      'if(Q$[0]!==W$||Q$[1]!==X$)' +
+      'V$=R$.createElement(T$,{"aria-label":"input:",color:W$,dimColor:X$},U$.pointer,"\\xA0")';
+    const result = writeInputChevronColor(input, 'blue');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('color:X$?W$:"blue",dimColor:!1');
+  });
+});

--- a/src/patches/inputChevronColor.ts
+++ b/src/patches/inputChevronColor.ts
@@ -1,0 +1,39 @@
+// Please see the note about writing patches in ./index
+
+import { showDiff } from './index';
+
+export const writeInputChevronColor = (
+  file: string,
+  idleColor: string
+): string | null => {
+  // Match the chevron component (gg4) by its unique structure:
+  // destructures {isLoading:VAR,themeColor:VAR}, then createElement with color:VAR,dimColor:VAR,...pointer
+  const pattern =
+    /,\{isLoading:([$\w]+),themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[$\w]+;if\([$\w]+\[0\]!==\3\|\|[$\w]+\[1\]!==\1\)[$\w]+=[$\w]+\.createElement\([$\w]+,\{color:\3,dimColor:\1\}/;
+
+  const match = file.match(pattern);
+
+  if (!match || match.index === undefined) {
+    console.error(
+      'patch: inputChevronColor: failed to find chevron component pattern'
+    );
+    return null;
+  }
+
+  const isLoadingVar = match[1];
+  const resolvedColorVar = match[3];
+
+  const oldColorPart = `color:${resolvedColorVar},dimColor:${isLoadingVar}`;
+  const newColorPart = `color:${isLoadingVar}?${resolvedColorVar}:${JSON.stringify(idleColor)},dimColor:!1`;
+
+  const colorPartIndex = match[0].indexOf(oldColorPart);
+  const startIndex = match.index + colorPartIndex;
+  const endIndex = startIndex + oldColorPart.length;
+
+  const newFile =
+    file.slice(0, startIndex) + newColorPart + file.slice(endIndex);
+
+  showDiff(file, newFile, newColorPart, startIndex, endIndex);
+
+  return newFile;
+};

--- a/src/patches/inputChevronColor.ts
+++ b/src/patches/inputChevronColor.ts
@@ -1,22 +1,17 @@
-// Please see the note about writing patches in ./index
-
+import { debug } from '../utils';
 import { showDiff } from './index';
 
 export const writeInputChevronColor = (
   file: string,
-  idleColor: string
+  resolvedColor: string
 ): string | null => {
-  // Match the chevron component (gg4) by its unique structure:
-  // destructures {isLoading:VAR,themeColor:VAR}, then createElement with color:VAR,dimColor:VAR,...pointer
   const pattern =
     /,\{isLoading:([$\w]+),themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[$\w]+;if\([$\w]+\[0\]!==\3\|\|[$\w]+\[1\]!==\1\)[$\w]+=[$\w]+\.createElement\([$\w]+,\{color:\3,dimColor:\1\}/;
 
   const match = file.match(pattern);
 
   if (!match || match.index === undefined) {
-    console.error(
-      'patch: inputChevronColor: failed to find chevron component pattern'
-    );
+    debug('patch: inputChevronColor: failed to find chevron component pattern');
     return null;
   }
 
@@ -24,7 +19,7 @@ export const writeInputChevronColor = (
   const resolvedColorVar = match[3];
 
   const oldColorPart = `color:${resolvedColorVar},dimColor:${isLoadingVar}`;
-  const newColorPart = `color:${isLoadingVar}?${resolvedColorVar}:${JSON.stringify(idleColor)},dimColor:!1`;
+  const newColorPart = `color:${isLoadingVar}?${resolvedColorVar}:${JSON.stringify(resolvedColor)},dimColor:!1`;
 
   const colorPartIndex = match[0].indexOf(oldColorPart);
   const startIndex = match.index + colorPartIndex;

--- a/src/patches/inputChevronColor.ts
+++ b/src/patches/inputChevronColor.ts
@@ -6,7 +6,7 @@ export const writeInputChevronColor = (
   resolvedColor: string
 ): string | null => {
   const pattern =
-    /,\{isLoading:([$\w]+),themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[$\w]+;if\([$\w]+\[0\]!==\3\|\|[$\w]+\[1\]!==\1\)[$\w]+=[$\w]+\.createElement\([$\w]+,\{color:\3,dimColor:\1\}/;
+    /,\{isLoading:([$\w]+),themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[$\w]+;if\([$\w]+\[0\]!==\3\|\|[$\w]+\[1\]!==\1\)[$\w]+=[$\w]+\.createElement\([$\w]+,\{"aria-label":"input:",color:\3,dimColor:\1\}/;
 
   const match = file.match(pattern);
 

--- a/src/patches/inputChevronColor.ts
+++ b/src/patches/inputChevronColor.ts
@@ -6,7 +6,7 @@ export const writeInputChevronColor = (
   resolvedColor: string
 ): string | null => {
   const pattern =
-    /,\{isLoading:([$\w]+),themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[$\w]+;if\([$\w]+\[0\]!==\3\|\|[$\w]+\[1\]!==\1\)[$\w]+=[$\w]+\.createElement\([$\w]+,\{"aria-label":"input:",color:\3,dimColor:\1\}/;
+    /,\{isLoading:([$\w]+),themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[$\w]+;if\([$\w]+\[0\]!==\3\|\|[$\w]+\[1\]!==\1\)[$\w]+=[$\w]+\.jsxs\([$\w]+,\{color:\3,dimColor:\1,children:/;
 
   const match = file.match(pattern);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,7 +102,7 @@ export interface UserMessageDisplayConfig {
 
 export interface InputBoxConfig {
   removeBorder: boolean;
-  chevronIdleColor: string | null;
+  chevronIdleThemeColor: string | null;
 }
 
 export type TableFormat = 'default' | 'ascii' | 'clean' | 'clean-top-bottom';

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,7 @@ export interface UserMessageDisplayConfig {
 
 export interface InputBoxConfig {
   removeBorder: boolean;
+  chevronIdleColor: string | null;
 }
 
 export type TableFormat = 'default' | 'ascii' | 'clean' | 'clean-top-bottom';

--- a/src/ui/components/MiscView.tsx
+++ b/src/ui/components/MiscView.tsx
@@ -3,6 +3,7 @@ import { useContext, useState, useMemo } from 'react';
 import { SettingsContext } from '../App';
 import Header from './Header';
 import { TableFormat } from '../../types';
+import { DEFAULT_SETTINGS } from '../../defaultSettings';
 
 interface MiscViewProps {
   onSubmit: () => void;
@@ -167,10 +168,7 @@ export function MiscView({ onSubmit }: MiscViewProps) {
         toggle: () => {
           updateSettings(settings => {
             if (!settings.inputBox) {
-              settings.inputBox = {
-                removeBorder: false,
-                chevronIdleColor: null,
-              };
+              settings.inputBox = { ...DEFAULT_SETTINGS.inputBox };
             }
             settings.inputBox.removeBorder = !settings.inputBox.removeBorder;
           });

--- a/src/ui/components/MiscView.tsx
+++ b/src/ui/components/MiscView.tsx
@@ -167,7 +167,10 @@ export function MiscView({ onSubmit }: MiscViewProps) {
         toggle: () => {
           updateSettings(settings => {
             if (!settings.inputBox) {
-              settings.inputBox = { removeBorder: false };
+              settings.inputBox = {
+                removeBorder: false,
+                chevronIdleColor: null,
+              };
             }
             settings.inputBox.removeBorder = !settings.inputBox.removeBorder;
           });


### PR DESCRIPTION
## Summary

New patch that changes the input chevron (❯) color based on loading state:
- **Idle** (waiting for input): configurable theme color (e.g. `"success"` for green)
- **Generating**: keeps the current theme color without dimming

## Changes

- `src/patches/inputChevronColor.ts` — new patch file
- `src/types.ts` — add `chevronIdleColor` to `InputBoxConfig`
- `src/defaultSettings.ts` — default `null` (disabled)
- `src/patches/index.ts` — import, definition, implementation
- `src/ui/components/MiscView.tsx` — type fix for `InputBoxConfig` initialization

## Configuration

Set in `config.json`:
```json
{
  "inputBox": {
    "chevronIdleColor": "success"
  }
}
```

The value is a theme color key (e.g. `"success"`, `"bashBorder"`, `"planMode"`). Set to `null` to disable.

## Testing

- [x] Manual testing on Linux with Claude Code 2.1.84 (native binary)
- [x] Verified chevron turns green when idle, keeps theme color during generation
- [x] All existing tests pass

## Related Issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "idle chevron color" for the input box so users can set the chevron color when the input is not loading.
  * UI toggle now initializes input box settings with defaults so the chevron option is preserved when toggling.

* **Chores**
  * Background logic now applies the configured chevron color when set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->