### PR TITLE
feat: add /clear-screen slash command

### DIFF
--- a/src/patches/clearScreen.test.ts
+++ b/src/patches/clearScreen.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { writeClearScreen } from './clearScreen';
+
+const cmds = Array.from({ length: 31 }, (_, i) => `c${i}`).join(',');
+const slashCommandArray = `=>[${cmds}]`;
+
+const makeInput = (delimiter = ';') =>
+  'const x=1' +
+  slashCommandArray +
+  `${delimiter}let Z=G_H.useCallback(()=>{Nw.get(process.stdout)?.forceRedraw()})`;
+
+describe('clearScreen', () => {
+  it('exposes forceRedraw and registers /clear-screen command', () => {
+    const result = writeClearScreen(makeInput());
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'globalThis.__tweakccForceRedraw=()=>Nw.get(process.stdout)?.forceRedraw()'
+    );
+    expect(result).toContain('name:"clear-screen"');
+    expect(result).toContain('$.setMessages(');
+    expect(result).toContain('globalThis.__tweakccForceRedraw?.()');
+  });
+
+  it('preserves original app:redraw callback', () => {
+    const result = writeClearScreen(makeInput());
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'let Z=G_H.useCallback(()=>{Nw.get(process.stdout)?.forceRedraw()})'
+    );
+  });
+
+  it('returns oldFile when already patched', () => {
+    const input = makeInput() + ',{name:"clear-screen"}';
+    const result = writeClearScreen(input);
+
+    expect(result).toBe(input);
+  });
+
+  it('returns null when app:redraw callback not found', () => {
+    const result = writeClearScreen('const x=1;');
+
+    expect(result).toBeNull();
+  });
+
+  it('works with different delimiters before useCallback', () => {
+    for (const d of [',', ';', '}', '{']) {
+      const result = writeClearScreen(makeInput(d));
+      expect(result).not.toBeNull();
+      expect(result).toContain('globalThis.__tweakccForceRedraw');
+    }
+  });
+});

--- a/src/patches/clearScreen.test.ts
+++ b/src/patches/clearScreen.test.ts
@@ -9,7 +9,7 @@ const renderFilter =
   'function g97(H,$){if(H.type!=="user")return!0;if(H.isMeta){if(H.origin?.kind==="channel")return!0;return!1}if(H.isVisibleInTranscriptOnly&&!$)return!1;return!0}';
 
 const makeInput = (delimiter = ';') =>
-  'const x=1' +
+  'const x=1;' +
   renderFilter +
   slashCommandArray +
   `${delimiter}let Z=G_H.useCallback(()=>{Nw.get(process.stdout)?.forceRedraw()})`;
@@ -90,16 +90,16 @@ describe('clearScreen', () => {
 
 describe('patchRenderFilter', () => {
   it('adds __tweakccHiddenUUIDs check at the start of the function', () => {
-    const result = patchRenderFilter(renderFilter);
+    const result = patchRenderFilter(';' + renderFilter);
 
     expect(result).not.toBeNull();
     expect(result).toContain(
-      'function g97(H,$){if(globalThis.__tweakccHiddenUUIDs?.has(H.uuid?.slice(0,24)))return!1;if(H.type!=="user")'
+      ';function g97(H,$){if(globalThis.__tweakccHiddenUUIDs?.has(H.uuid?.slice(0,24)))return!1;if(H.type!=="user")'
     );
   });
 
   it('preserves the rest of the function', () => {
-    const result = patchRenderFilter(renderFilter);
+    const result = patchRenderFilter(';' + renderFilter);
 
     expect(result).not.toBeNull();
     expect(result).toContain('if(H.isMeta)');
@@ -112,9 +112,19 @@ describe('patchRenderFilter', () => {
     expect(result).toBeNull();
   });
 
+  it('works with different delimiters before function', () => {
+    for (const d of [',', ';', '}', '{']) {
+      const result = patchRenderFilter(d + renderFilter);
+      expect(result).not.toBeNull();
+      expect(result).toContain(
+        'if(globalThis.__tweakccHiddenUUIDs?.has(H.uuid?.slice(0,24)))return!1;'
+      );
+    }
+  });
+
   it('works with different function and argument names', () => {
     const input =
-      'function abc(X$,Y$){if(X$.type!=="user")return!0;if(X$.isMeta){if(X$.origin?.kind==="channel")return!0;return!1}return!0}';
+      ';function abc(X$,Y$){if(X$.type!=="user")return!0;if(X$.isMeta){if(X$.origin?.kind==="channel")return!0;return!1}return!0}';
     const result = patchRenderFilter(input);
 
     expect(result).not.toBeNull();

--- a/src/patches/clearScreen.test.ts
+++ b/src/patches/clearScreen.test.ts
@@ -45,6 +45,13 @@ describe('clearScreen', () => {
     expect(result).toBeNull();
   });
 
+  it('preserves fallback for assistant messages without usage', () => {
+    const result = writeClearScreen(makeInput());
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('if(!k&&m[i]?.type==="assistant")k=m[i]');
+  });
+
   it('works with different delimiters before useCallback', () => {
     for (const d of [',', ';', '}', '{']) {
       const result = writeClearScreen(makeInput(d));

--- a/src/patches/clearScreen.test.ts
+++ b/src/patches/clearScreen.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { writeClearScreen } from './clearScreen';
+import { writeClearScreen, patchRenderFilter } from './clearScreen';
 
 const cmds = Array.from({ length: 31 }, (_, i) => `c${i}`).join(',');
 const slashCommandArray = `=>[${cmds}]`;
 
+const renderFilter =
+  'function g97(H,$){if(H.type!=="user")return!0;if(H.isMeta){if(H.origin?.kind==="channel")return!0;return!1}if(H.isVisibleInTranscriptOnly&&!$)return!1;return!0}';
+
 const makeInput = (delimiter = ';') =>
   'const x=1' +
+  renderFilter +
   slashCommandArray +
   `${delimiter}let Z=G_H.useCallback(()=>{Nw.get(process.stdout)?.forceRedraw()})`;
 
@@ -19,8 +23,28 @@ describe('clearScreen', () => {
       'globalThis.__tweakccForceRedraw=()=>Nw.get(process.stdout)?.forceRedraw()'
     );
     expect(result).toContain('name:"clear-screen"');
-    expect(result).toContain('$.setMessages(');
+    expect(result).toContain('__tweakccHiddenUUIDs');
     expect(result).toContain('globalThis.__tweakccForceRedraw?.()');
+  });
+
+  it('preserves all messages for API context (hides via UUID set, does not remove)', () => {
+    const result = writeClearScreen(makeInput());
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('__tweakccHiddenUUIDs=new Set(');
+    expect(result).toContain('return[...m]');
+    expect(result).not.toContain('content:[]');
+    expect(result).not.toContain('return k?[');
+    expect(result).not.toContain('return[]');
+  });
+
+  it('patches render filter to check __tweakccHiddenUUIDs', () => {
+    const result = writeClearScreen(makeInput());
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'globalThis.__tweakccHiddenUUIDs?.has(H.uuid?.slice(0,24)))return!1;if(H.type!=="user")'
+    );
   });
 
   it('preserves original app:redraw callback', () => {
@@ -45,11 +69,14 @@ describe('clearScreen', () => {
     expect(result).toBeNull();
   });
 
-  it('preserves fallback for assistant messages without usage', () => {
-    const result = writeClearScreen(makeInput());
+  it('returns null when render filter not found', () => {
+    const input =
+      'const x=1' +
+      slashCommandArray +
+      ';let Z=G_H.useCallback(()=>{Nw.get(process.stdout)?.forceRedraw()})';
+    const result = writeClearScreen(input);
 
-    expect(result).not.toBeNull();
-    expect(result).toContain('if(!k&&m[i]?.type==="assistant")k=m[i]');
+    expect(result).toBeNull();
   });
 
   it('works with different delimiters before useCallback', () => {
@@ -58,5 +85,41 @@ describe('clearScreen', () => {
       expect(result).not.toBeNull();
       expect(result).toContain('globalThis.__tweakccForceRedraw');
     }
+  });
+});
+
+describe('patchRenderFilter', () => {
+  it('adds __tweakccHiddenUUIDs check at the start of the function', () => {
+    const result = patchRenderFilter(renderFilter);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'function g97(H,$){if(globalThis.__tweakccHiddenUUIDs?.has(H.uuid?.slice(0,24)))return!1;if(H.type!=="user")'
+    );
+  });
+
+  it('preserves the rest of the function', () => {
+    const result = patchRenderFilter(renderFilter);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('if(H.isMeta)');
+    expect(result).toContain('if(H.isVisibleInTranscriptOnly&&!$)return!1');
+  });
+
+  it('returns null when pattern not found', () => {
+    const result = patchRenderFilter('const x=1;');
+
+    expect(result).toBeNull();
+  });
+
+  it('works with different function and argument names', () => {
+    const input =
+      'function abc(X$,Y$){if(X$.type!=="user")return!0;if(X$.isMeta){if(X$.origin?.kind==="channel")return!0;return!1}return!0}';
+    const result = patchRenderFilter(input);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'if(globalThis.__tweakccHiddenUUIDs?.has(X$.uuid?.slice(0,24)))return!1;'
+    );
   });
 });

--- a/src/patches/clearScreen.test.ts
+++ b/src/patches/clearScreen.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { writeClearScreen, patchRenderFilter } from './clearScreen';
 
 const cmds = Array.from({ length: 31 }, (_, i) => `c${i}`).join(',');
-const slashCommandArray = `=>[${cmds}]`;
+const slashCommandArray =
+  'var Cmd0={type:"local",name:"clear",description:"Clear"};' +
+  `Cmds=memo9(()=>[${cmds},...Fa?[Fa]:[]])`;
 
 const renderFilter =
   'function g97(H,$){if(H.type!=="user")return!0;if(H.isMeta){if(H.origin?.kind==="channel")return!0;return!1}if(H.isVisibleInTranscriptOnly&&!$)return!1;return!0}';
@@ -11,8 +13,9 @@ const renderFilter =
 const makeInput = (delimiter = ';') =>
   'const x=1;' +
   renderFilter +
+  ';' +
   slashCommandArray +
-  `${delimiter}let Z=G_H.useCallback(()=>{Nw.get(process.stdout)?.forceRedraw()})`;
+  `${delimiter}function cHz(){Nw.get(process.stdout)?.forceRedraw()}`;
 
 describe('clearScreen', () => {
   it('exposes forceRedraw and registers /clear-screen command', () => {
@@ -47,12 +50,12 @@ describe('clearScreen', () => {
     );
   });
 
-  it('preserves original app:redraw callback', () => {
+  it('preserves original forceRedraw function', () => {
     const result = writeClearScreen(makeInput());
 
     expect(result).not.toBeNull();
     expect(result).toContain(
-      'let Z=G_H.useCallback(()=>{Nw.get(process.stdout)?.forceRedraw()})'
+      'function cHz(){Nw.get(process.stdout)?.forceRedraw()}'
     );
   });
 
@@ -63,7 +66,7 @@ describe('clearScreen', () => {
     expect(result).toBe(input);
   });
 
-  it('returns null when app:redraw callback not found', () => {
+  it('returns null when forceRedraw function not found', () => {
     const result = writeClearScreen('const x=1;');
 
     expect(result).toBeNull();
@@ -71,15 +74,15 @@ describe('clearScreen', () => {
 
   it('returns null when render filter not found', () => {
     const input =
-      'const x=1' +
+      'const x=1;' +
       slashCommandArray +
-      ';let Z=G_H.useCallback(()=>{Nw.get(process.stdout)?.forceRedraw()})';
+      ';function cHz(){Nw.get(process.stdout)?.forceRedraw()}';
     const result = writeClearScreen(input);
 
     expect(result).toBeNull();
   });
 
-  it('works with different delimiters before useCallback', () => {
+  it('works with different delimiters before forceRedraw function', () => {
     for (const d of [',', ';', '}', '{']) {
       const result = writeClearScreen(makeInput(d));
       expect(result).not.toBeNull();

--- a/src/patches/clearScreen.ts
+++ b/src/patches/clearScreen.ts
@@ -1,0 +1,61 @@
+// Please see the note about writing patches in ./index
+
+import { debug } from '../utils';
+import { showDiff } from './index';
+import { writeSlashCommandDefinition } from './slashCommands';
+
+export const writeClearScreen = (oldFile: string): string | null => {
+  const alreadyPatchedPattern = /name:"clear-screen"/;
+  if (alreadyPatchedPattern.test(oldFile)) {
+    return oldFile;
+  }
+
+  const redrawPattern =
+    /([,;{}])(let [$\w]+=[$\w]+\.useCallback\(\(\)=>\{)([$\w]+)\.get\(process\.stdout\)\?\.forceRedraw\(\)\}/;
+  const redrawMatch = oldFile.match(redrawPattern);
+  if (!redrawMatch || redrawMatch.index === undefined) {
+    debug('patch: clearScreen: failed to find app:redraw callback');
+    return null;
+  }
+
+  const delimiter = redrawMatch[1];
+  const mapVar = redrawMatch[3];
+  const redrawReplacement =
+    `${delimiter}globalThis.__tweakccForceRedraw=()=>${mapVar}.get(process.stdout)?.forceRedraw();` +
+    redrawMatch[0].slice(1);
+
+  const file =
+    oldFile.slice(0, redrawMatch.index) +
+    redrawReplacement +
+    oldFile.slice(redrawMatch.index + redrawMatch[0].length);
+
+  showDiff(
+    oldFile,
+    file,
+    redrawReplacement,
+    redrawMatch.index,
+    redrawMatch.index + redrawMatch[0].length
+  );
+
+  const commandDef =
+    ',{type:"local",name:"clear-screen",' +
+    'description:"Clear screen without resetting conversation context",' +
+    'supportsNonInteractive:!1,' +
+    'load:()=>Promise.resolve().then(()=>({call:(H,$)=>{' +
+    '$.setMessages(m=>{' +
+    'for(let i=m.length-1;i>=0;i--)' +
+    'if(m[i]?.type==="assistant"&&m[i].message?.usage)' +
+    'return[{...m[i],message:{...m[i].message,content:[]}}];' +
+    'return[]});' +
+    'process.stdout.write("\\x1b[3J");' +
+    'globalThis.__tweakccForceRedraw?.();' +
+    'return{type:"skip"}}}))}';
+
+  const result = writeSlashCommandDefinition(file, commandDef);
+  if (!result) {
+    debug('patch: clearScreen: failed to register slash command');
+    return null;
+  }
+
+  return result;
+};

--- a/src/patches/clearScreen.ts
+++ b/src/patches/clearScreen.ts
@@ -67,21 +67,22 @@ export const writeClearScreen = (oldFile: string): string | null => {
 
 export const patchRenderFilter = (oldFile: string): string | null => {
   const pattern =
-    /(function [$\w]+\([$\w]+,[$\w]+\)\{)if\([$\w]+\.type!=="user"\)return!0;if\([$\w]+\.isMeta\)/;
+    /([,;{}])(function [$\w]+\([$\w]+,[$\w]+\)\{)if\([$\w]+\.type!=="user"\)return!0;if\([$\w]+\.isMeta\)/;
   const match = oldFile.match(pattern);
   if (!match || match.index === undefined) {
     return null;
   }
 
-  const funcPrefix = match[1];
+  const delimiter = match[1];
+  const funcPrefix = match[2];
   const firstArg = match[0].match(/function ([$\w]+)\(([$\w]+),/)?.[2];
   if (!firstArg) {
     return null;
   }
 
   const replacement =
-    `${funcPrefix}if(globalThis.__tweakccHiddenUUIDs?.has(${firstArg}.uuid?.slice(0,24)))return!1;` +
-    match[0].slice(funcPrefix.length);
+    `${delimiter}${funcPrefix}if(globalThis.__tweakccHiddenUUIDs?.has(${firstArg}.uuid?.slice(0,24)))return!1;` +
+    match[0].slice(delimiter.length + funcPrefix.length);
 
   const result =
     oldFile.slice(0, match.index) +

--- a/src/patches/clearScreen.ts
+++ b/src/patches/clearScreen.ts
@@ -67,7 +67,7 @@ export const writeClearScreen = (oldFile: string): string | null => {
 
 export const patchRenderFilter = (oldFile: string): string | null => {
   const pattern =
-    /([,;{}])(function [$\w]+\([$\w]+,[$\w]+\)\{)if\([$\w]+\.type!=="user"\)return!0;if\([$\w]+\.isMeta\)/;
+    /([,;{}])(function [$\w]+\(([$\w]+),[$\w]+\)\{)if\(\3\.type!=="user"\)return!0;if\(\3\.isMeta\)/;
   const match = oldFile.match(pattern);
   if (!match || match.index === undefined) {
     return null;
@@ -75,10 +75,7 @@ export const patchRenderFilter = (oldFile: string): string | null => {
 
   const delimiter = match[1];
   const funcPrefix = match[2];
-  const firstArg = match[0].match(/function ([$\w]+)\(([$\w]+),/)?.[2];
-  if (!firstArg) {
-    return null;
-  }
+  const firstArg = match[3];
 
   const replacement =
     `${delimiter}${funcPrefix}if(globalThis.__tweakccHiddenUUIDs?.has(${firstArg}.uuid?.slice(0,24)))return!1;` +

--- a/src/patches/clearScreen.ts
+++ b/src/patches/clearScreen.ts
@@ -24,7 +24,7 @@ export const writeClearScreen = (oldFile: string): string | null => {
     `${delimiter}globalThis.__tweakccForceRedraw=()=>${mapVar}.get(process.stdout)?.forceRedraw();` +
     redrawMatch[0].slice(1);
 
-  const file =
+  let file =
     oldFile.slice(0, redrawMatch.index) +
     redrawReplacement +
     oldFile.slice(redrawMatch.index + redrawMatch[0].length);
@@ -37,18 +37,22 @@ export const writeClearScreen = (oldFile: string): string | null => {
     redrawMatch.index + redrawMatch[0].length
   );
 
+  const renderFilterResult = patchRenderFilter(file);
+  if (!renderFilterResult) {
+    debug('patch: clearScreen: failed to patch render filter g97');
+    return null;
+  }
+  file = renderFilterResult;
+
   const commandDef =
     ',{type:"local",name:"clear-screen",' +
     'description:"Clear screen without resetting conversation context",' +
     'supportsNonInteractive:!1,' +
     'load:()=>Promise.resolve().then(()=>({call:(H,$)=>{' +
     '$.setMessages(m=>{' +
-    'let k=null;' +
-    'for(let i=m.length-1;i>=0;i--){' +
-    'if(m[i]?.type==="assistant"&&m[i].message?.usage){k=m[i];break}' +
-    'if(!k&&m[i]?.type==="assistant")k=m[i]}' +
-    'return k?[{...k,message:{...k.message,content:[]}}]:[]});' +
-    'process.stdout.write("\\x1b[3J");' +
+    'globalThis.__tweakccHiddenUUIDs=new Set(m.map(x=>x.uuid?.slice(0,24)).filter(Boolean));' +
+    'return[...m]});' +
+    'process.stdout.write("\\x1b[2J\\x1b[H\\x1b[3J");' +
     'globalThis.__tweakccForceRedraw?.();' +
     'return{type:"skip"}}}))}';
 
@@ -57,6 +61,40 @@ export const writeClearScreen = (oldFile: string): string | null => {
     debug('patch: clearScreen: failed to register slash command');
     return null;
   }
+
+  return result;
+};
+
+export const patchRenderFilter = (oldFile: string): string | null => {
+  const pattern =
+    /(function [$\w]+\([$\w]+,[$\w]+\)\{)if\([$\w]+\.type!=="user"\)return!0;if\([$\w]+\.isMeta\)/;
+  const match = oldFile.match(pattern);
+  if (!match || match.index === undefined) {
+    return null;
+  }
+
+  const funcPrefix = match[1];
+  const firstArg = match[0].match(/function ([$\w]+)\(([$\w]+),/)?.[2];
+  if (!firstArg) {
+    return null;
+  }
+
+  const replacement =
+    `${funcPrefix}if(globalThis.__tweakccHiddenUUIDs?.has(${firstArg}.uuid?.slice(0,24)))return!1;` +
+    match[0].slice(funcPrefix.length);
+
+  const result =
+    oldFile.slice(0, match.index) +
+    replacement +
+    oldFile.slice(match.index + match[0].length);
+
+  showDiff(
+    oldFile,
+    result,
+    replacement,
+    match.index,
+    match.index + match[0].length
+  );
 
   return result;
 };

--- a/src/patches/clearScreen.ts
+++ b/src/patches/clearScreen.ts
@@ -43,10 +43,11 @@ export const writeClearScreen = (oldFile: string): string | null => {
     'supportsNonInteractive:!1,' +
     'load:()=>Promise.resolve().then(()=>({call:(H,$)=>{' +
     '$.setMessages(m=>{' +
-    'for(let i=m.length-1;i>=0;i--)' +
-    'if(m[i]?.type==="assistant"&&m[i].message?.usage)' +
-    'return[{...m[i],message:{...m[i].message,content:[]}}];' +
-    'return[]});' +
+    'let k=null;' +
+    'for(let i=m.length-1;i>=0;i--){' +
+    'if(m[i]?.type==="assistant"&&m[i].message?.usage){k=m[i];break}' +
+    'if(!k&&m[i]?.type==="assistant")k=m[i]}' +
+    'return k?[{...k,message:{...k.message,content:[]}}]:[]});' +
     'process.stdout.write("\\x1b[3J");' +
     'globalThis.__tweakccForceRedraw?.();' +
     'return{type:"skip"}}}))}';

--- a/src/patches/clearScreen.ts
+++ b/src/patches/clearScreen.ts
@@ -11,10 +11,10 @@ export const writeClearScreen = (oldFile: string): string | null => {
   }
 
   const redrawPattern =
-    /([,;{}])(let [$\w]+=[$\w]+\.useCallback\(\(\)=>\{)([$\w]+)\.get\(process\.stdout\)\?\.forceRedraw\(\)\}/;
+    /([,;{}])(function [$\w]+\(\)\{)([$\w]+)\.get\(process\.stdout\)\?\.forceRedraw\(\)\}/;
   const redrawMatch = oldFile.match(redrawPattern);
   if (!redrawMatch || redrawMatch.index === undefined) {
-    debug('patch: clearScreen: failed to find app:redraw callback');
+    debug('patch: clearScreen: failed to find forceRedraw function');
     return null;
   }
 

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -75,6 +75,7 @@ import { writeWorktreeMode } from './worktreeMode';
 import { writeAllowCustomAgentModels } from './allowCustomAgentModels';
 import { writeVoiceMode } from './voiceMode';
 import { writeChannelsMode } from './channelsMode';
+import { writeClearScreen } from './clearScreen';
 import {
   restoreNativeBinaryFromBackup,
   restoreClijsFromBackup,
@@ -175,6 +176,12 @@ const PATCH_DEFINITIONS = [
     name: `Statusline update throttling correction`,
     group: PatchGroup.ALWAYS_APPLIED,
     description: `Statusline updates will be properly throttled instead of queued (or debounced)`,
+  },
+  {
+    id: 'clear-screen',
+    name: 'Clear screen command',
+    group: PatchGroup.ALWAYS_APPLIED,
+    description: 'Register /clear-screen command (clear scrollback + redraw)',
   },
   // Misc Configurable
   {
@@ -690,6 +697,9 @@ export const applyCustomization = async (
           config.settings.misc?.statuslineUseFixedInterval ?? false
         ),
       condition: config.settings.misc?.statuslineThrottleMs != null,
+    },
+    'clear-screen': {
+      fn: c => writeClearScreen(c),
     },
     // Misc Configurable
     'patches-applied-indication': {


### PR DESCRIPTION
## Summary

Add `/clear-screen` slash command that clears the screen without resetting conversation context.

- All messages remain in the `messages` array (full API context preserved)
- Messages are hidden from ink rendering via UUID-based filter on `g97`
- Terminal scrollback cleared via ANSI escape sequences
- Ink repaint triggered via `globalThis.__tweakccForceRedraw`
- Recommended keybinding: `ctrl+k ctrl+l` (Chat context)

## How it works

Three-part patch:

1. **Expose ink's `forceRedraw()`** — patches the `app:redraw` callback registration site to assign `globalThis.__tweakccForceRedraw` pointing to the ink instance's `forceRedraw()` method
2. **Patch render filter `g97`** — injects a check at the top of the render visibility function: if a message's UUID prefix is in `globalThis.__tweakccHiddenUUIDs`, return `false` (hide from UI). This works for both user and assistant messages, including multi-content assistant messages whose UUIDs are derived via `m$` (first 24 chars stay the same)
3. **Register `/clear-screen` command** — a `type:"local"` slash command that collects all current message UUID prefixes into a `Set` on `globalThis.__tweakccHiddenUUIDs`, clears terminal scrollback, and triggers ink repaint

### Why UUID-based hiding instead of replacing messages

The initial approach replaced the messages array via `setMessages`, keeping only the last assistant message with `content: []` to preserve ctx%. This caused Claude to lose conversation context — it would respond with "This is the first message in our session" because `setMessages` is the sole source for API messages. The UUID-based approach leaves all messages intact in the array (preserving full API context) and only hides them from ink rendering.

## Test plan

- [x] `/clear-screen` clears visible messages while preserving full conversation context
- [x] After `/clear-screen`, Claude remembers prior conversation (no "first message in session")
- [x] `ctrl+k ctrl+l` keybinding triggers the command (Chat context)
- [x] Terminal scrollback is cleared
- [x] Ink repaints correctly after clear
- [x] Unit tests pass (12 tests covering both `writeClearScreen` and `patchRenderFilter`: success, already patched, pattern not found, context preservation, delimiter variants, different function/argument names)
- [x] Tested on Claude Code 2.1.87 and 2.1.88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a clear-screen slash command that clears the terminal, updates hidden-message tracking, and triggers a screen redraw without affecting hidden messages.

* **Tests**
  * Adds tests covering command injection, render-filter patching, preservation of original redraw behavior, and edge cases (already-present command, missing patterns, delimiter variations, parameter-name differences).

* **Chores**
  * Registers the clear-screen patch in the patch application pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->