### PR TITLE
Fix patch theme settings schema to include custom theme IDs (#702)

### DIFF
--- a/src/patches/themes.test.ts
+++ b/src/patches/themes.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { Theme } from '../types';
+import { writeThemes } from './themes';
+
+const BASE_SWITCH =
+  'switch(A){case"light":return LX9;case"dark":return DX9;default:return CX9}';
+const BASE_OBJ_ARR =
+  '[{"label":"Dark mode","value":"dark"},{"label":"Light mode","value":"light"}]';
+const BASE_OBJ = 'return{"dark":"Dark mode","light":"Light mode"}';
+const BASE_SCHEMA_ENUM =
+  'K8$=["dark","light","light-daltonized","dark-daltonized","light-ansi","dark-ansi"]';
+
+const makeBundle = (schemaEnum = BASE_SCHEMA_ENUM) =>
+  `${BASE_SWITCH}${BASE_OBJ_ARR}${BASE_OBJ}${schemaEnum}`;
+
+const CUSTOM_THEME = {
+  id: 'winter',
+  name: 'Winter',
+  colors: {},
+} as unknown as Theme;
+
+describe('patchThemeSchema (via writeThemes)', () => {
+  it('appends custom theme ID to the built-in schema enum', () => {
+    const result = writeThemes(makeBundle(), [CUSTOM_THEME]);
+
+    expect(result).not.toBeNull();
+    expect(result).toMatch(
+      /"dark","light","light-daltonized","dark-daltonized","light-ansi","dark-ansi","winter"/
+    );
+  });
+
+  it('appends multiple custom theme IDs', () => {
+    const themes = [
+      CUSTOM_THEME,
+      { id: 'ocean', name: 'Ocean', colors: {} } as unknown as Theme,
+    ];
+
+    const result = writeThemes(makeBundle(), themes);
+
+    expect(result).not.toBeNull();
+    expect(result).toMatch(
+      /"dark-daltonized","light-ansi","dark-ansi","winter","ocean"/
+    );
+  });
+
+  it('preserves all built-in IDs in the schema enum after patching', () => {
+    const result = writeThemes(makeBundle(), [CUSTOM_THEME]);
+
+    expect(result).not.toBeNull();
+    const schemaSection = result ?? '';
+    expect(schemaSection).toContain('"dark-daltonized"');
+    expect(schemaSection).toContain('"light-ansi"');
+    expect(schemaSection).toContain('"dark-ansi"');
+  });
+
+  it('is non-fatal when schema enum is absent — returns patched file without crashing', () => {
+    const bundleNoSchema = `${BASE_SWITCH}${BASE_OBJ_ARR}${BASE_OBJ}`;
+
+    const result = writeThemes(bundleNoSchema, [CUSTOM_THEME]);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('"winter"');
+  });
+});

--- a/src/patches/themes.ts
+++ b/src/patches/themes.ts
@@ -146,6 +146,31 @@ function getThemesLocation(oldFile: string): {
   };
 }
 
+function patchThemeSchema(file: string, themes: Theme[]): string {
+  if (themes.length === 0) return file;
+
+  const customStr = themes.map(t => `"${t.id}"`).join(',');
+
+  const anchor = '"dark","light","light-daltonized","dark-daltonized"';
+  const anchorIdx = file.indexOf(anchor);
+  if (anchorIdx === -1) {
+    console.warn(
+      'patch: themes: settings schema enum not found — custom theme IDs may be flagged invalid in settings.json'
+    );
+    return file;
+  }
+
+  const openBracket = file.lastIndexOf('[', anchorIdx);
+  if (openBracket === -1) return file;
+  const closeBracket = file.indexOf(']', anchorIdx);
+  if (closeBracket === -1) return file;
+
+  const original = file.slice(openBracket, closeBracket + 1);
+  const extended = original.slice(0, -1) + ',' + customStr + ']';
+
+  return file.slice(0, openBracket) + extended + file.slice(closeBracket + 1);
+}
+
 export const writeThemes = (
   oldFile: string,
   themes: Theme[]
@@ -223,6 +248,8 @@ export const writeThemes = (
     locations.switchStatement.startIndex,
     locations.switchStatement.endIndex
   );
+
+  newFile = patchThemeSchema(newFile, themes);
 
   return newFile;
 };


### PR DESCRIPTION
## Summary

When a custom tweakcc theme is selected via `/theme`, CC writes the custom theme ID to `settings.json`. On next startup, CC validates that file against an internal schema that only allows built-in theme IDs (`["dark","light","light-daltonized","dark-daltonized","light-ansi","dark-ansi"]`). The custom ID fails validation and CC **skips the entire settings file** — breaking status line, hooks, and all other settings.

## Changes

- Added `patchThemeSchema()` to `src/patches/themes.ts`, which locates CC's built-in theme enum by its unique fingerprint (`"dark","light","light-daltonized","dark-daltonized"`) and extends it with all user-configured theme IDs
- Called from `writeThemes()` after all other patches, so it operates on the fully-patched bundle
- **Non-fatal**: if the enum anchor isn't found in a future CC version, a warning is logged and patching continues normally
- Added `src/patches/themes.test.ts` with 4 tests covering: single custom ID, multiple IDs, built-in ID preservation, and graceful degradation when enum is absent

## Testing

- [x] 4 new tests pass: `pnpm run test -- themes`
- [x] Full test suite passes: 238 tests, 0 failures
- [x] `pnpm lint` clean

## Related Issues

Closes #702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for theme functionality, verifying custom theme registration and schema updates.

* **Improvements**
  * Enhanced theme system to properly register custom theme IDs in the application schema, ensuring custom themes are fully integrated alongside built-in options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->