### PR TITLE
Add include rules for short system prompt fragments

### DIFF
--- a/tools/promptExtractor.js
+++ b/tools/promptExtractor.js
@@ -29,6 +29,22 @@ function validateInput(text, minLength = 500) {
   if (text.includes('IMPORTANT: Assist with authorized security testing'))
     return true;
 
+  // Short prompts from the "Doing tasks" section (rJ3 function in cli.js)
+  if (text.includes('exploratory questions')) return true;
+  if (text.includes('well-named identifiers already do that')) return true;
+  if (text.includes('golden path and edge cases')) return true;
+  if (text.includes('Prefer editing existing files')) return true;
+  if (text.includes('Default to writing no comments')) return true;
+  if (text.startsWith("Don't add features, refactor")) return true;
+
+  // Short prompts from the "Tone and style" section (HM3 function in cli.js)
+  if (text.includes('Only use emojis if the user explicitly')) return true;
+  if (text === 'Your responses should be short and concise.') return true;
+  if (text.includes('Do not use a colon before tool calls')) return true;
+
+  // Short prompts from the memory "What NOT to save" section
+  if (text.includes('What NOT to save in memory')) return true;
+
   // ////////////////
   // What to exclude.
   // ////////////////


### PR DESCRIPTION
## Summary

Several system prompt fragments in Claude Code's `cli.js` are under 500 characters and get filtered out by the `minLength` check in `validateInput()`. This means users cannot customize these prompts via tweakcc's system prompt editing feature.

These fragments come from:
- **Doing Tasks section** (`rJ3` function): exploratory questions behavior, code comment policy, UI testing, prefer-editing rule, no-gold-plating rule
- **Tone and Style section** (`HM3` function): emoji policy, concise output, colon-before-tool-calls rule  
- **Memory section**: "What NOT to save in memory" guidelines

## Changes

Added specific string-match include rules in `validateInput()`, following the same pattern already used for the security testing prompt (line 28-30). No changes to the filtering logic itself.

## Test plan

- [x] Run `node tools/promptExtractor.js` against Claude Code 2.1.126 binary and verify the newly included prompts appear in the output
- [x] Check that no false positives are introduced (the matches are specific substring checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation to accept additional shorter prompt fragments from multiple content sections, improving flexibility in accepted input formats.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Piebald-AI/tweakcc/pull/731)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->