### PR TITLE
Add suppress-rate-limit-warning patch

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -699,6 +699,7 @@ export const DEFAULT_SETTINGS: Settings = {
     increaseFileReadLimit: false,
     suppressLineNumbers: false,
     suppressRateLimitOptions: false,
+    suppressRateLimitWarning: false,
     mcpConnectionNonBlocking: true,
     mcpServerBatchSize: null,
     statuslineThrottleMs: null,

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -58,6 +58,7 @@ import { writeHideStartupClawd } from './hideStartupClawd';
 import { writeIncreaseFileReadLimit } from './increaseFileReadLimit';
 import { writeSuppressLineNumbers } from './suppressLineNumbers';
 import { writeSuppressRateLimitOptions } from './suppressRateLimitOptions';
+import { writeSuppressRateLimitWarning } from './suppressRateLimitWarning';
 import { writeSessionMemory } from './sessionMemory';
 import { writeRememberSkill } from './rememberSkill';
 import { writeThinkingBlockStyling } from './thinkingBlockStyling';
@@ -325,6 +326,13 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.MISC_CONFIGURABLE,
     description:
       "/rate-limit-options won't be injected when limits are reached",
+  },
+  {
+    id: 'suppress-rate-limit-warning',
+    name: 'Suppress rate limit warning',
+    group: PatchGroup.MISC_CONFIGURABLE,
+    description:
+      'Rate limit warning banners will be suppressed (errors still shown)',
   },
   {
     id: 'token-count-rounding',
@@ -811,6 +819,10 @@ export const applyCustomization = async (
     'suppress-rate-limit-options': {
       fn: c => writeSuppressRateLimitOptions(c),
       condition: !!config.settings.misc?.suppressRateLimitOptions,
+    },
+    'suppress-rate-limit-warning': {
+      fn: c => writeSuppressRateLimitWarning(c),
+      condition: !!config.settings.misc?.suppressRateLimitWarning,
     },
     'token-count-rounding': {
       fn: c =>

--- a/src/patches/suppressRateLimitWarning.test.ts
+++ b/src/patches/suppressRateLimitWarning.test.ts
@@ -25,6 +25,16 @@ describe('writeSuppressRateLimitWarning', () => {
     expect(result).toBeNull();
   });
 
+  it('should preserve error-path message returns', () => {
+    const input =
+      'function Rp8(H,$){let q=d2K(H,$)}if(q&&q.severity==="error")return q.message;return null}' +
+      'function Ip8(H,$){let q=d2K(H,$)}if(q&&q.severity==="warning")return q.message;return null}';
+    const result = writeSuppressRateLimitWarning(input);
+    expect(result).not.toBeNull();
+    expect(result).toContain('severity==="error")return q.message;');
+    expect(result).toContain('severity==="warning")return null;');
+  });
+
   it('should work with different delimiters', () => {
     for (const d of [',', ';', '}', '{']) {
       const result = writeSuppressRateLimitWarning(makeInput(d));

--- a/src/patches/suppressRateLimitWarning.test.ts
+++ b/src/patches/suppressRateLimitWarning.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { writeSuppressRateLimitWarning } from './suppressRateLimitWarning';
+
+describe('writeSuppressRateLimitWarning', () => {
+  const makeInput = () =>
+    'function Ip8(H,$){let q=d2K(H,$);if(q&&q.severity==="warning")return q.message;return null}';
+
+  it('should replace warning message return with null', () => {
+    const input = makeInput();
+    const result = writeSuppressRateLimitWarning(input);
+    expect(result).not.toBeNull();
+    expect(result).toContain('.severity==="warning")return null;');
+    expect(result).not.toContain('return q.message');
+  });
+
+  it('should return unchanged file when already patched', () => {
+    const input = makeInput();
+    const patched = writeSuppressRateLimitWarning(input)!;
+    const result = writeSuppressRateLimitWarning(patched);
+    expect(result).toBe(patched);
+  });
+
+  it('should return null when pattern not found', () => {
+    const result = writeSuppressRateLimitWarning('no matching content here');
+    expect(result).toBeNull();
+  });
+});

--- a/src/patches/suppressRateLimitWarning.test.ts
+++ b/src/patches/suppressRateLimitWarning.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { writeSuppressRateLimitWarning } from './suppressRateLimitWarning';
 
 describe('writeSuppressRateLimitWarning', () => {
-  const makeInput = () =>
-    'function Ip8(H,$){let q=d2K(H,$);if(q&&q.severity==="warning")return q.message;return null}';
+  const makeInput = (delimiter = '}') =>
+    `function Ip8(H,$){let q=d2K(H,$)${delimiter}if(q&&q.severity==="warning")return q.message;return null}`;
 
   it('should replace warning message return with null', () => {
     const input = makeInput();
     const result = writeSuppressRateLimitWarning(input);
     expect(result).not.toBeNull();
-    expect(result).toContain('.severity==="warning")return null;');
+    expect(result).toContain('if(q&&q.severity==="warning")return null;');
     expect(result).not.toContain('return q.message');
   });
 
@@ -23,5 +23,13 @@ describe('writeSuppressRateLimitWarning', () => {
   it('should return null when pattern not found', () => {
     const result = writeSuppressRateLimitWarning('no matching content here');
     expect(result).toBeNull();
+  });
+
+  it('should work with different delimiters', () => {
+    for (const d of [',', ';', '}', '{']) {
+      const result = writeSuppressRateLimitWarning(makeInput(d));
+      expect(result).not.toBeNull();
+      expect(result).toContain('severity==="warning")return null;');
+    }
   });
 });

--- a/src/patches/suppressRateLimitWarning.ts
+++ b/src/patches/suppressRateLimitWarning.ts
@@ -1,0 +1,34 @@
+import { debug } from '../utils';
+import { showDiff } from './index';
+
+export const writeSuppressRateLimitWarning = (
+  oldFile: string
+): string | null => {
+  const alreadyPatched = /\.severity\s*===\s*"warning"\)\s*return null;/;
+  if (alreadyPatched.test(oldFile)) return oldFile;
+
+  const pattern = /\.severity\s*===\s*"warning"\)\s*return ([$\w]+)\.message;/;
+
+  const match = oldFile.match(pattern);
+
+  if (!match || match.index === undefined) {
+    debug(
+      'patch: suppressRateLimitWarning: failed to find rate limit warning getter pattern'
+    );
+    return null;
+  }
+
+  const original = match[0];
+  const replacement = original.replace(
+    /return ([$\w]+)\.message;/,
+    'return null;'
+  );
+  const startIndex = match.index;
+  const endIndex = startIndex + original.length;
+
+  const newFile =
+    oldFile.slice(0, startIndex) + replacement + oldFile.slice(endIndex);
+
+  showDiff(oldFile, newFile, replacement, startIndex, endIndex);
+  return newFile;
+};

--- a/src/patches/suppressRateLimitWarning.ts
+++ b/src/patches/suppressRateLimitWarning.ts
@@ -4,10 +4,12 @@ import { showDiff } from './index';
 export const writeSuppressRateLimitWarning = (
   oldFile: string
 ): string | null => {
-  const alreadyPatched = /\.severity\s*===\s*"warning"\)\s*return null;/;
+  const alreadyPatched =
+    /[,;{}]if\(([$\w]+)&&\1\.severity==="warning"\)return null;/;
   if (alreadyPatched.test(oldFile)) return oldFile;
 
-  const pattern = /\.severity\s*===\s*"warning"\)\s*return ([$\w]+)\.message;/;
+  const pattern =
+    /[,;{}]if\(([$\w]+)&&\1\.severity==="warning"\)return \1\.message;/;
 
   const match = oldFile.match(pattern);
 
@@ -18,11 +20,10 @@ export const writeSuppressRateLimitWarning = (
     return null;
   }
 
+  const varName = match[1];
   const original = match[0];
-  const replacement = original.replace(
-    /return ([$\w]+)\.message;/,
-    'return null;'
-  );
+  const delimiter = original[0];
+  const replacement = `${delimiter}if(${varName}&&${varName}.severity==="warning")return null;`;
   const startIndex = match.index;
   const endIndex = startIndex + original.length;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,7 @@ export interface MiscConfig {
   increaseFileReadLimit: boolean;
   suppressLineNumbers: boolean;
   suppressRateLimitOptions: boolean;
+  suppressRateLimitWarning: boolean;
   mcpConnectionNonBlocking: boolean;
   mcpServerBatchSize: number | null;
   statuslineThrottleMs: number | null;

--- a/src/ui/components/MiscView.tsx
+++ b/src/ui/components/MiscView.tsx
@@ -65,6 +65,7 @@ export function MiscView({ onSubmit }: MiscViewProps) {
     increaseFileReadLimit: false,
     suppressLineNumbers: false,
     suppressRateLimitOptions: false,
+    suppressRateLimitWarning: false,
     mcpConnectionNonBlocking: true,
     mcpServerBatchSize: null as number | null,
     statuslineThrottleMs: null as number | null,
@@ -321,6 +322,20 @@ export function MiscView({ onSubmit }: MiscViewProps) {
             ensureMisc();
             settings.misc!.suppressRateLimitOptions =
               !settings.misc!.suppressRateLimitOptions;
+          });
+        },
+      },
+      {
+        id: 'suppressRateLimitWarning',
+        title: 'Suppress rate limit warning banners',
+        description:
+          'Hides rate limit warning banners in the status bar. Error messages when limits are actually reached are still shown.',
+        getValue: () => settings.misc?.suppressRateLimitWarning ?? false,
+        toggle: () => {
+          updateSettings(settings => {
+            ensureMisc();
+            settings.misc!.suppressRateLimitWarning =
+              !settings.misc!.suppressRateLimitWarning;
           });
         },
       },


### PR DESCRIPTION
## Summary

- Adds a new `suppress-rate-limit-warning` patch that suppresses rate limit warning banners while preserving error messages when limits are actually reached
- Patches the warning getter function by replacing `return <var>.message` with `return null` for `severity === "warning"` case
- Configurable via `misc.suppressRateLimitWarning` setting (default: `false`)

## Details

Claude Code shows warning banners when approaching rate limits (`allowed_warning` status). This patch suppresses those warnings while keeping error-level messages (actual rate limit hits) intact.

The patch targets the function that extracts warning messages from rate limit status objects — a small, stable pattern (`severity === "warning"`) with a single match in the codebase.

## Files

| File | Change |
|------|--------|
| `suppressRateLimitWarning.ts` | Patch implementation |
| `suppressRateLimitWarning.test.ts` | Tests: success, already patched, pattern not found |
| `index.ts` | Import, PATCH_DEFINITIONS entry, implementation |
| `types.ts` | `suppressRateLimitWarning: boolean` in MiscConfig |
| `defaultSettings.ts` | Default: `false` |
| `MiscView.tsx` | UI toggle in settings |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Settings toggle: **“Suppress rate limit warning banners”** (off by default).

* **Behavior**
  * When enabled, the rate limit warning banner is suppressed.

* **Tests**
  * Added automated coverage for the banner suppression behavior, including idempotency and robustness across input variations, plus failure-path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->