### PR TITLE
feat: add session-color patch for env-based prompt bar color

### DIFF
--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -671,6 +671,9 @@ export const applyCustomization = async (
         ),
       condition: config.settings.misc?.statuslineThrottleMs != null,
     },
+    'session-color': {
+      fn: c => writeSessionColor(c),
+    },
     // Misc Configurable
     'patches-applied-indication': {
       fn: c =>
@@ -895,9 +898,6 @@ export const applyCustomization = async (
     'channels-mode': {
       fn: c => writeChannelsMode(c),
       condition: !!config.settings.misc?.enableChannelsMode,
-    },
-    'session-color': {
-      fn: c => writeSessionColor(c),
     },
   };
 

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -73,6 +73,7 @@ import { writeWorktreeMode } from './worktreeMode';
 import { writeAllowCustomAgentModels } from './allowCustomAgentModels';
 import { writeVoiceMode } from './voiceMode';
 import { writeChannelsMode } from './channelsMode';
+import { writeSessionColor } from './sessionColor';
 import {
   restoreNativeBinaryFromBackup,
   restoreClijsFromBackup,
@@ -173,6 +174,13 @@ const PATCH_DEFINITIONS = [
     name: `Statusline update throttling correction`,
     group: PatchGroup.ALWAYS_APPLIED,
     description: `Statusline updates will be properly throttled instead of queued (or debounced)`,
+  },
+  {
+    id: 'session-color',
+    name: 'Session color from env',
+    group: PatchGroup.ALWAYS_APPLIED,
+    description:
+      'Set session prompt bar color via TWEAKCC_SESSION_COLOR env var',
   },
   // Misc Configurable
   {
@@ -887,6 +895,9 @@ export const applyCustomization = async (
     'channels-mode': {
       fn: c => writeChannelsMode(c),
       condition: !!config.settings.misc?.enableChannelsMode,
+    },
+    'session-color': {
+      fn: c => writeSessionColor(c),
     },
   };
 

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -681,6 +681,9 @@ export const applyCustomization = async (
     'clear-screen': {
       fn: c => writeClearScreen(c),
     },
+    'session-color': {
+      fn: c => writeSessionColor(c),
+    },
     // Misc Configurable
     'patches-applied-indication': {
       fn: c =>
@@ -910,9 +913,6 @@ export const applyCustomization = async (
     'channels-mode': {
       fn: c => writeChannelsMode(c),
       condition: !!config.settings.misc?.enableChannelsMode,
-    },
-    'session-color': {
-      fn: c => writeSessionColor(c),
     },
   };
 

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -74,6 +74,7 @@ import { writeAllowCustomAgentModels } from './allowCustomAgentModels';
 import { writeVoiceMode } from './voiceMode';
 import { writeChannelsMode } from './channelsMode';
 import { writeClearScreen } from './clearScreen';
+import { writeSessionColor } from './sessionColor';
 import {
   restoreNativeBinaryFromBackup,
   restoreClijsFromBackup,
@@ -180,6 +181,13 @@ const PATCH_DEFINITIONS = [
     name: 'Clear screen command',
     group: PatchGroup.ALWAYS_APPLIED,
     description: 'Register /clear-screen command (clear scrollback + redraw)',
+  },
+  {
+    id: 'session-color',
+    name: 'Session color from env',
+    group: PatchGroup.ALWAYS_APPLIED,
+    description:
+      'Set session prompt bar color via TWEAKCC_SESSION_COLOR env var',
   },
   // Misc Configurable
   {
@@ -902,6 +910,9 @@ export const applyCustomization = async (
     'channels-mode': {
       fn: c => writeChannelsMode(c),
       condition: !!config.settings.misc?.enableChannelsMode,
+    },
+    'session-color': {
+      fn: c => writeSessionColor(c),
     },
   };
 

--- a/src/patches/sessionColor.test.ts
+++ b/src/patches/sessionColor.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { writeSessionColor } from './sessionColor';
+import { writeSessionColor, patchSaveAgentColor } from './sessionColor';
+
+const makeSaveAgentColor = () =>
+  ';async function Mr$(H,$,q){let K=q??sT(H);' +
+  'if(Hv(K,{type:"agent-color",agentColor:$,sessionId:H}),H===V$())' +
+  'WA().currentSessionAgentColor=$;c("tengu_agent_color_set",{})}';
 
 const makeCLIState = () =>
   'effortValue:oR(w.effort),' +
@@ -12,37 +17,41 @@ const makeDefaultState = () =>
 const makeBoth = () =>
   'first{' + makeDefaultState() + 'second{' + makeCLIState();
 
+const makeFullFile = () => makeBoth() + makeSaveAgentColor();
+
 describe('sessionColor', () => {
   describe('writeSessionColor', () => {
-    it('should inject into CLI initialState', () => {
-      const result = writeSessionColor(makeCLIState());
+    it('should inject into CLI initialState and patch saveAgentColor', () => {
+      const result = writeSessionColor(makeFullFile());
       expect(result).not.toBeNull();
       expect(result).toContain('TWEAKCC_SESSION_COLOR');
       expect(result).toContain('{name:"",color:__c}');
+      expect(result).toContain('__tweakccSaveAgentColor');
     });
 
     it('should inject into default app state', () => {
-      const result = writeSessionColor(makeDefaultState());
+      const input = makeDefaultState() + makeSaveAgentColor();
+      const result = writeSessionColor(input);
       expect(result).not.toBeNull();
       expect(result).toContain('TWEAKCC_SESSION_COLOR');
     });
 
-    it('should patch both locations when both present', () => {
-      const result = writeSessionColor(makeBoth())!;
+    it('should patch both initialState locations', () => {
+      const result = writeSessionColor(makeFullFile())!;
       expect(result).not.toBeNull();
       const count = (result.match(/TWEAKCC_SESSION_COLOR/g) || []).length;
       expect(count).toBe(2);
     });
 
     it('should validate color against allowed list', () => {
-      const result = writeSessionColor(makeCLIState())!;
+      const result = writeSessionColor(makeFullFile())!;
       expect(result).toContain('.includes(__c)');
       expect(result).toContain('"green"');
       expect(result).toContain('"cyan"');
     });
 
     it('should be idempotent', () => {
-      const first = writeSessionColor(makeBoth())!;
+      const first = writeSessionColor(makeFullFile())!;
       const second = writeSessionColor(first)!;
       expect(second).toBe(first);
     });
@@ -50,6 +59,38 @@ describe('sessionColor', () => {
     it('should return null when no pattern found', () => {
       const result = writeSessionColor('not a valid file');
       expect(result).toBeNull();
+    });
+
+    it('should schedule color save via queueMicrotask', () => {
+      const result = writeSessionColor(makeFullFile())!;
+      expect(result).toContain('queueMicrotask');
+      expect(result).toContain('__tweakccSaveAgentColor');
+    });
+
+    it('should expose saveAgentColor on globalThis', () => {
+      const result = writeSessionColor(makeFullFile())!;
+      expect(result).toContain(
+        'globalThis.__tweakccSaveAgentColor=(c)=>Mr$(V$(),c)'
+      );
+    });
+  });
+
+  describe('patchSaveAgentColor', () => {
+    it('should find and patch saveAgentColor', () => {
+      const result = patchSaveAgentColor(makeSaveAgentColor());
+      expect(result).not.toBeNull();
+      expect(result).toContain('globalThis.__tweakccSaveAgentColor');
+    });
+
+    it('should return null when pattern not found', () => {
+      const result = patchSaveAgentColor('no match here');
+      expect(result).toBeNull();
+    });
+
+    it('should preserve original function', () => {
+      const result = patchSaveAgentColor(makeSaveAgentColor())!;
+      expect(result).toContain('async function Mr$');
+      expect(result).toContain('type:"agent-color"');
     });
   });
 });

--- a/src/patches/sessionColor.test.ts
+++ b/src/patches/sessionColor.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { writeSessionColor } from './sessionColor';
+
+const makeCLIState = () =>
+  'effortValue:oR(w.effort),' +
+  'activeOverlays:new Set,fastMode:cP8(N5),' +
+  '...(uF()&&d1&&{advisorModel:d1})';
+
+const makeDefaultState = () =>
+  'effortValue:void 0,' + 'activeOverlays:new Set,fastMode:!1}';
+
+const makeBoth = () =>
+  'first{' + makeDefaultState() + 'second{' + makeCLIState();
+
+describe('sessionColor', () => {
+  describe('writeSessionColor', () => {
+    it('should inject into CLI initialState', () => {
+      const result = writeSessionColor(makeCLIState());
+      expect(result).not.toBeNull();
+      expect(result).toContain('TWEAKCC_SESSION_COLOR');
+      expect(result).toContain('{name:"",color:__c}');
+    });
+
+    it('should inject into default app state', () => {
+      const result = writeSessionColor(makeDefaultState());
+      expect(result).not.toBeNull();
+      expect(result).toContain('TWEAKCC_SESSION_COLOR');
+    });
+
+    it('should patch both locations when both present', () => {
+      const result = writeSessionColor(makeBoth())!;
+      expect(result).not.toBeNull();
+      const count = (result.match(/TWEAKCC_SESSION_COLOR/g) || []).length;
+      expect(count).toBe(2);
+    });
+
+    it('should validate color against allowed list', () => {
+      const result = writeSessionColor(makeCLIState())!;
+      expect(result).toContain('.includes(__c)');
+      expect(result).toContain('"green"');
+      expect(result).toContain('"cyan"');
+    });
+
+    it('should be idempotent', () => {
+      const first = writeSessionColor(makeBoth())!;
+      const second = writeSessionColor(first)!;
+      expect(second).toBe(first);
+    });
+
+    it('should return null when no pattern found', () => {
+      const result = writeSessionColor('not a valid file');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/patches/sessionColor.ts
+++ b/src/patches/sessionColor.ts
@@ -54,7 +54,7 @@ export const writeSessionColor = (oldFile: string): string | null => {
     showDiff(
       prePatch,
       result,
-      replacement,
+      INJECTION,
       match.index,
       match.index + match[0].length
     );
@@ -95,10 +95,11 @@ export const patchSaveAgentColor = (oldFile: string): string | null => {
   const funcName = match[3];
   const getSessionIdName = match[7];
 
-  const replacement =
-    `${delimiter}globalThis.__tweakccSaveAgentColor=` +
-    `(c)=>${funcName}(${getSessionIdName}(),c);` +
-    funcBody;
+  const injection =
+    `globalThis.__tweakccSaveAgentColor=` +
+    `(c)=>${funcName}(${getSessionIdName}(),c);`;
+
+  const replacement = `${delimiter}${injection}${funcBody}`;
 
   const result =
     oldFile.slice(0, match.index) +
@@ -108,7 +109,7 @@ export const patchSaveAgentColor = (oldFile: string): string | null => {
   showDiff(
     oldFile,
     result,
-    replacement,
+    injection,
     match.index,
     match.index + match[0].length
   );

--- a/src/patches/sessionColor.ts
+++ b/src/patches/sessionColor.ts
@@ -1,0 +1,63 @@
+import { showDiff } from './index';
+import { debug } from '../utils';
+
+const VALID_COLORS = [
+  'red',
+  'blue',
+  'green',
+  'yellow',
+  'purple',
+  'orange',
+  'pink',
+  'cyan',
+];
+
+const INJECTION =
+  `,standaloneAgentContext:` +
+  `(()=>{` +
+  `let __c=process.env.TWEAKCC_SESSION_COLOR;` +
+  `return __c&&${JSON.stringify(VALID_COLORS)}.includes(__c)` +
+  `?{name:"",color:__c}` +
+  `:void 0` +
+  `})()`;
+
+export const writeSessionColor = (oldFile: string): string | null => {
+  if (oldFile.includes('TWEAKCC_SESSION_COLOR')) {
+    return oldFile;
+  }
+
+  const patterns = [
+    /,activeOverlays:new Set,fastMode:[$\w]+\([$\w]+\)/,
+    /,activeOverlays:new Set,fastMode:!1\}/,
+  ];
+
+  let result = oldFile;
+  let patched = false;
+
+  for (const pattern of patterns) {
+    const match = result.match(pattern);
+    if (!match || match.index === undefined) continue;
+
+    const replacement = INJECTION + match[0];
+    result =
+      result.slice(0, match.index) +
+      replacement +
+      result.slice(match.index + match[0].length);
+
+    showDiff(
+      oldFile,
+      result,
+      replacement,
+      match.index,
+      match.index + match[0].length
+    );
+    patched = true;
+  }
+
+  if (!patched) {
+    debug('patch: sessionColor: failed to find app state init patterns');
+    return null;
+  }
+
+  return result;
+};

--- a/src/patches/sessionColor.ts
+++ b/src/patches/sessionColor.ts
@@ -22,7 +22,11 @@ const INJECTION =
   `})()`;
 
 export const writeSessionColor = (oldFile: string): string | null => {
-  if (oldFile.includes('TWEAKCC_SESSION_COLOR')) {
+  if (
+    oldFile.includes(
+      'standaloneAgentContext:(()=>{let __c=process.env.TWEAKCC_SESSION_COLOR;'
+    )
+  ) {
     return oldFile;
   }
 

--- a/src/patches/sessionColor.ts
+++ b/src/patches/sessionColor.ts
@@ -42,14 +42,15 @@ export const writeSessionColor = (oldFile: string): string | null => {
     const match = result.match(pattern);
     if (!match || match.index === undefined) continue;
 
+    const prePatch = result;
     const replacement = INJECTION + match[0];
     result =
-      result.slice(0, match.index) +
+      prePatch.slice(0, match.index) +
       replacement +
-      result.slice(match.index + match[0].length);
+      prePatch.slice(match.index + match[0].length);
 
     showDiff(
-      oldFile,
+      prePatch,
       result,
       replacement,
       match.index,

--- a/src/patches/sessionColor.ts
+++ b/src/patches/sessionColor.ts
@@ -16,9 +16,11 @@ const INJECTION =
   `,standaloneAgentContext:` +
   `(()=>{` +
   `let __c=process.env.TWEAKCC_SESSION_COLOR;` +
-  `return __c&&${JSON.stringify(VALID_COLORS)}.includes(__c)` +
-  `?{name:"",color:__c}` +
-  `:void 0` +
+  `if(!__c||!${JSON.stringify(VALID_COLORS)}.includes(__c))return void 0;` +
+  `queueMicrotask(()=>{` +
+  `if(globalThis.__tweakccSaveAgentColor)globalThis.__tweakccSaveAgentColor(__c)` +
+  `});` +
+  `return{name:"",color:__c}` +
   `})()`;
 
 export const writeSessionColor = (oldFile: string): string | null => {
@@ -63,6 +65,53 @@ export const writeSessionColor = (oldFile: string): string | null => {
     debug('patch: sessionColor: failed to find app state init patterns');
     return null;
   }
+
+  const saveColorResult = patchSaveAgentColor(result);
+  if (!saveColorResult) {
+    debug('patch: sessionColor: failed to patch saveAgentColor');
+    return null;
+  }
+
+  return saveColorResult;
+};
+
+export const patchSaveAgentColor = (oldFile: string): string | null => {
+  const pattern = new RegExp(
+    '([,;{}])' +
+      '(async function ([$\\w]+)' +
+      '\\(([$\\w]+),([$\\w]+),([$\\w]+)\\)' +
+      '\\{let [$\\w]+=\\6\\?\\?[$\\w]+\\(\\4\\);' +
+      'if\\([$\\w]+\\([$\\w]+,' +
+      '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}\\),' +
+      '\\4===([$\\w]+)\\(\\)\\))'
+  );
+  const match = oldFile.match(pattern);
+  if (!match || match.index === undefined) {
+    return null;
+  }
+
+  const delimiter = match[1];
+  const funcBody = match[2];
+  const funcName = match[3];
+  const getSessionIdName = match[7];
+
+  const replacement =
+    `${delimiter}globalThis.__tweakccSaveAgentColor=` +
+    `(c)=>${funcName}(${getSessionIdName}(),c);` +
+    funcBody;
+
+  const result =
+    oldFile.slice(0, match.index) +
+    replacement +
+    oldFile.slice(match.index + match[0].length);
+
+  showDiff(
+    oldFile,
+    result,
+    replacement,
+    match.index,
+    match.index + match[0].length
+  );
 
   return result;
 };


### PR DESCRIPTION
## Summary

Add an always-applied patch that reads `TWEAKCC_SESSION_COLOR` env var at startup
and sets the session prompt bar color accordingly.

- Designed for wrapper scripts (e.g. `ccw`) that determine color based on the
  working directory before launching Claude Code
- Valid values: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`
- Invalid or unset values are silently ignored (no color applied)
- On session resume, Claude Code restores color from the session file, so the
  env var only affects new sessions

## How it works

Claude Code has two app state initialization sites — the CLI bootstrap (builds
`initialState` inline with dynamic values like `effortValue`, `fastMode`) and
the default state factory (used as fallback). Neither includes
`standaloneAgentContext`, so it defaults to `undefined`.

The patch injects a `standaloneAgentContext` IIFE into both sites that reads
`TWEAKCC_SESSION_COLOR`, validates it against the hardcoded allowed color list,
and returns `{name:"",color:value}` or `void 0`. This is the same state shape
that `/color` sets interactively.

## Test plan

- [x] Unit tests pass (6 tests: CLI state injection, default state injection,
  both locations, color validation, idempotency, pattern-not-found)
- [x] `pnpm lint` clean (tsc + eslint)
- [x] Manual test: `TWEAKCC_SESSION_COLOR=cyan ccw-test` shows cyan prompt bar
- [ ] Verify color persists after `/clear`
- [ ] Verify session resume restores color without env var

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session color can be set via an environment variable; values are validated against an allowlist and injected automatically into session initialization points when applicable. Changes are reported when applied.

* **Tests**
  * Added tests covering injection points, validation behavior, idempotency, multiple-insertion handling, scheduling of save behavior, and no-op/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->