### PR TITLE
Windows: look for `~/.local/bin/claude.exe`, skip `maybeResolveNixWrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Fix Linux native installation support (#644) - @signadou
+- Windows: look for `~/.local/bin/claude.exe`, skip `maybeResolveNixWrapper` (#721) - @bl-ue
 
 ## [v4.0.11](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.0.11) - 2026-03-05
 

--- a/src/installationDetection.ts
+++ b/src/installationDetection.ts
@@ -224,6 +224,12 @@ async function readFilePrefix(
  * operations (backup, extract, repack) operate on the right file.
  */
 async function maybeResolveNixWrapper(binaryPath: string): Promise<string> {
+  // Nix `makeBinaryWrapper` produces ELF/Mach-O wrappers; on Windows the
+  // concept doesn't apply, and lief throws "Failed to parse binary file" on
+  // PE binaries. Short-circuit to avoid the noise and the wasted work.
+  if (process.platform === 'win32') {
+    return binaryPath;
+  }
   const resolved = await resolveNixBinaryWrapper(binaryPath);
   if (resolved) {
     debug(
@@ -310,6 +316,8 @@ export async function resolvePathToInstallationType(
  * Cross-platform: works on Windows, macOS, and Linux.
  */
 async function getClaudeFromPath(): Promise<string | null> {
+  debug(`getClaudeFromPath: PATH = ${process.env.PATH}`);
+  debug(`getClaudeFromPath: PATHEXT = ${process.env.PATHEXT}`);
   try {
     const claudePath = await which('claude');
     debug(`getClaudeFromPath: Found claude at ${claudePath}`);
@@ -671,7 +679,8 @@ export async function findClaudeCodeInstallation(
     const resolved = await resolvePathToInstallationType(pathClaudeExe);
     if (!resolved) {
       debug(
-        `Unable to detect installation type from 'claude' on PATH (${pathClaudeExe}). ` +
+        `Found 'claude' on PATH at '${pathClaudeExe}', but it isn't a Claude Code cli.js or native binary ` +
+          `(likely a CMD/BAT shim from a Node version manager such as Volta or nvm-windows). ` +
           `Falling back to hardcoded search paths.`
       );
     } else {

--- a/src/installationPaths.ts
+++ b/src/installationPaths.ts
@@ -247,6 +247,9 @@ const getNativeSearchPathsWithInfo = (): SearchPathInfo[] => {
 
   // Direct binary path
   addPath(`${home}/.local/bin/claude`);
+  if (process.platform === 'win32') {
+    addPath(`${home}/.local/bin/claude.exe`);
+  }
 
   // Versioned binaries (filenames are versions like 2.0.65)
   addPath(`${home}/.local/share/claude/versions/*`, true);

--- a/src/tests/searchPaths.test.ts
+++ b/src/tests/searchPaths.test.ts
@@ -330,3 +330,66 @@ describe('getClijsSearchPathsWithInfo - glob error handling', () => {
     expect(globPattern?.expandedPaths).toEqual(expectedPaths);
   });
 });
+
+describe('getNativeSearchPathsWithInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    // Default: globbySync returns empty so we don't depend on the real fs
+    vi.mocked(globbySync).mockImplementation(() => []);
+  });
+
+  it('should include the bare ~/.local/bin/claude path', async () => {
+    const { NATIVE_SEARCH_PATH_INFO } = await import('../installationPaths');
+
+    const sep = process.platform === 'win32' ? '\\' : '/';
+    const expectedTail = `${sep}.local${sep}bin${sep}claude`;
+
+    const match = NATIVE_SEARCH_PATH_INFO.find(
+      info => !info.isGlob && info.pattern.endsWith(expectedTail)
+    );
+
+    expect(match).toBeDefined();
+  });
+
+  it.skipIf(process.platform !== 'win32')(
+    'should include ~/.local/bin/claude.exe on Windows',
+    async () => {
+      const { NATIVE_SEARCH_PATH_INFO } = await import('../installationPaths');
+
+      const expectedTail = '\\.local\\bin\\claude.exe';
+
+      const match = NATIVE_SEARCH_PATH_INFO.find(
+        info => !info.isGlob && info.pattern.endsWith(expectedTail)
+      );
+
+      expect(match).toBeDefined();
+    }
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'should not include claude.exe on non-Windows platforms',
+    async () => {
+      const { NATIVE_SEARCH_PATH_INFO } = await import('../installationPaths');
+
+      const match = NATIVE_SEARCH_PATH_INFO.find(
+        info => !info.isGlob && info.pattern.endsWith('claude.exe')
+      );
+
+      expect(match).toBeUndefined();
+    }
+  );
+
+  it('should include the versions directory glob', async () => {
+    const { NATIVE_SEARCH_PATH_INFO } = await import('../installationPaths');
+
+    const sep = process.platform === 'win32' ? '\\' : '/';
+    const expectedTail = `${sep}.local${sep}share${sep}claude${sep}versions${sep}*`;
+
+    const match = NATIVE_SEARCH_PATH_INFO.find(
+      info => info.isGlob && info.pattern.endsWith(expectedTail)
+    );
+
+    expect(match).toBeDefined();
+  });
+});


### PR DESCRIPTION
It wasn't suggesting `claude.exe` for me, and `maybeResolveNixWrapper` was throwing errors when it tried to parse a PE file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installation detection by skipping unnecessary wrapper resolution checks and reducing PE/parse noise.
  * Clarified error messaging when binary resolution fails, with explicit context for version-manager shims before falling back to other search methods.

* **New Features**
  * Added a direct Windows native search path for the Claude executable to improve discovery on Windows systems.

* **Tests**
  * Expanded test coverage for native installation search path detection across Windows and Unix/macOS.

* **Documentation**
  * Updated changelog to note Windows detection improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->