### PR TITLE
Fix Text component detection for Claude Code 2.1.170

### DIFF
--- a/src/patches/helpers.ts
+++ b/src/patches/helpers.ts
@@ -296,7 +296,7 @@ export const findTextComponent = (fileContents: string): string | undefined => {
   // The minified Text component has this signature:
   // function X({color:A,backgroundColor:B,dimColor:C=!1,bold:D=!1,...})
   const textComponentPattern =
-    /\bfunction ([$\w]+).{0,30}color:[$\w]+,backgroundColor:[$\w]+,dimColor:[$\w]+(?:=![01])?,bold:[$\w]+(?:=![01])?/;
+    /\bfunction ([$\w]+).{0,80}?color:[$\w]+,backgroundColor:[$\w]+,dimColor:[$\w]+(?:=![01])?,bold:[$\w]+(?:=![01])?/;
   const match = fileContents.match(textComponentPattern);
   if (!match) {
     console.log('patch: findTextComponent: failed to find text component');


### PR DESCRIPTION
On Claude Code 2.1.170, `--apply` fails with:

```
patch: findTextComponent: failed to find text component
patch: patchesAppliedIndication: failed to find text component
[Refusing to repack native binary because one or more binary patches failed: patches-applied-indication]
```

The 2.1.170 bundle is now compiled with React Compiler, which inserts a memo cache preamble between the Text component's function name and the props destructure:

```js
function V(H){let _=wO7.c(31),q,K,O,T,z,$,A,Y,w,j,f;if(_[0]!==H)({color:T,backgroundColor:K,dimColor:z,bold:$,...
```

That puts ~56 chars between `function V` and `color:`, but `findTextComponent` only allows 30, so the pattern no longer matches. This widens the gap to 80 (lazily, so it still grabs the nearest match).

Verified on the 2.1.170 native build (macOS arm64): the pattern matches exactly one function (`V`, the real Text component) and all patches apply again. Tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with different bundle minifications to ensure components load correctly across various optimization levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->