### PR TITLE
fix(themes): handle CC >=2.1.92 assembly format (fixes objArrMatch + obj prefix bugs)

### DIFF
--- a/src/patches/themes.ts
+++ b/src/patches/themes.ts
@@ -9,6 +9,19 @@ type ThemesLocation = {
   obj: LocationResult & { prefix: string };
 };
 
+/**
+ * Locates the three theme-related code sections in the CC bundle that need to
+ * be rewritten: the switch statement (colors per theme), the options array
+ * (dropdown items), and the name-mapping object (theme ID → display name).
+ *
+ * Handles two assembly formats:
+ * - CC <2.1.92: options array is a single inline `[{label,value},...]` literal.
+ * - CC >=2.1.92: "auto" option is its own variable; remaining built-ins are
+ *   spread in an assembly expression `[...autoVar,t1,t2,...,...custom.map()]`.
+ *
+ * @param oldFile - The CC bundle source as a string
+ * @returns Locations of the three sections, or null if any section is not found
+ */
 function getThemesLocation(oldFile: string): ThemesLocation | null {
   // === Switch Statement ===
   // CC >=2.1.83: switch(A){case"light":return LX9;...default:return CX9}
@@ -155,6 +168,17 @@ function getThemesLocation(oldFile: string): ThemesLocation | null {
   };
 }
 
+/**
+ * Rewrites the theme-related sections of the CC bundle to inject custom themes.
+ *
+ * Replaces the switch statement, options dropdown array, and name-mapping object
+ * so that all provided themes (including built-ins like dark/light) are available
+ * via `/theme`. Processes in reverse index order to avoid offset shifts.
+ *
+ * @param oldFile - The CC bundle source as a string
+ * @param themes  - Full list of themes to inject (built-ins + custom)
+ * @returns The modified bundle, or null if any required section was not found
+ */
 export const writeThemes = (
   oldFile: string,
   themes: Theme[]

--- a/src/patches/themes.ts
+++ b/src/patches/themes.ts
@@ -89,7 +89,9 @@ function getThemesLocation(oldFile: string): ThemesLocation | null {
     startIndex: objArrMatch.index,
     endIndex: objArrMatch.index + objArrMatch[0].length,
   };
-  const objArrItemCount = (objArrMatch[0].match(/"?value"?:/g) || []).length;
+  // Count items by object-opening label key to avoid false positives from
+  // label text that happens to contain the substring "value:".
+  const objArrItemCount = (objArrMatch[0].match(/\{"?label"?:/g) || []).length;
   if (objArrItemCount === 1) {
     // Find the variable name holding this single-item array (e.g. "HH")
     const beforeObjArr = oldFile.slice(
@@ -97,30 +99,37 @@ function getThemesLocation(oldFile: string): ThemesLocation | null {
       objArrMatch.index
     );
     const varNameMatch = beforeObjArr.match(/([A-Za-z_$][\w$]*)=$/);
-    if (varNameMatch) {
-      const autoVarName = varNameMatch[1].replace(/[$]/g, '\\$');
-      // Find assembly: [...autoVar, theme1, theme2, ..., ...customThemes.map(
-      const assemblyPat = new RegExp(
-        `\\[\\.\\.\\.${autoVarName}(?:,[A-Za-z_$][\\w$]*){2,},\\.\\.\\.`
-      );
-      const assemblyMatch = oldFile.match(assemblyPat);
-      if (assemblyMatch && assemblyMatch.index != undefined) {
-        // assemblyMatch[0] ends with ",..." — endIndex is right before "..."
-        // Replacement "[{theme},..." joins cleanly with remaining "...X.map(kB1),...FH]"
-        objArrLocation = {
-          startIndex: assemblyMatch.index,
-          endIndex: assemblyMatch.index + assemblyMatch[0].length - 3,
-          isAssemblyPrefix: true,
-        };
-      }
+    if (!varNameMatch) {
+      console.error('patch: themes: failed to find auto-option variable name');
+      return null;
     }
+    const autoVarName = varNameMatch[1].replace(/[$]/g, '\\$');
+    // Find assembly: [...autoVar, theme1, theme2, ..., ...customThemes.map(
+    const assemblyPat = new RegExp(
+      `\\[\\.\\.\\.${autoVarName}(?:,[A-Za-z_$][\\w$]*){2,},\\.\\.\\.`
+    );
+    const assemblyMatch = oldFile.match(assemblyPat);
+    if (!assemblyMatch || assemblyMatch.index == undefined) {
+      console.error(
+        `patch: themes: failed to find assembly spread for variable "${varNameMatch[1]}"`,
+      );
+      return null;
+    }
+    // assemblyMatch[0] ends with ",..." — endIndex is right before "..."
+    // Replacement "[{theme},..." joins cleanly with remaining "...X.map(kB1),...FH]"
+    objArrLocation = {
+      startIndex: assemblyMatch.index,
+      endIndex: assemblyMatch.index + assemblyMatch[0].length - 3,
+      isAssemblyPrefix: true,
+    };
   }
 
   // === Theme Name Mapping Object ===
   // Old: return{dark:"Dark mode",...}
   // New (CC >=2.1.92): VAR={auto:"Auto...",dark:"Dark mode",...}
+  // Capture group 1 holds the prefix so we can preserve it in the replacement.
   const objPat =
-    /(?:return|[$\w]+=)\{(?:"?(?:[$\w-]+)"?:"(?:Auto |Dark|Light|Monochrome)[^"]*",?)+\}/;
+    /(return|[$\w]+=)\{(?:"?(?:[$\w-]+)"?:"(?:Auto |Dark|Light|Monochrome)[^"]*",?)+\}/;
   const objMatch = oldFile.match(objPat);
 
   if (!objMatch || objMatch.index == undefined) {
@@ -129,7 +138,7 @@ function getThemesLocation(oldFile: string): ThemesLocation | null {
   }
 
   // Preserve the original prefix (either "return" or "VARNAME=")
-  const objPrefix = objMatch[0].slice(0, objMatch[0].indexOf('{'));
+  const objPrefix = objMatch[1];
 
   return {
     switchStatement: {

--- a/src/patches/themes.ts
+++ b/src/patches/themes.ts
@@ -111,7 +111,7 @@ function getThemesLocation(oldFile: string): ThemesLocation | null {
     const assemblyMatch = oldFile.match(assemblyPat);
     if (!assemblyMatch || assemblyMatch.index == undefined) {
       console.error(
-        `patch: themes: failed to find assembly spread for variable "${varNameMatch[1]}"`,
+        `patch: themes: failed to find assembly spread for variable "${varNameMatch[1]}"`
       );
       return null;
     }

--- a/src/patches/themes.ts
+++ b/src/patches/themes.ts
@@ -106,7 +106,7 @@ function getThemesLocation(oldFile: string): ThemesLocation | null {
     const autoVarName = varNameMatch[1].replace(/[$]/g, '\\$');
     // Find assembly: [...autoVar, theme1, theme2, ..., ...customThemes.map(
     const assemblyPat = new RegExp(
-      `\\[\\.\\.\\.${autoVarName}(?:,[A-Za-z_$][\\w$]*){2,},\\.\\.\\.`
+      `\\[\\.\\.\\.${autoVarName}(?:,[A-Za-z_$][\\w$]*){1,},\\.\\.\\.`
     );
     const assemblyMatch = oldFile.match(assemblyPat);
     if (!assemblyMatch || assemblyMatch.index == undefined) {

--- a/src/patches/themes.ts
+++ b/src/patches/themes.ts
@@ -3,11 +3,13 @@
 import { Theme } from '../types';
 import { LocationResult, showDiff } from './index';
 
-function getThemesLocation(oldFile: string): {
+type ThemesLocation = {
   switchStatement: LocationResult;
-  objArr: LocationResult;
-  obj: LocationResult;
-} | null {
+  objArr: LocationResult & { isAssemblyPrefix?: boolean };
+  obj: LocationResult & { prefix: string };
+};
+
+function getThemesLocation(oldFile: string): ThemesLocation | null {
   // === Switch Statement ===
   // CC >=2.1.83: switch(A){case"light":return LX9;...default:return CX9}
   // CC <2.1.83: switch(A){case"light":return{...};...}
@@ -70,7 +72,9 @@ function getThemesLocation(oldFile: string): {
   }
 
   // === Theme Options Array ===
-  // Both old and new: [{label:"...",value:"..."}, ...] or [{"label":"...",...]
+  // Old format: [{label:"Dark mode",value:"dark"},{label:"Light mode",value:"light"},...]
+  // New format (CC >=2.1.92): HH=[{label:"Auto (match terminal)",value:"auto"}] only,
+  //   with individual vars DH,YH,... spread in assembly: e=[...HH,DH,YH,...,...X.map(kB1),...FH]
   const objArrPat =
     /\[(?:\.\.\.\[\],)?(?:\{"?label"?:"(?:Dark|Light|Auto|Monochrome)[^"]*","?value"?:"[^"]+"\},?)+\]/;
   const objArrMatch = oldFile.match(objArrPat);
@@ -80,8 +84,41 @@ function getThemesLocation(oldFile: string): {
     return null;
   }
 
+  // Check if new assembly format: objArr has only 1 item (just "auto" option)
+  let objArrLocation: LocationResult & { isAssemblyPrefix?: boolean } = {
+    startIndex: objArrMatch.index,
+    endIndex: objArrMatch.index + objArrMatch[0].length,
+  };
+  const objArrItemCount = (objArrMatch[0].match(/"?value"?:/g) || []).length;
+  if (objArrItemCount === 1) {
+    // Find the variable name holding this single-item array (e.g. "HH")
+    const beforeObjArr = oldFile.slice(
+      Math.max(0, objArrMatch.index - 30),
+      objArrMatch.index
+    );
+    const varNameMatch = beforeObjArr.match(/([A-Za-z_$][\w$]*)=$/);
+    if (varNameMatch) {
+      const autoVarName = varNameMatch[1].replace(/[$]/g, '\\$');
+      // Find assembly: [...autoVar, theme1, theme2, ..., ...customThemes.map(
+      const assemblyPat = new RegExp(
+        `\\[\\.\\.\\.${autoVarName}(?:,[A-Za-z_$][\\w$]*){2,},\\.\\.\\.`
+      );
+      const assemblyMatch = oldFile.match(assemblyPat);
+      if (assemblyMatch && assemblyMatch.index != undefined) {
+        // assemblyMatch[0] ends with ",..." — endIndex is right before "..."
+        // Replacement "[{theme},..." joins cleanly with remaining "...X.map(kB1),...FH]"
+        objArrLocation = {
+          startIndex: assemblyMatch.index,
+          endIndex: assemblyMatch.index + assemblyMatch[0].length - 3,
+          isAssemblyPrefix: true,
+        };
+      }
+    }
+  }
+
   // === Theme Name Mapping Object ===
-  // {dark:"Dark mode",...} or {"dark":"Dark mode",...}
+  // Old: return{dark:"Dark mode",...}
+  // New (CC >=2.1.92): VAR={auto:"Auto...",dark:"Dark mode",...}
   const objPat =
     /(?:return|[$\w]+=)\{(?:"?(?:[$\w-]+)"?:"(?:Auto |Dark|Light|Monochrome)[^"]*",?)+\}/;
   const objMatch = oldFile.match(objPat);
@@ -91,19 +128,20 @@ function getThemesLocation(oldFile: string): {
     return null;
   }
 
+  // Preserve the original prefix (either "return" or "VARNAME=")
+  const objPrefix = objMatch[0].slice(0, objMatch[0].indexOf('{'));
+
   return {
     switchStatement: {
       startIndex: switchStart,
       endIndex: switchEnd,
       identifiers: [switchIdent],
     },
-    objArr: {
-      startIndex: objArrMatch.index,
-      endIndex: objArrMatch.index + objArrMatch[0].length,
-    },
+    objArr: objArrLocation,
     obj: {
       startIndex: objMatch.index,
       endIndex: objMatch.index + objMatch[0].length,
+      prefix: objPrefix,
     },
   };
 }
@@ -126,8 +164,10 @@ export const writeThemes = (
   // Process in reverse order to avoid index shifting
 
   // Update theme mapping object (obj)
+  // Preserve the original prefix ("return" or "VARNAME=") to avoid turning a
+  // module-level variable assignment into an invalid return statement.
   const obj =
-    'return' +
+    locations.obj.prefix +
     JSON.stringify(
       Object.fromEntries(themes.map(theme => [theme.id, theme.name]))
     );
@@ -145,9 +185,16 @@ export const writeThemes = (
   oldFile = newFile;
 
   // Update theme options array (objArr)
-  const objArr = JSON.stringify(
+  // In new assembly format (CC >=2.1.92), objArr points to the prefix of the
+  // spread expression "[...auto,theme1,...,themeN," (endIndex is just before
+  // the custom-themes spread "...U.map(...)").  We emit an open array without
+  // the closing "]" so the existing suffix "...U.map(kB1),...FH]" completes it.
+  const themeItems = JSON.stringify(
     themes.map(theme => ({ label: theme.name, value: theme.id }))
   );
+  const objArr = locations.objArr.isAssemblyPrefix
+    ? themeItems.slice(0, -1) + ',' // "[{...},"  — no closing ], suffix provides it
+    : themeItems;
   newFile =
     newFile.slice(0, locations.objArr.startIndex) +
     objArr +


### PR DESCRIPTION
## Problem

Fixes #665.

The themes patch fails on Claude Code >=2.1.92 with two bugs. PR #671 fixes Bug 2 but not Bug 1.

---

**Bug 1 — objArr only patches the auto-option variable (not fixed by #671)**

In CC >=2.1.92, theme options are no longer a single flat array. Only the \"auto\" option lives in one variable (e.g. `HH=[{label:\"Auto (match terminal)\",value:\"auto\"}]`). The remaining built-in themes are individual variables spread in a React-memo cache guard:

```js
e=[...HH,DH,YH,PH,t,o,_H,...U.map(kB1),...FH]
```

The old code replaced only `HH`, so `DH,YH,…` stayed in the spread — resulting in tweakcc themes *plus* all built-in themes showing in the selector.

**Bug 2 — obj replacement emits `return{…}` at module level (also fixed by #671)**

The old code always prefixed the name-mapping object with `return`. In the new format the mapping is a module-level variable assignment (`eB1={auto:\"Auto…\",dark:\"Dark mode\",…}`), so replacing it with `return{…}` produces a syntax error.

---

## Fix

`src/patches/themes.ts` only:

1. **Assembly-prefix detection (Bug 1)**: when `objArr` has exactly 1 item (just \"auto\"), look for the assembly expression `[...autoVar,t1,t2,…,...X.map(`. Set `objArr` startIndex/endIndex to span only the prefix `[...HH,DH,…,_H,` (everything before the custom-themes spread). `writeThemes` emits the tweakcc theme array without the closing `]` so the existing suffix `...U.map(kB1),...FH]` completes the expression — CC's own custom-theme and new-theme-creation entries are preserved.

2. **Prefix extraction (Bug 2)**: extract the original prefix of the obj match (`return` or `VARNAME=`) and use it in the replacement instead of always hard-coding `return`. (Same approach as #671.)

## Testing

- Reproduced both bugs against the v2.1.119 binary (via `native-claudejs-orig.js`).
- Verified the patched output: `eB1={"winter":"Winter"}` (correct assignment), `[{"label":"Winter","value":"winter"},...U.map(kB1),...FH]` (correct array, built-in themes removed, CC custom themes preserved).
- All 221 existing tests pass (`npx vitest run`).
- TypeScript type-checks clean (`tsc --noEmit`).
- Old format (single flat array) still works — the assembly-prefix path is only taken when exactly 1 item is found in `objArr`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme detection to handle newer encoding formats and single-item "auto" assemblies for more reliable theme updates.
  * Preserved original assignment/return prefixes to avoid generating invalid syntax when inserting theme mappings.
  * Safer emission of options arrays: emits either a full array or an open fragment so replacements integrate cleanly with surrounding generated output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->