### PR TITLE
Update node from 22 to 24 in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
           registry-url: https://registry.npmjs.org
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to tweakcc! This document provides g
 
 ### Prerequisites
 
-- **Node.js**: 22.x (20.0.0 or higher required)
+- **Node.js**: 24.x (20.0.0 or higher required)
 - **pnpm**: 10.13.1 or higher
 
 ```bash


### PR DESCRIPTION
`Cannot find module 'promise-retry'` (nodejs/node#62430) seems to be specifically an issue with node v22.22.2, which is exactly the version we were using.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version from 22.x to 24.x across CI/release workflows and development environment prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->