### PR TITLE
Fix toolsets for Claude Code 2.1.167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix toolsets for Claude Code 2.1.167+: separate acceptEdits mode binding, preserve the `Skill` tool, and show the live `[toolset]` in the footer (#778) - @basekevin
+- Apply mode-bound toolsets at program load and add `TWEAKCC_TOOLSET_DEFAULT`, `TWEAKCC_TOOLSET_ALLOW_EDITS`, `TWEAKCC_TOOLSET_PLAN`, and `TWEAKCC_TOOLSET_AUTO` env overrides (#778) - @basekevin
+- Make agents without explicit `tools:` frontmatter respect the active toolset (#778) - @basekevin
+
 ## [v4.0.14](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.0.14) - 2026-06-03
 
 - Fix patches for Claude Code 2.1.160+ (#761) - @basekevin

--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -722,6 +722,7 @@ export const DEFAULT_SETTINGS: Settings = {
   },
   toolsets: [],
   defaultToolset: null,
+  acceptEditsToolset: null,
   planModeToolset: null,
   subagentModels: {
     plan: null,

--- a/src/patches/helpers.ts
+++ b/src/patches/helpers.ts
@@ -298,11 +298,19 @@ export const findTextComponent = (fileContents: string): string | undefined => {
   const textComponentPattern =
     /\bfunction ([$\w]+).{0,30}color:[$\w]+,backgroundColor:[$\w]+,dimColor:[$\w]+(?:=![01])?,bold:[$\w]+(?:=![01])?/;
   const match = fileContents.match(textComponentPattern);
-  if (!match) {
-    console.log('patch: findTextComponent: failed to find text component');
-    return undefined;
+  if (match) {
+    return match[1];
   }
-  return match[1];
+
+  const bodyDestructurePattern =
+    /\bfunction ([$\w]+)\(([$\w]+)\)\{(?=[\s\S]{0,700}\{color:[$\w]+,backgroundColor:[$\w]+,dimColor:[$\w]+,bold:[$\w]+,italic:[$\w]+,underline:[$\w]+,strikethrough:[$\w]+,inverse:[$\w]+,wrap:[$\w]+,children:[$\w]+,[\s\S]{0,80}=\2\))(?=[\s\S]{0,1400}children:)[\s\S]{0,1600}?\}/;
+  const bodyDestructureMatch = fileContents.match(bodyDestructurePattern);
+  if (bodyDestructureMatch) {
+    return bodyDestructureMatch[1];
+  }
+
+  console.log('patch: findTextComponent: failed to find text component');
+  return undefined;
 };
 
 /**

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -870,6 +870,7 @@ export const applyCustomization = async (
           c,
           config.settings.toolsets!,
           config.settings.defaultToolset,
+          config.settings.acceptEditsToolset,
           config.settings.planModeToolset
         ),
       condition: !!(

--- a/src/patches/toolsets.test.ts
+++ b/src/patches/toolsets.test.ts
@@ -16,6 +16,7 @@ import { Toolset } from '../types';
 
 const toolsets: Toolset[] = [
   { name: 'default', allowedTools: ['Read'] },
+  { name: 'accept-only', allowedTools: ['Edit'] },
   { name: 'plan-only', allowedTools: ['TodoWrite'] },
 ];
 
@@ -36,10 +37,10 @@ const computeToolsInput =
   `return resolve(agent,${mergedToolsVar},!1,!0).resolvedTools}`;
 
 const modeAwareFallback =
-  'state.toolPermissionContext?.mode!=="plan"&&state.toolsetAutoMode==="plan"?"default":(state.toolset??(state.toolPermissionContext?.mode==="plan"?"plan-only":"default"))';
-const computeModeAwareFallback = `${appStateVar}.toolPermissionContext?.mode!=="plan"&&${appStateVar}.toolsetAutoMode==="plan"?"default":(${appStateVar}.toolset??(${appStateVar}.toolPermissionContext?.mode==="plan"?"plan-only":"default"))`;
+  'state.toolPermissionContext?.mode!=="plan"&&state.toolsetAutoMode==="plan"?"default":(state.toolset??(state.toolPermissionContext?.mode==="plan"?"plan-only":(state.toolPermissionContext?.mode==="acceptEdits"?"accept-only":"default")))';
+const computeModeAwareFallback = `${appStateVar}.toolPermissionContext?.mode!=="plan"&&${appStateVar}.toolsetAutoMode==="plan"?"default":(${appStateVar}.toolset??(${appStateVar}.toolPermissionContext?.mode==="plan"?"plan-only":(${appStateVar}.toolPermissionContext?.mode==="acceptEdits"?"accept-only":"default")))`;
 const printModeAwareFallback =
-  's.toolPermissionContext?.mode!=="plan"&&s.toolsetAutoMode==="plan"?"default":(s.toolset??(s.toolPermissionContext?.mode==="plan"?"plan-only":"default"))';
+  's.toolPermissionContext?.mode!=="plan"&&s.toolsetAutoMode==="plan"?"default":(s.toolset??(s.toolPermissionContext?.mode==="plan"?"plan-only":(s.toolPermissionContext?.mode==="acceptEdits"?"accept-only":"default")))';
 
 describe('toolsets missing state.toolset fallback', () => {
   it('uses the mode-aware fallback in UI tool filtering', () => {
@@ -51,6 +52,7 @@ describe('toolsets missing state.toolset fallback', () => {
       file,
       toolsets,
       'default',
+      'accept-only',
       'plan-only'
     );
 
@@ -63,6 +65,7 @@ describe('toolsets missing state.toolset fallback', () => {
       computeToolsInput,
       toolsets,
       'default',
+      'accept-only',
       'plan-only'
     );
 
@@ -78,6 +81,7 @@ describe('toolsets missing state.toolset fallback', () => {
       file,
       toolsets,
       'default',
+      'accept-only',
       'plan-only'
     );
 
@@ -101,6 +105,7 @@ describe('toolsets missing state.toolset fallback', () => {
       file,
       toolsets,
       'default',
+      'accept-only',
       'plan-only'
     );
 
@@ -123,6 +128,7 @@ describe('toolsets missing state.toolset fallback', () => {
       file,
       toolsets,
       'default',
+      'accept-only',
       'plan-only'
     );
 
@@ -148,6 +154,7 @@ describe('toolsets missing state.toolset fallback', () => {
       file,
       toolsets,
       'default',
+      'accept-only',
       'plan-only'
     );
 
@@ -171,6 +178,7 @@ describe('toolsets missing state.toolset fallback', () => {
       file,
       toolsets,
       'default',
+      'accept-only',
       'plan-only'
     );
 
@@ -188,7 +196,12 @@ describe('toolsets missing state.toolset fallback', () => {
       appStateAccessors +
       'function Status(p){return render({color:"bashBorder"},"! for shell mode")}';
 
-    const result = insertShiftTabAppStateVar(file, 'default', 'plan-only');
+    const result = insertShiftTabAppStateVar(
+      file,
+      'default',
+      'accept-only',
+      'plan-only'
+    );
 
     expect(result).not.toBeNull();
     expect(result).toContain(
@@ -204,6 +217,7 @@ describe('toolsets missing state.toolset fallback', () => {
     const result = addCurrentToolsetAtToolChangeComponentScope(
       file,
       'default',
+      'accept-only',
       'plan-only'
     );
 
@@ -215,14 +229,21 @@ describe('toolsets missing state.toolset fallback', () => {
 });
 
 describe('writeModeChangeUpdateToolset', () => {
-  it('marks plan toolset as auto-selected only on automatic mode changes', () => {
+  it('switches default, accept edits, and plan modes independently', () => {
     const input =
       'if(setState((prev)=>({...prev,toolPermissionContext:{...prev.toolPermissionContext,mode:nextMode}}))){}';
 
-    const result = writeModeChangeUpdateToolset(input, 'plan-only', 'default');
+    const result = writeModeChangeUpdateToolset(
+      input,
+      'default',
+      'accept-only',
+      'plan-only'
+    );
 
     expect(result).not.toBeNull();
     expect(result).toContain('toolset:"plan-only",toolsetAutoMode:"plan"');
+    expect(result).toContain('nextMode==="acceptEdits"');
+    expect(result).toContain('toolset:"accept-only",toolsetAutoMode:null');
     expect(result).toContain('toolset:"default",toolsetAutoMode:null');
   });
 });
@@ -300,6 +321,7 @@ describe('writeComputeToolsFilter', () => {
       computeToolsInput,
       toolsets,
       'default',
+      'accept-only',
       'plan-only'
     );
 
@@ -312,6 +334,7 @@ describe('writeComputeToolsFilter', () => {
       computeToolsInput,
       toolsets,
       'default',
+      'accept-only',
       'plan-only'
     );
 

--- a/src/patches/toolsets.test.ts
+++ b/src/patches/toolsets.test.ts
@@ -4,6 +4,7 @@ import {
   addCurrentToolsetAtToolChangeComponentScope,
   findSelectComponentName,
   insertShiftTabAppStateVar,
+  appendToolsetToModeDisplay,
   writeComputeToolsFilter,
   writePrintToolsFilter,
   writeSubagentResolvedToolContextFix,
@@ -71,6 +72,9 @@ describe('toolsets missing state.toolset fallback', () => {
 
     expect(result).not.toBeNull();
     expect(result).toContain(computeModeAwareFallback);
+    expect(result).toContain(
+      'return t.filter(d=>d.name==="Skill"||a.includes(d.name))'
+    );
   });
 
   it('uses the mode-aware fallback in print-mode tool filtering', () => {
@@ -92,6 +96,12 @@ describe('toolsets missing state.toolset fallback', () => {
     );
     expect(result).toContain(
       'canUseTool:async(...a)=>__tptc(a[0],getState())??await allowTool(...a)'
+    );
+    expect(result).toContain(
+      'return t.filter(d=>d.name==="Skill"||a.includes(d.name))'
+    );
+    expect(result).toContain(
+      'if(tool&&tool.name!=="Skill"&&Array.isArray(a)&&!a.includes(tool.name))'
     );
   });
 
@@ -194,7 +204,7 @@ describe('toolsets missing state.toolset fallback', () => {
   it('uses the mode-aware fallback in the statusline display', () => {
     const file =
       appStateAccessors +
-      'function Status(p){return render({color:"bashBorder"},"! for shell mode")}';
+      'function Status({toolPermissionContext:permission}){return render({color:"bashBorder"},"! for shell mode")}';
 
     const result = insertShiftTabAppStateVar(
       file,
@@ -207,6 +217,22 @@ describe('toolsets missing state.toolset fallback', () => {
     expect(result).toContain(
       `let currentToolset=useAppState(state => ${modeAwareFallback});`
     );
+  });
+
+  it('appends the live toolset to every mode display site', () => {
+    const file =
+      'let k6=el(y,{},sym(mode)," ",title(mode).toLowerCase()," on",hint);' +
+      'let NH=el(y,{},sym(mode)," ",title(mode).toLowerCase()," on",chord);';
+
+    const result = appendToolsetToModeDisplay(file);
+
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('.toLowerCase()," on"');
+    expect(
+      result!.match(
+        /title\(mode\)\.toLowerCase\(\),currentToolset\?` on \[\$\{currentToolset\}\]`:""/g
+      )
+    ).toHaveLength(2);
   });
 
   it('uses the mode-aware fallback in the tool-change component scope', () => {

--- a/src/patches/toolsets.test.ts
+++ b/src/patches/toolsets.test.ts
@@ -4,6 +4,7 @@ import {
   addCurrentToolsetAtToolChangeComponentScope,
   findSelectComponentName,
   insertShiftTabAppStateVar,
+  writeToolsetFieldToAppState,
   appendToolsetToModeDisplay,
   writeComputeToolsFilter,
   writePrintToolsFilter,
@@ -37,11 +38,15 @@ const computeToolsInput =
   `if(!agent)return ${mergedToolsVar};` +
   `return resolve(agent,${mergedToolsVar},!1,!0).resolvedTools}`;
 
-const modeAwareFallback =
-  'state.toolPermissionContext?.mode!=="plan"&&state.toolsetAutoMode==="plan"?"default":(state.toolset??(state.toolPermissionContext?.mode==="plan"?"plan-only":(state.toolPermissionContext?.mode==="acceptEdits"?"accept-only":"default")))';
-const computeModeAwareFallback = `${appStateVar}.toolPermissionContext?.mode!=="plan"&&${appStateVar}.toolsetAutoMode==="plan"?"default":(${appStateVar}.toolset??(${appStateVar}.toolPermissionContext?.mode==="plan"?"plan-only":(${appStateVar}.toolPermissionContext?.mode==="acceptEdits"?"accept-only":"default")))`;
-const printModeAwareFallback =
-  's.toolPermissionContext?.mode!=="plan"&&s.toolsetAutoMode==="plan"?"default":(s.toolset??(s.toolPermissionContext?.mode==="plan"?"plan-only":(s.toolPermissionContext?.mode==="acceptEdits"?"accept-only":"default")))';
+const envDefault = '(process.env.TWEAKCC_TOOLSET_DEFAULT||"default")';
+const envAccept = '(process.env.TWEAKCC_TOOLSET_ALLOW_EDITS||"accept-only")';
+const envPlan = '(process.env.TWEAKCC_TOOLSET_PLAN||"plan-only")';
+const envAuto = `(process.env.TWEAKCC_TOOLSET_AUTO||${envDefault})`;
+const fallbackFor = (s: string): string =>
+  `${s}.toolPermissionContext?.mode!=="plan"&&${s}.toolsetAutoMode==="plan"?${envDefault}:(${s}.toolset??(${s}.toolPermissionContext?.mode==="plan"?${envPlan}:(${s}.toolPermissionContext?.mode==="acceptEdits"?${envAccept}:(${s}.toolPermissionContext?.mode==="auto"?${envAuto}:${envDefault}))))`;
+const modeAwareFallback = fallbackFor('state');
+const computeModeAwareFallback = fallbackFor(appStateVar);
+const printModeAwareFallback = fallbackFor('s');
 
 describe('toolsets missing state.toolset fallback', () => {
   it('uses the mode-aware fallback in UI tool filtering', () => {
@@ -219,6 +224,18 @@ describe('toolsets missing state.toolset fallback', () => {
     );
   });
 
+  it('initializes app state toolset as undefined so the mode binding applies at load', () => {
+    const file = 'state={thinkingEnabled:FDH(),promptSuggestionEnabled:rX()}';
+
+    const result = writeToolsetFieldToAppState(file);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'thinkingEnabled:FDH(),toolset:undefined,toolsetAutoMode:null'
+    );
+    expect(result).not.toContain('toolset:"');
+  });
+
   it('appends the live toolset to every mode display site', () => {
     const file =
       'let k6=el(y,{},sym(mode)," ",title(mode).toLowerCase()," on",hint);' +
@@ -267,10 +284,20 @@ describe('writeModeChangeUpdateToolset', () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result).toContain('toolset:"plan-only",toolsetAutoMode:"plan"');
+    expect(result).toContain(
+      'toolset:process.env.TWEAKCC_TOOLSET_PLAN||"plan-only",toolsetAutoMode:"plan"'
+    );
     expect(result).toContain('nextMode==="acceptEdits"');
-    expect(result).toContain('toolset:"accept-only",toolsetAutoMode:null');
-    expect(result).toContain('toolset:"default",toolsetAutoMode:null');
+    expect(result).toContain(
+      'toolset:process.env.TWEAKCC_TOOLSET_ALLOW_EDITS||"accept-only",toolsetAutoMode:null'
+    );
+    expect(result).toContain('nextMode==="auto"');
+    expect(result).toContain(
+      'toolset:process.env.TWEAKCC_TOOLSET_AUTO||process.env.TWEAKCC_TOOLSET_DEFAULT||"default",toolsetAutoMode:null'
+    );
+    expect(result).toContain(
+      'toolset:process.env.TWEAKCC_TOOLSET_DEFAULT||"default",toolsetAutoMode:null'
+    );
   });
 });
 
@@ -355,7 +382,7 @@ describe('writeComputeToolsFilter', () => {
     expect(result).toContain(`if(!agent)return __tf(${mergedToolsVar});`);
   });
 
-  it('preserves native resolved tools for active agents', () => {
+  it('preserves declared agent tools but filters undeclared agents', () => {
     const result = writeComputeToolsFilter(
       computeToolsInput,
       toolsets,
@@ -366,7 +393,7 @@ describe('writeComputeToolsFilter', () => {
 
     expect(result).not.toBeNull();
     expect(result).toContain(
-      `return resolve(agent,${mergedToolsVar},!1,!0).resolvedTools`
+      `return resolve(agent,agent.tools?${mergedToolsVar}:__tf(${mergedToolsVar}),!1,!0).resolvedTools`
     );
     expect(result).not.toContain(
       `return __tf(resolve(agent,${mergedToolsVar},!1,!0).resolvedTools)`

--- a/src/patches/toolsets.test.ts
+++ b/src/patches/toolsets.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addCurrentToolsetAtToolChangeComponentScope,
+  findSelectComponentName,
+  insertShiftTabAppStateVar,
+  writeComputeToolsFilter,
+  writePrintToolsFilter,
+  writeSubagentResolvedToolContextFix,
+  writeTaskAgentFrontmatterToolsFix,
+  writeToolFetchingUseMemo,
+  writeModeChangeUpdateToolset,
+} from './toolsets';
+import { findTextComponent } from './helpers';
+import { Toolset } from '../types';
+
+const toolsets: Toolset[] = [
+  { name: 'default', allowedTools: ['Read'] },
+  { name: 'plan-only', allowedTools: ['TodoWrite'] },
+];
+
+const appStateVar = 'appState';
+const assembledToolsVar = 'assembledTools';
+const mergedToolsVar = 'mergedTools';
+
+const appStateAccessors =
+  'function useAppState(selector){return `Your selector in ${selector}`}' +
+  'function setAppState(){return appStore().setState}';
+
+const computeToolsInput =
+  appStateAccessors +
+  `computeTools=()=>{let ${appStateVar}=toolStore.getState(),` +
+  `${assembledToolsVar}=assemble(${appStateVar}.toolPermissionContext,${appStateVar}.mcp.tools),` +
+  `${mergedToolsVar}=merge(baseTools,${assembledToolsVar},${appStateVar}.toolPermissionContext.mode);` +
+  `if(!agent)return ${mergedToolsVar};` +
+  `return resolve(agent,${mergedToolsVar},!1,!0).resolvedTools}`;
+
+const modeAwareFallback =
+  'state.toolPermissionContext?.mode!=="plan"&&state.toolsetAutoMode==="plan"?"default":(state.toolset??(state.toolPermissionContext?.mode==="plan"?"plan-only":"default"))';
+const computeModeAwareFallback = `${appStateVar}.toolPermissionContext?.mode!=="plan"&&${appStateVar}.toolsetAutoMode==="plan"?"default":(${appStateVar}.toolset??(${appStateVar}.toolPermissionContext?.mode==="plan"?"plan-only":"default"))`;
+const printModeAwareFallback =
+  's.toolPermissionContext?.mode!=="plan"&&s.toolsetAutoMode==="plan"?"default":(s.toolset??(s.toolPermissionContext?.mode==="plan"?"plan-only":"default"))';
+
+describe('toolsets missing state.toolset fallback', () => {
+  it('uses the mode-aware fallback in UI tool filtering', () => {
+    const file =
+      appStateAccessors +
+      'let merged=aggregate(firstArg,source.tools,permissionMode),tail';
+
+    const result = writeToolFetchingUseMemo(
+      file,
+      toolsets,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(modeAwareFallback);
+  });
+
+  it('uses the mode-aware fallback in computeTools filtering', () => {
+    const result = writeComputeToolsFilter(
+      computeToolsInput,
+      toolsets,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(computeModeAwareFallback);
+  });
+
+  it('uses the mode-aware fallback in print-mode tool filtering', () => {
+    const file =
+      'let tools=computeTools(state);startQuery({tools:tools,refreshTools:()=>computeTools(getState()),canUseTool:allowTool})';
+
+    const result = writePrintToolsFilter(
+      file,
+      toolsets,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(printModeAwareFallback);
+    expect(result).toContain(
+      'refreshTools:()=>{let s=getState(),u=computeTools(s);__tptu=u;return __tptf(u,s)}'
+    );
+    expect(result).toContain(
+      'canUseTool:async(...a)=>__tptc(a[0],getState())??await allowTool(...a)'
+    );
+  });
+
+  it('filters 2.1.165 print-mode resolver tools', () => {
+    const file =
+      'let visibleTools=resolveTools(currentState);' +
+      'x'.repeat(3200) +
+      'startQuery({tools:visibleTools,refreshTools:()=>resolveTools(getState()),canUseTool:allowTool})';
+
+    const result = writePrintToolsFilter(
+      file,
+      toolsets,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(printModeAwareFallback);
+    expect(result).toContain('visibleTools=__tptf(visibleTools,currentState);');
+    expect(result).toContain(
+      'refreshTools:()=>{let s=getState(),u=resolveTools(s);__tptu=u;return __tptf(u,s)}'
+    );
+    expect(result).toContain(
+      'canUseTool:async(...a)=>__tptc(a[0],getState())??await allowTool(...a)'
+    );
+  });
+
+  it('filters direct-state print-mode refresh tools', () => {
+    const file =
+      'let tools=computeTools(state);startQuery({tools:tools,refreshTools:()=>computeTools(state),canUseTool:allowTool})';
+
+    const result = writePrintToolsFilter(
+      file,
+      toolsets,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(printModeAwareFallback);
+    expect(result).toContain(
+      'refreshTools:()=>{let u=computeTools(state);__tptu=u;return __tptf(u,state)}'
+    );
+    expect(result).toContain(
+      'canUseTool:async(...a)=>__tptc(a[0],state)??await allowTool(...a)'
+    );
+  });
+
+  it('preserves the initial print-mode tool snapshot', () => {
+    const initialSnapshot =
+      'let dyn=assembleDynamic(state.mcp.tools,state.toolPermissionContext),initial=[...base,...dyn];toolsRef.current=initial;';
+    const file =
+      'let tools=computeTools(state);' +
+      initialSnapshot +
+      'startQuery({tools:tools,refreshTools:()=>computeTools(state),canUseTool:allowTool})';
+
+    const result = writePrintToolsFilter(
+      file,
+      toolsets,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(initialSnapshot);
+    expect(result).toContain('let tools=computeTools(state),__tptu=tools;');
+    expect(result).not.toContain('initial=__tptf(initial,state)');
+  });
+
+  it('preserves unfiltered print-mode tools for latest Task subagents', () => {
+    const file =
+      'let taskTools=computeTools(state);startQuery({tools:taskTools,' +
+      'refreshTools:()=>computeTools(getState()),canUseTool:allowTool,' +
+      'availableTools:S,forkContextMessages:void 0,' +
+      'options:{tools:childTools,commands:[],debug:false,verbose:false}});' +
+      'for await(let event of runQuery({messages:msgs,systemPrompt:sys,' +
+      'userContext:user,systemContext:ctx,canUseTool:parentCanUse,' +
+      'toolUseContext:childCtx,querySource:source})){}';
+
+    const result = writePrintToolsFilter(
+      file,
+      toolsets,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'let taskTools=computeTools(state),__tptu=taskTools;'
+    );
+    expect(result).toContain('taskTools=__tptf(taskTools,state);');
+    expect(result).toContain('availableTools:__tptu');
+    expect(result).not.toContain('availableTools:S');
+  });
+
+  it('uses the mode-aware fallback in the statusline display', () => {
+    const file =
+      appStateAccessors +
+      'function Status(p){return render({color:"bashBorder"},"! for shell mode")}';
+
+    const result = insertShiftTabAppStateVar(file, 'default', 'plan-only');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      `let currentToolset=useAppState(state => ${modeAwareFallback});`
+    );
+  });
+
+  it('uses the mode-aware fallback in the tool-change component scope', () => {
+    const file =
+      appStateAccessors +
+      'wrap(arg,function(evt){track("tengu_ext_at_mentioned",{});return null})';
+
+    const result = addCurrentToolsetAtToolChangeComponentScope(
+      file,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      `const currentToolset = useAppState(state => ${modeAwareFallback});`
+    );
+  });
+});
+
+describe('writeModeChangeUpdateToolset', () => {
+  it('marks plan toolset as auto-selected only on automatic mode changes', () => {
+    const input =
+      'if(setState((prev)=>({...prev,toolPermissionContext:{...prev.toolPermissionContext,mode:nextMode}}))){}';
+
+    const result = writeModeChangeUpdateToolset(input, 'plan-only', 'default');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('toolset:"plan-only",toolsetAutoMode:"plan"');
+    expect(result).toContain('toolset:"default",toolsetAutoMode:null');
+  });
+});
+
+describe('writeSubagentResolvedToolContextFix', () => {
+  it('uses captured resolved tool/context variables for tool execution lookup', () => {
+    const resolvedToolsVar = '$tools';
+    const contextVar = 'ctx2';
+    const canUseToolVar = '$allow';
+    const querySourceVar = 'src2';
+    const input =
+      `let ${resolvedToolsVar}=agentMcpTools.length>0?dedupe([...frontmatterTools,...agentMcpTools],"name"):frontmatterTools;` +
+      `if(!exact)for(let item of attach(${resolvedToolsVar},model,msgs,{callSite:"attachments_subagent"})){};` +
+      `let childOptions={tools:${resolvedToolsVar},commands:[]},${contextVar}=clone(parent,{options:childOptions});` +
+      'for await(let event of query({messages:msgs,systemPrompt:sys,' +
+      `userContext:user,systemContext:system,canUseTool:${canUseToolVar},` +
+      `toolUseContext:${contextVar},querySource:${querySourceVar},` +
+      'spawnedBySkill:skill,maxTurns:maxTurns})){}';
+
+    const result = writeSubagentResolvedToolContextFix(input);
+
+    expect(result).toContain(
+      `canUseTool:async(...a)=>${resolvedToolsVar}.some(t=>t.name===a[0]?.name)?{behavior:"allow",decisionReason:{type:"other",reason:"subagent_toolset"}}:await ${canUseToolVar}(...a)`
+    );
+    expect(result).toContain(
+      `toolUseContext:{...${contextVar},options:{...${contextVar}.options,tools:${resolvedToolsVar}}},querySource:${querySourceVar}`
+    );
+    expect(result).not.toContain(
+      `canUseTool:${canUseToolVar},toolUseContext:${contextVar}`
+    );
+  });
+});
+
+describe('writeTaskAgentFrontmatterToolsFix', () => {
+  it('uses captured vars for the full native candidate pool before frontmatter filtering', () => {
+    const nativeToolsVar = '$nativeTools';
+    const appStateVar = 'state2';
+    const candidateVar = '$candidate';
+    const resolvedVar = 'resolved2';
+    const contextVar = 'ctx2';
+    const input =
+      'let agentDef=customAgent??defaultAgent,' +
+      `${appStateVar}=runtime.getAppState(),permission=readPerm(runtime),` +
+      `${nativeToolsVar}=runtime.options.tools.filter(isBaseTool),` +
+      'permissionForAgent={...permission,mode:agentDef.permissionMode??"acceptEdits"};' +
+      `${candidateVar}=resolve(permissionForAgent,wrap(${appStateVar}.mcp.tools.concat(${nativeToolsVar})),{skipReplFilter:!0,skillTools:${appStateVar}.skillTools}),` +
+      `${resolvedVar}=schemaTool?[...${candidateVar}.filter((tool)=>!same(tool,structuredOutput)),schemaTool]:${candidateVar},` +
+      `launch={agentDefinition:agentDef,availableTools:isFork?runtime.options.tools:${resolvedVar},` +
+      'forkContextMessages:isFork?runtime.messages:void 0};' +
+      'for await(let event of query({messages:msgs,systemPrompt:sys,' +
+      `systemContext:system,canUseTool:allow,toolUseContext:${contextVar},` +
+      'querySource:source,spawnedBySkill:skill,maxTurns:maxTurns})){}';
+
+    const result = writeTaskAgentFrontmatterToolsFix(input);
+
+    expect(result).toContain(
+      `${candidateVar}=${appStateVar}.mcp.tools.concat(${nativeToolsVar}),${resolvedVar}=`
+    );
+    expect(result).toContain(
+      `availableTools:isFork?runtime.options.tools:${resolvedVar}`
+    );
+    expect(result).not.toContain(`${candidateVar}=resolve(`);
+  });
+
+  it('does not rewrite unrelated simple availableTools fields', () => {
+    const input = 'start({availableTools:S,forkContextMessages:void 0})';
+
+    expect(writeTaskAgentFrontmatterToolsFix(input)).toBe(input);
+  });
+});
+
+describe('writeComputeToolsFilter', () => {
+  it('filters the no-agent computeTools branch', () => {
+    const result = writeComputeToolsFilter(
+      computeToolsInput,
+      toolsets,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(`if(!agent)return __tf(${mergedToolsVar});`);
+  });
+
+  it('preserves native resolved tools for active agents', () => {
+    const result = writeComputeToolsFilter(
+      computeToolsInput,
+      toolsets,
+      'default',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      `return resolve(agent,${mergedToolsVar},!1,!0).resolvedTools`
+    );
+    expect(result).not.toContain(
+      `return __tf(resolve(agent,${mergedToolsVar},!1,!0).resolvedTools)`
+    );
+  });
+});
+
+describe('findTextComponent', () => {
+  it('finds text component when props are destructured in the function body', () => {
+    const input =
+      'function TextLike(props){let cacheSlot=cache.c(31),rest,background,textChildren,color,dim,bold,italic,underline,strikethrough,inverse,wrap;' +
+      'if(cacheSlot[0]!==props)({color:color,backgroundColor:background,dimColor:dim,bold:bold,italic:italic,underline:underline,strikethrough:strikethrough,inverse:inverse,wrap:wrap,children:textChildren,...rest}=props);' +
+      'let resolvedDim=dim===void 0?!1:dim,resolvedBold=bold===void 0?!1:bold,resolvedItalic=italic===void 0?!1:italic}';
+
+    expect(findTextComponent(input)).toBe('TextLike');
+  });
+});
+
+describe('findSelectComponentName', () => {
+  it('finds a Select component from its options/onChange/onCancel signature', () => {
+    const input =
+      'function SelectMenu({options:opts,onChange:change,onCancel:cancel,placeholder:hint}){' +
+      'return R.createElement(Box,{children:opts.map(option=>option.label)})}' +
+      'R.createElement(YesNoPrompt,{options:yesNoOptions,onChange:onYes,onCancel:onNo,children:"Yes, use recommended settings"});';
+
+    expect(findSelectComponentName(input)).toBe('SelectMenu');
+  });
+
+  it('skips the recommended-settings yes/no prompt when using usage fallback', () => {
+    const input =
+      'R.createElement(YesNoPrompt,{options:yesNoOptions,onChange:onYes,onCancel:onNo,children:"Yes, use recommended settings"});' +
+      'R.createElement(GenericSelect,{options:selectOptions,onChange:onSelect,onCancel:onCancel});';
+
+    expect(findSelectComponentName(input)).toBe('GenericSelect');
+  });
+
+  it('skips selector/state helpers and finds the render component', () => {
+    const input =
+      'function SelectState({options:opts,onChange:change,onCancel:cancel}){' +
+      'return {options:opts,onChange:change,onCancel:cancel,highlightedIndex:0}}' +
+      'function MenuSelect({options:items,onChange:onPick,onCancel:onClose,placeholder:hint}){' +
+      'return R.createElement(Box,{children:items.map(option=>option.label)})}';
+
+    expect(findSelectComponentName(input)).toBe('MenuSelect');
+  });
+});

--- a/src/patches/toolsets.ts
+++ b/src/patches/toolsets.ts
@@ -23,18 +23,58 @@ import { Toolset } from '../types';
 export const findSelectComponentName = (
   fileContents: string
 ): string | null => {
-  // Pattern matches the Select component's function signature
-  const selectPattern =
-    /\.createElement\(([$\w]+),.{0,100}"Yes, use recommended settings"/;
-  const match = fileContents.match(selectPattern);
-  if (!match) {
-    console.error(
-      'patch: findSelectComponentName: failed to find selectPattern'
+  const createElementPattern =
+    /\.createElement\(([$\w]+),\{(?=[^}]{0,240}options:)(?=[^}]{0,240}onChange:)[^}]{0,360}\}/g;
+
+  for (const match of fileContents.matchAll(createElementPattern)) {
+    const window = fileContents.slice(
+      match.index,
+      Math.min(fileContents.length, match.index + match[0].length + 180)
     );
-    return null;
+    if (/Yes, use recommended settings|recommended settings/.test(window)) {
+      continue;
+    }
+    return match[1];
   }
 
-  return match[1];
+  const selectDefinitionPatterns = [
+    /function ([$\w]+)\(\{(?=[^}]{0,600}options:)(?=[^}]{0,600}onChange:)(?=[^}]{0,600}onCancel:)[^}]{0,900}\}\)/g,
+    /function ([$\w]+)\(([$\w]+)\)\{(?:(?!function ).){0,900}\{(?=[^}]{0,600}options:)(?=[^}]{0,600}onChange:)(?=[^}]{0,600}onCancel:)[^}]{0,900}\}=\2/g,
+  ];
+
+  for (const selectPattern of selectDefinitionPatterns) {
+    for (const match of fileContents.matchAll(selectPattern)) {
+      const body = fileContents.slice(
+        match.index,
+        Math.min(fileContents.length, match.index + match[0].length + 1200)
+      );
+      if (/\.createElement\(/.test(body) && !/return\s*\{/.test(body)) {
+        return match[1];
+      }
+    }
+  }
+
+  console.error('patch: findSelectComponentName: failed to find selectPattern');
+  return null;
+};
+
+const getToolsetFallbackExpression = (
+  stateExpression: string,
+  defaultToolset: string | null,
+  planModeToolset?: string | null
+): string => {
+  const defaultValue = defaultToolset
+    ? JSON.stringify(defaultToolset)
+    : 'undefined';
+  const planValue = planModeToolset
+    ? JSON.stringify(planModeToolset)
+    : defaultValue;
+
+  if (planModeToolset) {
+    return `${stateExpression}.toolPermissionContext?.mode!=="plan"&&${stateExpression}.toolsetAutoMode==="plan"?${defaultValue}:(${stateExpression}.toolset??(${stateExpression}.toolPermissionContext?.mode==="plan"?${planValue}:${defaultValue}))`;
+  }
+
+  return `${stateExpression}.toolset??${defaultValue}`;
 };
 
 /**
@@ -269,7 +309,7 @@ export const writeToolsetFieldToAppState = (
   const toolsetValue = defaultToolset
     ? JSON.stringify(defaultToolset)
     : 'undefined';
-  const textToInsert = `,toolset:${toolsetValue}`;
+  const textToInsert = `,toolset:${toolsetValue},toolsetAutoMode:null`;
   for (const mod of modifications) {
     newFile =
       newFile.slice(0, mod.index) + textToInsert + newFile.slice(mod.index);
@@ -293,7 +333,8 @@ export const writeToolsetFieldToAppState = (
 export const writeToolFetchingUseMemo = (
   oldFile: string,
   toolsets: Toolset[],
-  defaultToolset: string | null
+  defaultToolset: string | null,
+  planModeToolset?: string | null
 ): string | null => {
   const stateInfo = getAppStateSelectorAndUseState(oldFile);
   if (!stateInfo) {
@@ -329,13 +370,15 @@ export const writeToolFetchingUseMemo = (
 
   // When persisted app state is loaded it may not have a toolset field (saved before
   // the toolset patch existed), causing currentToolset to be undefined. Fall back to
-  // defaultToolset so the restriction is active from the very first render.
-  const fallback = defaultToolset
-    ? JSON.stringify(defaultToolset)
-    : 'undefined';
+  // the active mode's toolset so restrictions are active from the first render.
+  const fallback = getToolsetFallbackExpression(
+    'state',
+    defaultToolset,
+    planModeToolset
+  );
 
   // Generate the replacement code
-  const replacement = `let currentToolset = ${appStateUseSelectorFn}(state => state.toolset) ?? ${fallback};
+  const replacement = `let currentToolset = ${appStateUseSelectorFn}(state => ${fallback});
 let ${toolAggregationVar} = undefined;
 const toolsets = ${toolsetsJSON};
 if (toolsets.hasOwnProperty(currentToolset)) {
@@ -374,12 +417,14 @@ if (toolsets.hasOwnProperty(currentToolset)) {
  *     if(!AGENT)return MERGED;
  *     return resolve(AGENT,MERGED,!1,!0).resolvedTools}
  *
- * We wrap both return statements with the toolset filter.
+ * We filter the main/orchestrator tools, but preserve native agent-resolved tools so
+ * custom agent frontmatter `tools:` definitions continue to work.
  */
 export const writeComputeToolsFilter = (
   oldFile: string,
   toolsets: Toolset[],
-  defaultToolset: string | null
+  defaultToolset: string | null,
+  planModeToolset?: string | null
 ): string | null => {
   const stateInfo = getAppStateSelectorAndUseState(oldFile);
   if (!stateInfo) {
@@ -429,9 +474,11 @@ export const writeComputeToolsFilter = (
     )
   );
 
-  const fallback = defaultToolset
-    ? JSON.stringify(defaultToolset)
-    : 'undefined';
+  const fallback = getToolsetFallbackExpression(
+    stateVar,
+    defaultToolset,
+    planModeToolset
+  );
 
   // Actually let me re-examine the match to get the init tools var
   const fullMatch = match[0];
@@ -450,7 +497,7 @@ export const writeComputeToolsFilter = (
   const initVar = mergeCallMatch[1];
 
   // Set globalThis.__tweakcc_toolset so the error message helper can read it
-  const newClosure = `${closureVar}=${useCallbackPrefix}()=>{let ${stateVar}=${storeVar}.getState(),${assembledVar}=${assembleFn}(${stateVar}.toolPermissionContext,${stateVar}.mcp.tools${skillToolsArg}),${mergedVar}=${mergeFn}(${initVar},${assembledVar},${stateVar}.toolPermissionContext.mode);const __ts=${toolsetsJSON},__tc=${stateVar}.toolset??${fallback},__tf=(t)=>{globalThis.__tweakcc_toolset={name:__tc,tools:__ts[__tc]};if(__ts.hasOwnProperty(__tc)){const a=__ts[__tc];if(a==="*")return t;return t.filter(d=>a.includes(d.name))}return t};if(!${agentVar})return __tf(${mergedVar});return __tf(${resolveFn}(${agentVar},${mergedVar},!1,!0).resolvedTools)}`;
+  const newClosure = `${closureVar}=${useCallbackPrefix}()=>{let ${stateVar}=${storeVar}.getState(),${assembledVar}=${assembleFn}(${stateVar}.toolPermissionContext,${stateVar}.mcp.tools${skillToolsArg}),${mergedVar}=${mergeFn}(${initVar},${assembledVar},${stateVar}.toolPermissionContext.mode);const __ts=${toolsetsJSON},__tc=${fallback},__tf=(t)=>{globalThis.__tweakcc_toolset={name:__tc,tools:__ts[__tc]};if(__ts.hasOwnProperty(__tc)){const a=__ts[__tc];if(a==="*")return t;return t.filter(d=>a.includes(d.name))}return t};if(!${agentVar})return __tf(${mergedVar});return ${resolveFn}(${agentVar},${mergedVar},!1,!0).resolvedTools}`;
 
   const startIndex = match.index;
   const endIndex = startIndex + fullMatch.length;
@@ -473,7 +520,8 @@ export const writeComputeToolsFilter = (
 export const writePrintToolsFilter = (
   oldFile: string,
   toolsets: Toolset[],
-  defaultToolset: string | null
+  defaultToolset: string | null,
+  planModeToolset?: string | null
 ): string | null => {
   const toolsetsJSON = JSON.stringify(
     Object.fromEntries(
@@ -483,42 +531,50 @@ export const writePrintToolsFilter = (
       ])
     )
   );
-  const fallback = defaultToolset
-    ? JSON.stringify(defaultToolset)
-    : 'undefined';
+  const fallback = getToolsetFallbackExpression(
+    's',
+    defaultToolset,
+    planModeToolset
+  );
 
-  const toolsPattern =
-    /let ([$\w]+)=([$\w]+)\(([$\w]+)\);(?=[\s\S]{0,2500}tools:\1,refreshTools:\(\)=>\2\(([$\w]+)\(\)\))/;
-  const toolsMatch = oldFile.match(toolsPattern);
-  if (!toolsMatch || toolsMatch.index === undefined) {
+  const resolverPattern =
+    /let ([$\w]+)=([$\w]+)\(([$\w]+)\);(?=[\s\S]{0,8000}tools:\1,refreshTools:\(\)=>\2\(([$\w]+)\(\)\))/;
+  const resolverMatch = oldFile.match(resolverPattern);
+  const directPattern =
+    /let ([$\w]+)=([$\w]+)\(([$\w]+)\);(?=[\s\S]{0,2500}tools:\1,refreshTools:\(\)=>\2\(\3\))/;
+  const directMatch = resolverMatch ? null : oldFile.match(directPattern);
+  const match = resolverMatch ?? directMatch;
+  if (!match || match.index === undefined) {
     console.error(
       'patch: toolsets: printToolsFilter: failed to find print tools initialization'
     );
     return null;
   }
 
-  const toolsVar = toolsMatch[1];
-  const computeFn = toolsMatch[2];
-  const stateVar = toolsMatch[3];
-  const getterFn = toolsMatch[4];
+  const toolsVar = match[1];
+  const computeFn = match[2];
+  const stateVar = match[3];
+  const getterFn = resolverMatch ? match[4] : null;
 
-  const filterCode = `let ${toolsVar}=${computeFn}(${stateVar});const __tpts=${toolsetsJSON},__tptf=(t,s)=>{const n=s.toolset??${fallback};globalThis.__tweakcc_toolset={name:n,tools:__tpts[n]};if(__tpts.hasOwnProperty(n)){const a=__tpts[n];if(a==="*")return t;return t.filter(d=>a.includes(d.name))}return t};${toolsVar}=__tptf(${toolsVar},${stateVar});`;
+  const filterCode = `let ${toolsVar}=${computeFn}(${stateVar}),__tptu=${toolsVar};const __tpts=${toolsetsJSON},__tptf=(t,s)=>{const n=${fallback};globalThis.__tweakcc_toolset={name:n,tools:__tpts[n]};if(__tpts.hasOwnProperty(n)){const a=__tpts[n];if(a==="*")return t;return t.filter(d=>a.includes(d.name))}return t},__tptc=(tool,s)=>{const n=${fallback};globalThis.__tweakcc_toolset={name:n,tools:__tpts[n]};if(__tpts.hasOwnProperty(n)){const a=__tpts[n];if(a==="*")return null;if(tool&&Array.isArray(a)&&!a.includes(tool.name))return{behavior:"deny",message:__tweakcc_toolErrorMsg(tool.name),decisionReason:{type:"other",reason:"toolset"}}}return null};${toolsVar}=__tptf(${toolsVar},${stateVar});`;
 
   let newFile =
-    oldFile.slice(0, toolsMatch.index) +
+    oldFile.slice(0, match.index) +
     filterCode +
-    oldFile.slice(toolsMatch.index + toolsMatch[0].length);
+    oldFile.slice(match.index + match[0].length);
 
   showDiff(
     oldFile,
     newFile,
     filterCode,
-    toolsMatch.index,
-    toolsMatch.index + toolsMatch[0].length
+    match.index,
+    match.index + match[0].length
   );
 
   const refreshPattern = new RegExp(
-    `refreshTools:\\(\\)=>${computeFn.replace(/\$/g, '\\$')}\\(${getterFn.replace(/\$/g, '\\$')}\\(\\)\\)`
+    getterFn
+      ? `refreshTools:\\(\\)=>${computeFn.replace(/\$/g, '\\$')}\\(${getterFn.replace(/\$/g, '\\$')}\\(\\)\\)`
+      : `refreshTools:\\(\\)=>${computeFn.replace(/\$/g, '\\$')}\\(${stateVar.replace(/\$/g, '\\$')}\\)`
   );
   const refreshMatch = newFile.match(refreshPattern);
   if (!refreshMatch || refreshMatch.index === undefined) {
@@ -528,7 +584,9 @@ export const writePrintToolsFilter = (
     return null;
   }
 
-  const refreshReplacement = `refreshTools:()=>{let s=${getterFn}();return __tptf(${computeFn}(s),s)}`;
+  const refreshReplacement = getterFn
+    ? `refreshTools:()=>{let s=${getterFn}(),u=${computeFn}(s);__tptu=u;return __tptf(u,s)}`
+    : `refreshTools:()=>{let u=${computeFn}(${stateVar});__tptu=u;return __tptf(u,${stateVar})}`;
   const beforeRefresh = newFile;
   newFile =
     newFile.slice(0, refreshMatch.index) +
@@ -541,6 +599,124 @@ export const writePrintToolsFilter = (
     refreshReplacement,
     refreshMatch.index,
     refreshMatch.index + refreshMatch[0].length
+  );
+
+  const canUseToolSearchStart = refreshMatch.index;
+  const canUseToolSearch = newFile.slice(
+    canUseToolSearchStart,
+    canUseToolSearchStart + 8000
+  );
+  const canUseToolMatch = canUseToolSearch.match(
+    /([,{])canUseTool:([$\w]+)(?=[,}])/
+  );
+  if (!canUseToolMatch || canUseToolMatch.index === undefined) {
+    console.error(
+      'patch: toolsets: printToolsFilter: failed to find print canUseTool'
+    );
+    return null;
+  }
+
+  const canUseToolVar = canUseToolMatch[2];
+  const canUseToolReplacement = getterFn
+    ? `${canUseToolMatch[1]}canUseTool:async(...a)=>__tptc(a[0],${getterFn}())??await ${canUseToolVar}(...a)`
+    : `${canUseToolMatch[1]}canUseTool:async(...a)=>__tptc(a[0],${stateVar})??await ${canUseToolVar}(...a)`;
+  const canUseToolIndex = canUseToolSearchStart + canUseToolMatch.index;
+  const beforeCanUseTool = newFile;
+  newFile =
+    newFile.slice(0, canUseToolIndex) +
+    canUseToolReplacement +
+    newFile.slice(canUseToolIndex + canUseToolMatch[0].length);
+
+  showDiff(
+    beforeCanUseTool,
+    newFile,
+    canUseToolReplacement,
+    canUseToolIndex,
+    canUseToolIndex + canUseToolMatch[0].length
+  );
+
+  const agentToolsSearchStart = canUseToolIndex;
+  const agentToolsSearch = newFile.slice(
+    agentToolsSearchStart,
+    agentToolsSearchStart + 12000
+  );
+  const agentToolsMatch = agentToolsSearch.match(
+    /availableTools:([$\w]+)(?=,[$\w]+:|,\.\.\.)/
+  );
+  if (agentToolsMatch?.index !== undefined) {
+    const agentToolsIndex = agentToolsSearchStart + agentToolsMatch.index;
+    const agentToolsReplacement = 'availableTools:__tptu';
+    const beforeAgentTools = newFile;
+    newFile =
+      newFile.slice(0, agentToolsIndex) +
+      agentToolsReplacement +
+      newFile.slice(agentToolsIndex + agentToolsMatch[0].length);
+
+    showDiff(
+      beforeAgentTools,
+      newFile,
+      agentToolsReplacement,
+      agentToolsIndex,
+      agentToolsIndex + agentToolsMatch[0].length
+    );
+  }
+
+  return newFile;
+};
+
+export const writeSubagentResolvedToolContextFix = (
+  oldFile: string
+): string => {
+  const pattern =
+    /tools:([$\w]+),commands:\[\]([\s\S]{0,4500}?)canUseTool:([$\w]+),toolUseContext:([$\w]+),querySource:([$\w]+),spawnedBySkill:/;
+  const match = oldFile.match(pattern);
+  if (!match || match.index === undefined) return oldFile;
+
+  const replacement = `tools:${match[1]},commands:[]${match[2]}canUseTool:async(...a)=>${match[1]}.some(t=>t.name===a[0]?.name)?{behavior:"allow",decisionReason:{type:"other",reason:"subagent_toolset"}}:await ${match[3]}(...a),toolUseContext:{...${match[4]},options:{...${match[4]}.options,tools:${match[1]}}},querySource:${match[5]},spawnedBySkill:`;
+  const newFile =
+    oldFile.slice(0, match.index) +
+    replacement +
+    oldFile.slice(match.index + match[0].length);
+
+  showDiff(
+    oldFile,
+    newFile,
+    replacement,
+    match.index,
+    match.index + match[0].length
+  );
+
+  return newFile;
+};
+
+export const writeTaskAgentFrontmatterToolsFix = (oldFile: string): string => {
+  const pattern =
+    /([,;])([$\w]+)=([$\w]+)\(([$\w]+),([$\w]+)\(([$\w]+)\.mcp\.tools\.concat\(([$\w]+)\)\),\{skipReplFilter:!0,skillTools:\6\.skillTools\}\)(?=,[$\w]+=)/;
+  const match = oldFile.match(pattern);
+  if (!match || match.index === undefined) return oldFile;
+
+  const prefix = oldFile.slice(Math.max(0, match.index - 1200), match.index);
+  const nativeToolsVar = match[7].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (
+    !new RegExp(`${nativeToolsVar}=.*?\\.options\\.tools\\.filter\\(`).test(
+      prefix
+    )
+  ) {
+    return oldFile;
+  }
+
+  const replacement = `${match[1]}${match[2]}=${match[6]}.mcp.tools.concat(${match[7]})`;
+  const newFile =
+    oldFile.slice(0, match.index) +
+    replacement +
+    oldFile.slice(match.index + match[0].length);
+
+  showDiff(
+    oldFile,
+    newFile,
+    replacement,
+    match.index,
+    match.index + match[0].length
   );
 
   return newFile;
@@ -636,7 +812,8 @@ export const writeToolsetAwareErrors = (
 export const writeToolsetComponentDefinition = (
   oldFile: string,
   toolsets: Toolset[],
-  defaultToolset: string | null
+  defaultToolset: string | null,
+  planModeToolset?: string | null
 ): string | null => {
   const insertionPoint = findTopLevelPositionBeforeSlashCommand(oldFile);
   if (insertionPoint === null) {
@@ -703,13 +880,15 @@ export const writeToolsetComponentDefinition = (
     }))
   );
 
-  const fallback = defaultToolset
-    ? JSON.stringify(defaultToolset)
-    : 'undefined';
+  const fallback = getToolsetFallbackExpression(
+    'state',
+    defaultToolset,
+    planModeToolset
+  );
 
   // Generate the component code
   const componentCode = `const toolsetComp = ({ onExit, input }) => {
-  const currentToolset = ${appStateUseSelectorFn}(state => state.toolset) ?? ${fallback};
+  const currentToolset = ${appStateUseSelectorFn}(state => ${fallback});
 
   const setState = ${appStateSetState}();
 
@@ -719,7 +898,7 @@ export const writeToolsetComponentDefinition = (
       onExit(${chalkVar}.red(\`\${${chalkVar}.bold(input)} is not a valid toolset. Valid toolsets: ${toolsets.map(t => t.name).join(', ')}\`));
       return;
     } else {
-      setState(prev => ({ ...prev, toolset: input }));
+      setState(prev => ({ ...prev, toolset: input, toolsetAutoMode: null }));
       onExit(\`Toolset changed to \${${chalkVar}.bold(input)}\`);
       return;
     }
@@ -765,7 +944,7 @@ export const writeToolsetComponentDefinition = (
         ${reactVar}.createElement(${selectComponent}, {
           options: ${selectOptions},
           onChange: (input) => {
-            setState(prev => ({ ...prev, toolset: input }));
+            setState(prev => ({ ...prev, toolset: input, toolsetAutoMode: null }));
             onExit(\`Toolset changed to \${${chalkVar}.bold(input)}\`);
           },
           onCancel: () => onExit(\`Toolset not changed (left as \${${chalkVar}.bold(currentToolset)})\`)
@@ -841,7 +1020,8 @@ export const findShiftTabAppStateVarInsertionPoint = (
  */
 export const insertShiftTabAppStateVar = (
   oldFile: string,
-  defaultToolset: string | null
+  defaultToolset: string | null,
+  planModeToolset?: string | null
 ): string | null => {
   const insertionPoint = findShiftTabAppStateVarInsertionPoint(oldFile);
   if (insertionPoint === null) {
@@ -860,10 +1040,12 @@ export const insertShiftTabAppStateVar = (
   }
 
   const { appStateUseSelectorFn } = stateInfo;
-  const fallback = defaultToolset
-    ? JSON.stringify(defaultToolset)
-    : 'undefined';
-  const codeToInsert = `let currentToolset=${appStateUseSelectorFn}(state => state.toolset) ?? ${fallback};`;
+  const fallback = getToolsetFallbackExpression(
+    'state',
+    defaultToolset,
+    planModeToolset
+  );
+  const codeToInsert = `let currentToolset=${appStateUseSelectorFn}(state => ${fallback});`;
 
   const newFile =
     oldFile.slice(0, insertionPoint) +
@@ -1025,7 +1207,8 @@ export const findToolChangeComponentScope = (
  */
 export const addCurrentToolsetAtToolChangeComponentScope = (
   oldFile: string,
-  defaultToolset: string | null
+  defaultToolset: string | null,
+  planModeToolset?: string | null
 ): string | null => {
   const scopeIndex = findToolChangeComponentScope(oldFile);
   if (scopeIndex === null) {
@@ -1041,12 +1224,14 @@ export const addCurrentToolsetAtToolChangeComponentScope = (
   }
 
   const { appStateUseSelectorFn } = stateInfo;
-  const fallback = defaultToolset
-    ? JSON.stringify(defaultToolset)
-    : 'undefined';
+  const fallback = getToolsetFallbackExpression(
+    'state',
+    defaultToolset,
+    planModeToolset
+  );
 
   // Inject the currentToolset access right at the start of the component scope
-  const injectionCode = `const currentToolset = ${appStateUseSelectorFn}(state => state.toolset) ?? ${fallback};`;
+  const injectionCode = `const currentToolset = ${appStateUseSelectorFn}(state => ${fallback});`;
 
   const newFile =
     oldFile.slice(0, scopeIndex) + injectionCode + oldFile.slice(scopeIndex);
@@ -1100,7 +1285,7 @@ export const writeModeChangeUpdateToolset = (
   const { index: modeChangeIndex, modeVar, setStateVar } = modeChangeResult;
 
   // Build the injection code using setState directly
-  const injectionCode = `if(${modeVar}==="plan"){${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(planModeToolset)}}));}else{${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(defaultToolset)}}));}`;
+  const injectionCode = `if(${modeVar}==="plan"){${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(planModeToolset)},toolsetAutoMode:"plan"}));}else{${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(defaultToolset)},toolsetAutoMode:null}));}`;
 
   // Inject right before the mode change
   const newFile =
@@ -1147,25 +1332,43 @@ export const writeToolsets = (
   }
 
   // Step 2: Modify tool fetching useMemo
-  result = writeToolFetchingUseMemo(result, toolsets, defaultToolset);
+  result = writeToolFetchingUseMemo(
+    result,
+    toolsets,
+    defaultToolset,
+    planModeToolset
+  );
   if (!result) {
     console.error('patch: toolsets: step 2 failed (writeToolFetchingUseMemo)');
     return null;
   }
 
   // Step 2b: Patch computeTools() to filter API-bound tools
-  result = writeComputeToolsFilter(result, toolsets, defaultToolset);
+  result = writeComputeToolsFilter(
+    result,
+    toolsets,
+    defaultToolset,
+    planModeToolset
+  );
   if (!result) {
     console.error('patch: toolsets: step 2b failed (writeComputeToolsFilter)');
     return null;
   }
 
   // Step 2c: Patch the non-interactive --print tool context
-  result = writePrintToolsFilter(result, toolsets, defaultToolset);
+  result = writePrintToolsFilter(
+    result,
+    toolsets,
+    defaultToolset,
+    planModeToolset
+  );
   if (!result) {
     console.error('patch: toolsets: step 2c failed (writePrintToolsFilter)');
     return null;
   }
+
+  result = writeTaskAgentFrontmatterToolsFix(result);
+  result = writeSubagentResolvedToolContextFix(result);
 
   // Step 2d: Patch "No such tool available" error messages to be toolset-aware
   const result2d = writeToolsetAwareErrors(result, toolsets, defaultToolset);
@@ -1178,7 +1381,12 @@ export const writeToolsets = (
   }
 
   // Step 3: Add toolset component definition
-  result = writeToolsetComponentDefinition(result, toolsets, defaultToolset);
+  result = writeToolsetComponentDefinition(
+    result,
+    toolsets,
+    defaultToolset,
+    planModeToolset
+  );
   if (!result) {
     console.error(
       'patch: toolsets: step 3 failed (writeToolsetComponentDefinition)'
@@ -1196,7 +1404,7 @@ export const writeToolsets = (
   }
 
   // Step 5: Insert state getter in statusline component
-  result = insertShiftTabAppStateVar(result, defaultToolset);
+  result = insertShiftTabAppStateVar(result, defaultToolset, planModeToolset);
   if (!result) {
     console.error('patch: toolsets: step 5 failed (insertShiftTabAppStateVar)');
     return null;
@@ -1225,7 +1433,8 @@ export const writeToolsets = (
     // First, add setState access at the tool change component scope
     result = addCurrentToolsetAtToolChangeComponentScope(
       result,
-      defaultToolset
+      defaultToolset,
+      planModeToolset
     );
     if (!result) {
       console.error(

--- a/src/patches/toolsets.ts
+++ b/src/patches/toolsets.ts
@@ -61,17 +61,21 @@ export const findSelectComponentName = (
 const getToolsetFallbackExpression = (
   stateExpression: string,
   defaultToolset: string | null,
+  acceptEditsToolset?: string | null,
   planModeToolset?: string | null
 ): string => {
   const defaultValue = defaultToolset
     ? JSON.stringify(defaultToolset)
     : 'undefined';
+  const acceptEditsValue = acceptEditsToolset
+    ? JSON.stringify(acceptEditsToolset)
+    : defaultValue;
   const planValue = planModeToolset
     ? JSON.stringify(planModeToolset)
     : defaultValue;
 
-  if (planModeToolset) {
-    return `${stateExpression}.toolPermissionContext?.mode!=="plan"&&${stateExpression}.toolsetAutoMode==="plan"?${defaultValue}:(${stateExpression}.toolset??(${stateExpression}.toolPermissionContext?.mode==="plan"?${planValue}:${defaultValue}))`;
+  if (acceptEditsToolset || planModeToolset) {
+    return `${stateExpression}.toolPermissionContext?.mode!=="plan"&&${stateExpression}.toolsetAutoMode==="plan"?${defaultValue}:(${stateExpression}.toolset??(${stateExpression}.toolPermissionContext?.mode==="plan"?${planValue}:(${stateExpression}.toolPermissionContext?.mode==="acceptEdits"?${acceptEditsValue}:${defaultValue})))`;
   }
 
   return `${stateExpression}.toolset??${defaultValue}`;
@@ -334,6 +338,7 @@ export const writeToolFetchingUseMemo = (
   oldFile: string,
   toolsets: Toolset[],
   defaultToolset: string | null,
+  acceptEditsToolset?: string | null,
   planModeToolset?: string | null
 ): string | null => {
   const stateInfo = getAppStateSelectorAndUseState(oldFile);
@@ -374,6 +379,7 @@ export const writeToolFetchingUseMemo = (
   const fallback = getToolsetFallbackExpression(
     'state',
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
 
@@ -424,6 +430,7 @@ export const writeComputeToolsFilter = (
   oldFile: string,
   toolsets: Toolset[],
   defaultToolset: string | null,
+  acceptEditsToolset?: string | null,
   planModeToolset?: string | null
 ): string | null => {
   const stateInfo = getAppStateSelectorAndUseState(oldFile);
@@ -477,6 +484,7 @@ export const writeComputeToolsFilter = (
   const fallback = getToolsetFallbackExpression(
     stateVar,
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
 
@@ -521,6 +529,7 @@ export const writePrintToolsFilter = (
   oldFile: string,
   toolsets: Toolset[],
   defaultToolset: string | null,
+  acceptEditsToolset?: string | null,
   planModeToolset?: string | null
 ): string | null => {
   const toolsetsJSON = JSON.stringify(
@@ -534,6 +543,7 @@ export const writePrintToolsFilter = (
   const fallback = getToolsetFallbackExpression(
     's',
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
 
@@ -813,6 +823,7 @@ export const writeToolsetComponentDefinition = (
   oldFile: string,
   toolsets: Toolset[],
   defaultToolset: string | null,
+  acceptEditsToolset?: string | null,
   planModeToolset?: string | null
 ): string | null => {
   const insertionPoint = findTopLevelPositionBeforeSlashCommand(oldFile);
@@ -883,6 +894,7 @@ export const writeToolsetComponentDefinition = (
   const fallback = getToolsetFallbackExpression(
     'state',
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
 
@@ -1021,6 +1033,7 @@ export const findShiftTabAppStateVarInsertionPoint = (
 export const insertShiftTabAppStateVar = (
   oldFile: string,
   defaultToolset: string | null,
+  acceptEditsToolset?: string | null,
   planModeToolset?: string | null
 ): string | null => {
   const insertionPoint = findShiftTabAppStateVarInsertionPoint(oldFile);
@@ -1043,6 +1056,7 @@ export const insertShiftTabAppStateVar = (
   const fallback = getToolsetFallbackExpression(
     'state',
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
   const codeToInsert = `let currentToolset=${appStateUseSelectorFn}(state => ${fallback});`;
@@ -1208,6 +1222,7 @@ export const findToolChangeComponentScope = (
 export const addCurrentToolsetAtToolChangeComponentScope = (
   oldFile: string,
   defaultToolset: string | null,
+  acceptEditsToolset?: string | null,
   planModeToolset?: string | null
 ): string | null => {
   const scopeIndex = findToolChangeComponentScope(oldFile);
@@ -1227,6 +1242,7 @@ export const addCurrentToolsetAtToolChangeComponentScope = (
   const fallback = getToolsetFallbackExpression(
     'state',
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
 
@@ -1274,8 +1290,9 @@ export const findModeChange = (
  */
 export const writeModeChangeUpdateToolset = (
   oldFile: string,
-  planModeToolset: string,
-  defaultToolset: string
+  defaultToolset: string,
+  acceptEditsToolset: string,
+  planModeToolset: string
 ): string | null => {
   const modeChangeResult = findModeChange(oldFile);
   if (!modeChangeResult) {
@@ -1285,7 +1302,7 @@ export const writeModeChangeUpdateToolset = (
   const { index: modeChangeIndex, modeVar, setStateVar } = modeChangeResult;
 
   // Build the injection code using setState directly
-  const injectionCode = `if(${modeVar}==="plan"){${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(planModeToolset)},toolsetAutoMode:"plan"}));}else{${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(defaultToolset)},toolsetAutoMode:null}));}`;
+  const injectionCode = `if(${modeVar}==="plan"){${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(planModeToolset)},toolsetAutoMode:"plan"}));}else if(${modeVar}==="acceptEdits"){${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(acceptEditsToolset)},toolsetAutoMode:null}));}else{${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(defaultToolset)},toolsetAutoMode:null}));}`;
 
   // Inject right before the mode change
   const newFile =
@@ -1306,13 +1323,15 @@ export const writeModeChangeUpdateToolset = (
  * Apply all toolset patches to the file
  * @param oldFile - The file content to patch
  * @param toolsets - Array of toolset configurations
- * @param defaultToolset - The default toolset name (or null)
+ * @param defaultToolset - Optional toolset to use in default Shift+Tab mode
+ * @param acceptEditsToolset - Optional toolset to use in accept-edits Shift+Tab mode
  * @param planModeToolset - Optional toolset to switch to when entering plan mode
  */
 export const writeToolsets = (
   oldFile: string,
   toolsets: Toolset[],
   defaultToolset: string | null,
+  acceptEditsToolset?: string | null,
   planModeToolset?: string | null
 ): string | null => {
   // Return if no toolsets are configured
@@ -1336,6 +1355,7 @@ export const writeToolsets = (
     result,
     toolsets,
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
   if (!result) {
@@ -1348,6 +1368,7 @@ export const writeToolsets = (
     result,
     toolsets,
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
   if (!result) {
@@ -1360,6 +1381,7 @@ export const writeToolsets = (
     result,
     toolsets,
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
   if (!result) {
@@ -1385,6 +1407,7 @@ export const writeToolsets = (
     result,
     toolsets,
     defaultToolset,
+    acceptEditsToolset,
     planModeToolset
   );
   if (!result) {
@@ -1404,7 +1427,12 @@ export const writeToolsets = (
   }
 
   // Step 5: Insert state getter in statusline component
-  result = insertShiftTabAppStateVar(result, defaultToolset, planModeToolset);
+  result = insertShiftTabAppStateVar(
+    result,
+    defaultToolset,
+    acceptEditsToolset,
+    planModeToolset
+  );
   if (!result) {
     console.error('patch: toolsets: step 5 failed (insertShiftTabAppStateVar)');
     return null;
@@ -1429,12 +1457,16 @@ export const writeToolsets = (
   }
 
   // Step 8: Mode-change toolset switching (optional)
-  if (planModeToolset && defaultToolset) {
+  if (defaultToolset && (acceptEditsToolset || planModeToolset)) {
+    const effectiveAcceptEditsToolset = acceptEditsToolset ?? defaultToolset;
+    const effectivePlanModeToolset = planModeToolset ?? defaultToolset;
+
     // First, add setState access at the tool change component scope
     result = addCurrentToolsetAtToolChangeComponentScope(
       result,
       defaultToolset,
-      planModeToolset
+      effectiveAcceptEditsToolset,
+      effectivePlanModeToolset
     );
     if (!result) {
       console.error(
@@ -1446,8 +1478,9 @@ export const writeToolsets = (
     // Then, inject the mode change toolset switching code
     result = writeModeChangeUpdateToolset(
       result,
-      planModeToolset,
-      defaultToolset
+      defaultToolset,
+      effectiveAcceptEditsToolset,
+      effectivePlanModeToolset
     );
     if (!result) {
       console.error(

--- a/src/patches/toolsets.ts
+++ b/src/patches/toolsets.ts
@@ -505,7 +505,7 @@ export const writeComputeToolsFilter = (
   const initVar = mergeCallMatch[1];
 
   // Set globalThis.__tweakcc_toolset so the error message helper can read it
-  const newClosure = `${closureVar}=${useCallbackPrefix}()=>{let ${stateVar}=${storeVar}.getState(),${assembledVar}=${assembleFn}(${stateVar}.toolPermissionContext,${stateVar}.mcp.tools${skillToolsArg}),${mergedVar}=${mergeFn}(${initVar},${assembledVar},${stateVar}.toolPermissionContext.mode);const __ts=${toolsetsJSON},__tc=${fallback},__tf=(t)=>{globalThis.__tweakcc_toolset={name:__tc,tools:__ts[__tc]};if(__ts.hasOwnProperty(__tc)){const a=__ts[__tc];if(a==="*")return t;return t.filter(d=>a.includes(d.name))}return t};if(!${agentVar})return __tf(${mergedVar});return ${resolveFn}(${agentVar},${mergedVar},!1,!0).resolvedTools}`;
+  const newClosure = `${closureVar}=${useCallbackPrefix}()=>{let ${stateVar}=${storeVar}.getState(),${assembledVar}=${assembleFn}(${stateVar}.toolPermissionContext,${stateVar}.mcp.tools${skillToolsArg}),${mergedVar}=${mergeFn}(${initVar},${assembledVar},${stateVar}.toolPermissionContext.mode);const __ts=${toolsetsJSON},__tc=${fallback},__tf=(t)=>{globalThis.__tweakcc_toolset={name:__tc,tools:__ts[__tc]};if(__ts.hasOwnProperty(__tc)){const a=__ts[__tc];if(a==="*")return t;return t.filter(d=>d.name==="Skill"||a.includes(d.name))}return t};if(!${agentVar})return __tf(${mergedVar});return ${resolveFn}(${agentVar},${mergedVar},!1,!0).resolvedTools}`;
 
   const startIndex = match.index;
   const endIndex = startIndex + fullMatch.length;
@@ -566,7 +566,7 @@ export const writePrintToolsFilter = (
   const stateVar = match[3];
   const getterFn = resolverMatch ? match[4] : null;
 
-  const filterCode = `let ${toolsVar}=${computeFn}(${stateVar}),__tptu=${toolsVar};const __tpts=${toolsetsJSON},__tptf=(t,s)=>{const n=${fallback};globalThis.__tweakcc_toolset={name:n,tools:__tpts[n]};if(__tpts.hasOwnProperty(n)){const a=__tpts[n];if(a==="*")return t;return t.filter(d=>a.includes(d.name))}return t},__tptc=(tool,s)=>{const n=${fallback};globalThis.__tweakcc_toolset={name:n,tools:__tpts[n]};if(__tpts.hasOwnProperty(n)){const a=__tpts[n];if(a==="*")return null;if(tool&&Array.isArray(a)&&!a.includes(tool.name))return{behavior:"deny",message:__tweakcc_toolErrorMsg(tool.name),decisionReason:{type:"other",reason:"toolset"}}}return null};${toolsVar}=__tptf(${toolsVar},${stateVar});`;
+  const filterCode = `let ${toolsVar}=${computeFn}(${stateVar}),__tptu=${toolsVar};const __tpts=${toolsetsJSON},__tptf=(t,s)=>{const n=${fallback};globalThis.__tweakcc_toolset={name:n,tools:__tpts[n]};if(__tpts.hasOwnProperty(n)){const a=__tpts[n];if(a==="*")return t;return t.filter(d=>d.name==="Skill"||a.includes(d.name))}return t},__tptc=(tool,s)=>{const n=${fallback};globalThis.__tweakcc_toolset={name:n,tools:__tpts[n]};if(__tpts.hasOwnProperty(n)){const a=__tpts[n];if(a==="*")return null;if(tool&&tool.name!=="Skill"&&Array.isArray(a)&&!a.includes(tool.name))return{behavior:"deny",message:__tweakcc_toolErrorMsg(tool.name),decisionReason:{type:"other",reason:"toolset"}}}return null};${toolsVar}=__tptf(${toolsVar},${stateVar});`;
 
   let newFile =
     oldFile.slice(0, match.index) +
@@ -1075,29 +1075,33 @@ export const insertShiftTabAppStateVar = (
  * Append the toolset name to the mode display text
  */
 export const appendToolsetToModeDisplay = (oldFile: string): string | null => {
-  // Find the pattern where mode text is rendered
-  // Looking for: tl(Y).toLowerCase(), " on"
-  // We want to change it to: tl(Y).toLowerCase(), " on: ", currentToolset || "undefined"
+  // Find every site where the mode text is rendered:
+  //   tl(Y).toLowerCase(), " on"
+  // Newer CC versions render the footer mode line from more than one of
+  // these sites (e.g. a variant with the "(shift+tab to cycle)" chord), so
+  // patch all of them. insertShiftTabAppStateVar defines `currentToolset`
+  // (a live app-state selector) in the enclosing component scope.
+  const modeDisplayPattern = /([$\w]+)\(([$\w]+)\)\.toLowerCase\(\)," on"/g;
+  const matches = Array.from(oldFile.matchAll(modeDisplayPattern));
 
-  const modeDisplayPattern = /([$\w]+)\(([$\w]+)\)\.toLowerCase\(\)," on"/;
-  const match = oldFile.match(modeDisplayPattern);
-
-  if (!match || match.index === undefined) {
+  if (matches.length === 0) {
     console.error(
       'patch: toolsets: appendToolsetToModeDisplay: failed to find mode display pattern'
     );
     return null;
   }
 
-  const tlFunction = match[1];
-  const modeVar = match[2];
-
-  // Replace with the new pattern that includes toolset
-  const oldText = match[0];
-  // insertShiftTabAppStateVar provides the definition for currentToolset.
-  const newText = `${tlFunction}(${modeVar}).toLowerCase(),currentToolset?\` on [\${currentToolset}]\`:""`;
-
-  const newFile = oldFile.replace(oldText, newText);
+  let newFile = oldFile;
+  for (const match of [...matches].reverse()) {
+    if (match.index === undefined) continue;
+    const tlFunction = match[1];
+    const modeVar = match[2];
+    const newText = `${tlFunction}(${modeVar}).toLowerCase(),currentToolset?\` on [\${currentToolset}]\`:""`;
+    newFile =
+      newFile.slice(0, match.index) +
+      newText +
+      newFile.slice(match.index + match[0].length);
+  }
 
   if (newFile === oldFile) {
     console.error(
@@ -1106,12 +1110,13 @@ export const appendToolsetToModeDisplay = (oldFile: string): string | null => {
     return null;
   }
 
+  const lastMatch = matches[matches.length - 1];
   showDiff(
     oldFile,
     newFile,
-    newText,
-    match.index,
-    match.index + oldText.length
+    'currentToolset?` on [${currentToolset}]`:""',
+    lastMatch.index ?? 0,
+    (lastMatch.index ?? 0) + lastMatch[0].length
   );
 
   return newFile;

--- a/src/patches/toolsets.ts
+++ b/src/patches/toolsets.ts
@@ -64,21 +64,21 @@ const getToolsetFallbackExpression = (
   acceptEditsToolset?: string | null,
   planModeToolset?: string | null
 ): string => {
-  const defaultValue = defaultToolset
-    ? JSON.stringify(defaultToolset)
-    : 'undefined';
-  const acceptEditsValue = acceptEditsToolset
-    ? JSON.stringify(acceptEditsToolset)
-    : defaultValue;
-  const planValue = planModeToolset
-    ? JSON.stringify(planModeToolset)
-    : defaultValue;
+  // Each mode binding can be forced at CC start via runtime environment
+  // variables (read by the patched cli.js, so no re-apply is needed). They
+  // override the bindings configured in the tweakcc menu (#569).
+  const defaultValue = `(process.env.TWEAKCC_TOOLSET_DEFAULT||${
+    defaultToolset ? JSON.stringify(defaultToolset) : 'undefined'
+  })`;
+  const acceptEditsValue = `(process.env.TWEAKCC_TOOLSET_ALLOW_EDITS||${
+    acceptEditsToolset ? JSON.stringify(acceptEditsToolset) : defaultValue
+  })`;
+  const planValue = `(process.env.TWEAKCC_TOOLSET_PLAN||${
+    planModeToolset ? JSON.stringify(planModeToolset) : defaultValue
+  })`;
+  const autoValue = `(process.env.TWEAKCC_TOOLSET_AUTO||${defaultValue})`;
 
-  if (acceptEditsToolset || planModeToolset) {
-    return `${stateExpression}.toolPermissionContext?.mode!=="plan"&&${stateExpression}.toolsetAutoMode==="plan"?${defaultValue}:(${stateExpression}.toolset??(${stateExpression}.toolPermissionContext?.mode==="plan"?${planValue}:(${stateExpression}.toolPermissionContext?.mode==="acceptEdits"?${acceptEditsValue}:${defaultValue})))`;
-  }
-
-  return `${stateExpression}.toolset??${defaultValue}`;
+  return `${stateExpression}.toolPermissionContext?.mode!=="plan"&&${stateExpression}.toolsetAutoMode==="plan"?${defaultValue}:(${stateExpression}.toolset??(${stateExpression}.toolPermissionContext?.mode==="plan"?${planValue}:(${stateExpression}.toolPermissionContext?.mode==="acceptEdits"?${acceptEditsValue}:(${stateExpression}.toolPermissionContext?.mode==="auto"?${autoValue}:${defaultValue}))))`;
 };
 
 /**
@@ -283,10 +283,7 @@ export const findTopLevelPositionBeforeSlashCommand = (
 /**
  * Sub-patch 1: Add toolset field to app state initialization
  */
-export const writeToolsetFieldToAppState = (
-  oldFile: string,
-  defaultToolset: string | null
-): string | null => {
+export const writeToolsetFieldToAppState = (oldFile: string): string | null => {
   // Find all occurrences of thinkingEnabled:SOMETHING()
   const thinkingEnabledPattern = /thinkingEnabled:([$\w]+)\(\)/g;
   const matches = Array.from(oldFile.matchAll(thinkingEnabledPattern));
@@ -310,10 +307,12 @@ export const writeToolsetFieldToAppState = (
 
   // Apply modifications
   let newFile = oldFile;
-  const toolsetValue = defaultToolset
-    ? JSON.stringify(defaultToolset)
-    : 'undefined';
-  const textToInsert = `,toolset:${toolsetValue},toolsetAutoMode:null`;
+  // Initialize toolset to undefined (NOT the default toolset name): every
+  // read site uses `state.toolset ?? <mode-aware fallback>`, so a non-null
+  // initial value would short-circuit the fallback and the toolset bound to
+  // the startup permission mode (e.g. --permission-mode plan) would never
+  // apply at load (#569). Shift+Tab and /toolset set it explicitly later.
+  const textToInsert = `,toolset:undefined,toolsetAutoMode:null`;
   for (const mod of modifications) {
     newFile =
       newFile.slice(0, mod.index) + textToInsert + newFile.slice(mod.index);
@@ -504,8 +503,11 @@ export const writeComputeToolsFilter = (
   }
   const initVar = mergeCallMatch[1];
 
-  // Set globalThis.__tweakcc_toolset so the error message helper can read it
-  const newClosure = `${closureVar}=${useCallbackPrefix}()=>{let ${stateVar}=${storeVar}.getState(),${assembledVar}=${assembleFn}(${stateVar}.toolPermissionContext,${stateVar}.mcp.tools${skillToolsArg}),${mergedVar}=${mergeFn}(${initVar},${assembledVar},${stateVar}.toolPermissionContext.mode);const __ts=${toolsetsJSON},__tc=${fallback},__tf=(t)=>{globalThis.__tweakcc_toolset={name:__tc,tools:__ts[__tc]};if(__ts.hasOwnProperty(__tc)){const a=__ts[__tc];if(a==="*")return t;return t.filter(d=>d.name==="Skill"||a.includes(d.name))}return t};if(!${agentVar})return __tf(${mergedVar});return ${resolveFn}(${agentVar},${mergedVar},!1,!0).resolvedTools}`;
+  // Set globalThis.__tweakcc_toolset so the error message helper can read it.
+  // Agents with an explicit `tools:` frontmatter list get the unfiltered pool
+  // (their declared tools win — #597); agents without one inherit the active
+  // toolset by resolving against the filtered pool instead of everything.
+  const newClosure = `${closureVar}=${useCallbackPrefix}()=>{let ${stateVar}=${storeVar}.getState(),${assembledVar}=${assembleFn}(${stateVar}.toolPermissionContext,${stateVar}.mcp.tools${skillToolsArg}),${mergedVar}=${mergeFn}(${initVar},${assembledVar},${stateVar}.toolPermissionContext.mode);const __ts=${toolsetsJSON},__tc=${fallback},__tf=(t)=>{globalThis.__tweakcc_toolset={name:__tc,tools:__ts[__tc]};if(__ts.hasOwnProperty(__tc)){const a=__ts[__tc];if(a==="*")return t;return t.filter(d=>d.name==="Skill"||a.includes(d.name))}return t};if(!${agentVar})return __tf(${mergedVar});return ${resolveFn}(${agentVar},${agentVar}.tools?${mergedVar}:__tf(${mergedVar}),!1,!0).resolvedTools}`;
 
   const startIndex = match.index;
   const endIndex = startIndex + fullMatch.length;
@@ -1306,8 +1308,9 @@ export const writeModeChangeUpdateToolset = (
 
   const { index: modeChangeIndex, modeVar, setStateVar } = modeChangeResult;
 
-  // Build the injection code using setState directly
-  const injectionCode = `if(${modeVar}==="plan"){${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(planModeToolset)},toolsetAutoMode:"plan"}));}else if(${modeVar}==="acceptEdits"){${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(acceptEditsToolset)},toolsetAutoMode:null}));}else{${setStateVar}((prev)=>({...prev,toolset:${JSON.stringify(defaultToolset)},toolsetAutoMode:null}));}`;
+  // Build the injection code using setState directly. Each binding can be
+  // forced at CC start via TWEAKCC_TOOLSET_* env vars (#569).
+  const injectionCode = `if(${modeVar}==="plan"){${setStateVar}((prev)=>({...prev,toolset:process.env.TWEAKCC_TOOLSET_PLAN||${JSON.stringify(planModeToolset)},toolsetAutoMode:"plan"}));}else if(${modeVar}==="acceptEdits"){${setStateVar}((prev)=>({...prev,toolset:process.env.TWEAKCC_TOOLSET_ALLOW_EDITS||${JSON.stringify(acceptEditsToolset)},toolsetAutoMode:null}));}else if(${modeVar}==="auto"){${setStateVar}((prev)=>({...prev,toolset:process.env.TWEAKCC_TOOLSET_AUTO||process.env.TWEAKCC_TOOLSET_DEFAULT||${JSON.stringify(defaultToolset)},toolsetAutoMode:null}));}else{${setStateVar}((prev)=>({...prev,toolset:process.env.TWEAKCC_TOOLSET_DEFAULT||${JSON.stringify(defaultToolset)},toolsetAutoMode:null}));}`;
 
   // Inject right before the mode change
   const newFile =
@@ -1347,7 +1350,7 @@ export const writeToolsets = (
   let result: string | null = oldFile;
 
   // Step 1: Add toolset field to app state
-  result = writeToolsetFieldToAppState(result, defaultToolset);
+  result = writeToolsetFieldToAppState(result);
   if (!result) {
     console.error(
       'patch: toolsets: step 1 failed (writeToolsetFieldToAppState)'

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,7 @@ export interface Settings {
   misc: MiscConfig;
   toolsets: Toolset[];
   defaultToolset: string | null;
+  acceptEditsToolset: string | null;
   planModeToolset: string | null;
   subagentModels: SubagentModelsConfig;
   inputPatternHighlighters: InputPatternHighlighter[];

--- a/src/ui/components/ToolsetEditView.tsx
+++ b/src/ui/components/ToolsetEditView.tsx
@@ -68,6 +68,9 @@ export function ToolsetEditView({
           if (settings.defaultToolset === oldName) {
             settings.defaultToolset = name;
           }
+          if (settings.acceptEditsToolset === oldName) {
+            settings.acceptEditsToolset = name;
+          }
           if (settings.planModeToolset === oldName) {
             settings.planModeToolset = name;
           }

--- a/src/ui/components/ToolsetsView.tsx
+++ b/src/ui/components/ToolsetsView.tsx
@@ -15,7 +15,13 @@ interface ToolsetsViewProps {
 
 export function ToolsetsView({ onBack }: ToolsetsViewProps) {
   const {
-    settings: { toolsets, defaultToolset, planModeToolset, themes },
+    settings: {
+      toolsets,
+      defaultToolset,
+      acceptEditsToolset,
+      planModeToolset,
+      themes,
+    },
     updateSettings,
   } = useContext(SettingsContext);
 
@@ -57,6 +63,10 @@ export function ToolsetsView({ onBack }: ToolsetsViewProps) {
       if (settings.defaultToolset === toolsetToDelete.name) {
         settings.defaultToolset = null;
       }
+      // Clear accept edits if we're deleting the accept edits toolset
+      if (settings.acceptEditsToolset === toolsetToDelete.name) {
+        settings.acceptEditsToolset = null;
+      }
       // Clear plan mode if we're deleting the plan mode toolset
       if (settings.planModeToolset === toolsetToDelete.name) {
         settings.planModeToolset = null;
@@ -72,6 +82,13 @@ export function ToolsetsView({ onBack }: ToolsetsViewProps) {
     const toolset = toolsets[index];
     updateSettings(settings => {
       settings.defaultToolset = toolset.name;
+    });
+  };
+
+  const handleSetAcceptEditsToolset = (index: number) => {
+    const toolset = toolsets[index];
+    updateSettings(settings => {
+      settings.acceptEditsToolset = toolset.name;
     });
   };
 
@@ -99,6 +116,8 @@ export function ToolsetsView({ onBack }: ToolsetsViewProps) {
         handleDeleteToolset(selectedIndex);
       } else if (input === 'd' && toolsets.length > 0) {
         handleSetDefaultToolset(selectedIndex);
+      } else if (input === 'a' && toolsets.length > 0) {
+        handleSetAcceptEditsToolset(selectedIndex);
       } else if (input === 'p' && toolsets.length > 0) {
         handleSetPlanModeToolset(selectedIndex);
       }
@@ -135,7 +154,10 @@ export function ToolsetsView({ onBack }: ToolsetsViewProps) {
       <Box marginBottom={1} flexDirection="column">
         <Text dimColor>n to create a new toolset</Text>
         {toolsets.length > 0 && (
-          <Text dimColor>d to set as default toolset</Text>
+          <Text dimColor>d to set as default mode toolset</Text>
+        )}
+        {toolsets.length > 0 && (
+          <Text dimColor>a to set as accept edits toolset</Text>
         )}
         {toolsets.length > 0 && (
           <Text dimColor>p to set as plan mode toolset</Text>
@@ -151,6 +173,7 @@ export function ToolsetsView({ onBack }: ToolsetsViewProps) {
         <Box flexDirection="column">
           {toolsets.map((toolset, index) => {
             const isDefault = toolset.name === defaultToolset;
+            const isAcceptEdits = toolset.name === acceptEditsToolset;
             const isPlanMode = toolset.name === planModeToolset;
             const isSelected = selectedIndex === index;
 
@@ -171,7 +194,8 @@ export function ToolsetsView({ onBack }: ToolsetsViewProps) {
                   ({getToolsetDescription(toolset)})
                 </Text>
 
-                {isDefault && (
+                {isDefault && <Text color={lineColor}> default</Text>}
+                {isAcceptEdits && (
                   <Text color={autoAcceptColor}> ⏵⏵ accept edits</Text>
                 )}
                 {isPlanMode && <Text color={planModeColor}> ⏸ plan mode</Text>}


### PR DESCRIPTION
Closes https://github.com/Piebald-AI/tweakcc/issues/768
Closes https://github.com/Piebald-AI/tweakcc/issues/608
Closes https://github.com/Piebald-AI/tweakcc/issues/597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mode-specific toolsets: separate toolsets for accept-edits vs plan with automatic switching and correct initial behavior; live toolset shown in footer.

* **Settings**
  * New accept-edits toolset setting added.

* **UI Updates**
  * Toolset management: assign/clear accept-edits toolset, updated default label, accept-edits indicator, propagates renames; keyboard shortcut "a" to assign.

* **Tests**
  * Added comprehensive tests for toolset filtering and mode switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->