### PR TITLE
fix: bypass keybinding customization gate for nonessential traffic mode

### DIFF
--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -77,6 +77,7 @@ import { writeVoiceMode } from './voiceMode';
 import { writeChannelsMode } from './channelsMode';
 import { writeClearScreen } from './clearScreen';
 import { writeSessionColor } from './sessionColor';
+import { writeKeybindingCustomization } from './keybindingCustomization';
 import {
   restoreNativeBinaryFromBackup,
   restoreClijsFromBackup,
@@ -190,6 +191,13 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.ALWAYS_APPLIED,
     description:
       'Set session prompt bar color via TWEAKCC_SESSION_COLOR env var',
+  },
+  {
+    id: 'keybinding-customization',
+    name: 'Keybinding customization',
+    group: PatchGroup.ALWAYS_APPLIED,
+    description:
+      'Force-enable custom keybindings when CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1',
   },
   // Misc Configurable
   {
@@ -699,6 +707,9 @@ export const applyCustomization = async (
     },
     'session-color': {
       fn: c => writeSessionColor(c),
+    },
+    'keybinding-customization': {
+      fn: c => writeKeybindingCustomization(c),
     },
     // Misc Configurable
     'patches-applied-indication': {

--- a/src/patches/keybindingCustomization.test.ts
+++ b/src/patches/keybindingCustomization.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { writeKeybindingCustomization } from './keybindingCustomization';
+
+describe('keybindingCustomization', () => {
+  it('bypasses the keybinding customization gate', () => {
+    const file =
+      'const x=1;' +
+      'function lE(){return u$("tengu_keybinding_customization_release",!1)}' +
+      'function DLK(H){let $=new Date()}';
+
+    const result = writeKeybindingCustomization(file);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'function lE(){return !0;return u$("tengu_keybinding_customization_release",!1)}'
+    );
+  });
+
+  it('returns unchanged file when already patched', () => {
+    const file =
+      'const x=1;' +
+      'function lE(){return !0;return u$("tengu_keybinding_customization_release",!1)}' +
+      'function DLK(H){let $=new Date()}';
+
+    const result = writeKeybindingCustomization(file);
+
+    expect(result).toBe(file);
+  });
+
+  it('returns null when the gate pattern is absent', () => {
+    expect(writeKeybindingCustomization('const x=1;')).toBeNull();
+  });
+});

--- a/src/patches/keybindingCustomization.ts
+++ b/src/patches/keybindingCustomization.ts
@@ -1,0 +1,36 @@
+import { showDiff } from './index';
+import { debug } from '../utils';
+
+export const writeKeybindingCustomization = (
+  oldFile: string
+): string | null => {
+  const alreadyPatched =
+    /function [$\w]+\(\)\{return !0;return [$\w]+\("tengu_keybinding_customization_release"/;
+
+  if (alreadyPatched.test(oldFile)) {
+    debug('patch: keybindingCustomization: already patched');
+    return oldFile;
+  }
+
+  const pattern =
+    /function [$\w]+\(\)\{return [$\w]+\("tengu_keybinding_customization_release"/;
+
+  const match = oldFile.match(pattern);
+
+  if (!match || match.index === undefined) {
+    debug(
+      'patch: keybindingCustomization: failed to find keybinding customization gate pattern'
+    );
+    return null;
+  }
+
+  const insertIndex = match.index + match[0].indexOf('{') + 1;
+  const insertion = 'return !0;';
+
+  const newFile =
+    oldFile.slice(0, insertIndex) + insertion + oldFile.slice(insertIndex);
+
+  showDiff(oldFile, newFile, insertion, insertIndex, insertIndex);
+
+  return newFile;
+};


### PR DESCRIPTION
## Summary

Custom keybindings from `~/.claude/keybindings.json` are silently ignored when `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`. The `tengu_keybinding_customization_release` feature flag defaults to `false` without GrowthBook, causing `isKeybindingCustomizationEnabled()` to block all user keybinding loading.

This patch force-enables the gate function (`return !0;` before the GrowthBook check), same technique as worktreeMode, voiceMode, and channelsMode patches.

## Changes

- `keybindingCustomization.ts` — patch implementation with idempotency check
- `keybindingCustomization.test.ts` — tests for success, already-patched, and pattern-not-found
- `index.ts` — register patch as `ALWAYS_APPLIED` (no config condition)

## Test plan

- [x] `pnpm test` — 224 tests pass
- [x] `pnpm lint` — no errors
- [x] Applied to CC 2.1.89 native binary — patch succeeds
- [x] Verified custom keybindings load with `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keybinding customization patch that forces custom keybindings to be enabled when a specific environment variable is set, and it runs through the standard patch flow.

* **Tests**
  * Added a dedicated test suite to verify behavior for already-patched files, unpatched files that match the expected pattern, and files that don’t match (ensuring a safe null result).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->