### PR TITLE
Preserve system prompt backslashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Preserve literal backslashes when applying system prompts to JavaScript string literals (#664) - @mike1858
 - Escape non-ASCII thinker symbols as `\uXXXX` to fix custom spinner mojibake on native binary installs (#853) - @StreamDemon
 - Fix model-customizations patch for Claude Code 2.1.199 (custom-model push anchor no longer requires a leading space) (#854) - @StreamDemon
 - Fix input-chevron-color patch for Claude Code 2.1.199 (chevron component gained an `isScreenReader` field and a third guard term) (#855) - @StreamDemon

--- a/src/patches/systemPrompts.test.ts
+++ b/src/patches/systemPrompts.test.ts
@@ -197,7 +197,7 @@ describe('systemPrompts.ts', () => {
       expect(result.newContent).toBe('msg:"Say \\"Hello\\""');
     });
 
-    it('should not double-escape already-escaped double quotes', async () => {
+    it('should escape backslashes before quotes to preserve literal backslash-quotes (#660)', async () => {
       const mockPromptData = buildMockPromptData({
         content: 'Say \\"Hello\\"',
         regex: 'Say \\\\"Hello\\\\"',
@@ -211,7 +211,7 @@ describe('systemPrompts.ts', () => {
 
       const result = await applySystemPrompts(cliContent, '1.0.0', false);
 
-      expect(result.newContent).toBe('msg:"Say \\"Hello\\""');
+      expect(result.newContent).toBe('msg:"Say \\\\\\"Hello\\\\\\""');
     });
 
     it('should auto-escape backticks in template literal context', async () => {
@@ -273,7 +273,7 @@ describe('systemPrompts.ts', () => {
       );
     });
 
-    it('should not double-escape already-escaped backticks', async () => {
+    it('should escape backslashes before backticks to preserve literal backslash-backticks (#660)', async () => {
       const mockPromptData = buildMockPromptData({
         content: 'Use \\`foo\\` for config',
         regex: 'Use \\\\`foo\\\\` for config',
@@ -287,7 +287,7 @@ describe('systemPrompts.ts', () => {
 
       const result = await applySystemPrompts(cliContent, '1.0.0', false);
 
-      expect(result.newContent).toBe('desc:`Use \\`foo\\` for config`');
+      expect(result.newContent).toBe('desc:`Use \\\\\\`foo\\\\\\` for config`');
     });
 
     it('should auto-escape backticks adjacent to template expressions', async () => {
@@ -307,7 +307,7 @@ describe('systemPrompts.ts', () => {
       expect(result.newContent).toBe('desc:`Value: \\`${x}\\``');
     });
 
-    it('should auto-escape only unescaped backticks when mixed with escaped ones', async () => {
+    it('should escape backslashes in already-escaped backticks and also escape bare backticks (#660)', async () => {
       const mockPromptData = buildMockPromptData({
         content: 'Use \\`foo\\` and `bar` for config',
         regex: 'Use \\\\`foo\\\\` and `bar` for config',
@@ -322,7 +322,7 @@ describe('systemPrompts.ts', () => {
       const result = await applySystemPrompts(cliContent, '1.0.0', false);
 
       expect(result.newContent).toBe(
-        'desc:`Use \\`foo\\` and \\`bar\\` for config`'
+        'desc:`Use \\\\\\`foo\\\\\\` and \\`bar\\` for config`'
       );
     });
 
@@ -406,7 +406,7 @@ describe('systemPrompts.ts', () => {
       expect(result.newContent).toBe("msg:'It\\'s working'");
     });
 
-    it('should not double-escape already-escaped single quotes', async () => {
+    it('should escape backslashes before single quotes to preserve literal backslash-quotes (#660)', async () => {
       const mockPromptData = buildMockPromptData({
         content: "It\\'s working",
         regex: "It\\\\'s working",
@@ -420,7 +420,7 @@ describe('systemPrompts.ts', () => {
 
       const result = await applySystemPrompts(cliContent, '1.0.0', false);
 
-      expect(result.newContent).toBe("msg:'It\\'s working'");
+      expect(result.newContent).toBe("msg:'It\\\\\\'s working'");
     });
 
     it('should set applied:true when auto-escape changes content even if char delta is 0', async () => {

--- a/src/patches/systemPrompts.test.ts
+++ b/src/patches/systemPrompts.test.ts
@@ -307,6 +307,30 @@ describe('systemPrompts.ts', () => {
       expect(result.newContent).toBe('desc:`Value: \\`${x}\\``');
     });
 
+    it('should preserve escaped interpolation markers in template literal context', async () => {
+      const mockPromptData = buildMockPromptData({
+        content: 'Use \\${name} literally',
+        regex: 'Use \\\\\\$\\{name\\} literally',
+        getInterpolatedContent: () => 'Use \\${name} literally',
+        pieces: ['Use \\${name} literally'],
+      });
+
+      setupMocks(mockPromptData);
+
+      const cliContent = 'desc:`Use \\${name} literally`';
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe('desc:`Use \\\\\\${name} literally`');
+      expect(
+        new Function(
+          'const name = "expanded"; return { ' + result.newContent + ' };'
+        )()
+      ).toEqual({
+        desc: 'Use \\${name} literally',
+      });
+    });
+
     it('should escape backslashes in already-escaped backticks and also escape bare backticks (#660)', async () => {
       const mockPromptData = buildMockPromptData({
         content: 'Use \\`foo\\` and `bar` for config',

--- a/src/patches/systemPrompts.ts
+++ b/src/patches/systemPrompts.ts
@@ -172,11 +172,15 @@ export const applySystemPrompts = async (
 
       let replacementContent = interpolatedContent;
 
-      // Escape literal backslashes FIRST so they survive JS string
-      // embedding. Without this, a markdown `\"user\"` ends up as `"user"`
-      // because the backslash is consumed as an escape character. (#660)
       if (delimiter === '"' || delimiter === "'" || delimiter === '`') {
         replacementContent = replacementContent.replace(/\\/g, '\\\\');
+      }
+
+      if (delimiter === '`') {
+        replacementContent = replacementContent.replace(
+          /\\\\\$\{/g,
+          '\\\\\\${'
+        );
       }
 
       if (delimiter === '"') {

--- a/src/patches/systemPrompts.ts
+++ b/src/patches/systemPrompts.ts
@@ -172,6 +172,13 @@ export const applySystemPrompts = async (
 
       let replacementContent = interpolatedContent;
 
+      // Escape literal backslashes FIRST so they survive JS string
+      // embedding. Without this, a markdown `\"user\"` ends up as `"user"`
+      // because the backslash is consumed as an escape character. (#660)
+      if (delimiter === '"' || delimiter === "'" || delimiter === '`') {
+        replacementContent = replacementContent.replace(/\\/g, '\\\\');
+      }
+
       if (delimiter === '"') {
         replacementContent = replacementContent.replace(/\n/g, '\\n');
         replacementContent = escapeUnescapedChar(replacementContent, '"');
@@ -180,7 +187,7 @@ export const applySystemPrompts = async (
         replacementContent = escapeUnescapedChar(replacementContent, "'");
       } else if (delimiter === '`') {
         const { content: escaped, incomplete } =
-          escapeDepthZeroBackticks(interpolatedContent);
+          escapeDepthZeroBackticks(replacementContent);
         if (incomplete) {
           console.log(
             chalk.red(
@@ -196,7 +203,7 @@ export const applySystemPrompts = async (
           });
           continue;
         }
-        if (escaped !== interpolatedContent) {
+        if (escaped !== replacementContent) {
           console.log(
             chalk.yellow(`Auto-escaped unescaped backticks in "${prompt.name}"`)
           );


### PR DESCRIPTION
## Why

System prompt application rewrites prompt markdown into JavaScript string literals in Claude Code's bundled `cli.js`. Prompt text can intentionally contain literal backslash-quote sequences such as `\'`, `\"`, or ``\` ``. Those backslashes need to survive the JavaScript embedding step; otherwise the generated bundle consumes them as escape syntax and the resulting prompt text no longer matches the markdown source.

Issue #660 reported this concretely for prompts that contain literal `\'` text. The same escaping rule applies to double-quoted strings, single-quoted strings, and template literals.

Closes #660.

## What changed

- Escapes literal backslashes before applying quote/newline/template-literal escaping in `applySystemPrompts`.
- Runs template-literal backtick escaping on the backslash-preserving replacement content so literal ``\` `` sequences survive as text.
- Preserves escaped template interpolation markers such as `\${name}` so they remain literal text after the backslash-doubling pass instead of becoming live `${...}` interpolation.
- Updates system prompt tests for double-quoted, single-quoted, and template-literal backslash cases, including a runtime assertion that the generated template-literal snippet evaluates to literal `\${name}` text.
- Adds the required changelog entry for the system prompt backslash preservation fix.

## Validation

- `pnpm --dir ../tweakcc-pr-664 exec vitest run src/patches/systemPrompts.test.ts` - 24 tests passed.
- `pnpm --dir ../tweakcc-pr-664 lint` - passed (`tsc --noEmit` and `eslint src`).
- `pnpm --dir ../tweakcc-pr-664 exec prettier --check CHANGELOG.md src/patches/systemPrompts.ts src/patches/systemPrompts.test.ts` - passed.
- Pre-commit hook during `git commit` ran `pnpm lint` and `pnpm test`; the full test suite reported 39 test files passed, 370 tests passed, and 5 skipped.

## Review notes

This is a non-visual CLI/library behavior fix, so visual proof is not applicable. I reviewed the escaping path and surrounding tests directly, including the interaction between backslash preservation and template-literal interpolation parsing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of system prompts in JavaScript strings so existing escape sequences stay literal.
  * Fixed cases where backslashes before quotes, backticks, and single quotes were being altered incorrectly.
  * Preserved escaped template interpolation markers like `\${...}` in generated output.
  * Updated the changelog to note the escaping fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->