### PR TITLE
Fix opusplan1m for Claude Code 2.1.175+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix toolsets for Claude Code 2.1.167+: separate acceptEdits mode binding, preserve the `Skill` tool, and show the live `[toolset]` in the footer (#778) - @basekevin
 - Apply mode-bound toolsets at program load and add `TWEAKCC_TOOLSET_DEFAULT`, `TWEAKCC_TOOLSET_ALLOW_EDITS`, `TWEAKCC_TOOLSET_PLAN`, and `TWEAKCC_TOOLSET_AUTO` env overrides (#778) - @basekevin
 - Make agents without explicit `tools:` frontmatter respect the active toolset (#778) - @basekevin
+- Fix opusplan1m for Claude Code 2.1.175+ (#798) - @basekevin
 
 ## [v4.0.14](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.0.14) - 2026-06-03
 

--- a/src/patches/opusplan1m.test.ts
+++ b/src/patches/opusplan1m.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { writeOpusplan1m } from './opusplan1m';
+
+describe('writeOpusplan1m', () => {
+  it('does not fail when mode switching already supports opusplan[1m]', () => {
+    const file = [
+      'if((A==="opusplan"||A==="opusplan[1m]")&&B==="plan"&&!C)return D();',
+      '["sonnet","opus","haiku","sonnet[1m]","opusplan"]',
+      'if(A==="opusplan")return"Opus in plan mode, else Sonnet";',
+      'if(A==="opusplan")return"Opus Plan";',
+      'if(A==="opusplan")return[...B,C()];',
+      'if(A===null||B.some((C)=>C.value===A))return B;',
+    ].join('');
+
+    const result = writeOpusplan1m(file);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('"opusplan[1m]"');
+  });
+});

--- a/src/patches/opusplan1m.ts
+++ b/src/patches/opusplan1m.ts
@@ -32,6 +32,10 @@ const patchModeSwitchingFunction = (oldFile: string): string | null => {
 
   const match = oldFile.match(pattern);
   if (!match || match.index === undefined) {
+    const nativePattern =
+      /if\s*\(\s*\(?[$\w]+\s*===\s*"opusplan"\s*\|\|\s*[$\w]+\s*===\s*"opusplan\[1m\]"\)?\s*&&\s*[$\w]+\s*===\s*"plan"\s*&&\s*![$\w]+\s*\)/;
+    if (nativePattern.test(oldFile)) return oldFile;
+
     console.error(
       'patch: opusplan1m: patchModeSwitchingFunction: failed to find mode switching pattern'
     );
@@ -69,8 +73,7 @@ const patchModeSwitchingFunction = (oldFile: string): string | null => {
  */
 const patchModelAliasesList = (oldFile: string): string | null => {
   // Pattern matches the model aliases array assignment
-  const pattern =
-    /(\["sonnet","opus","haiku",(?:"best",)?"sonnet\[1m\]",(?:"opus\[1m\]",)?"opusplan")/;
+  const pattern = /(\[(?:"[^"]+",)*"opusplan")/;
 
   const match = oldFile.match(pattern);
   if (!match || match.index === undefined) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of existing `opusplan[1m]` support to avoid unnecessary changes
  * Enhanced patching logic to better work with minified implementations and improve compatibility with newer Claude Code releases
* **Tests**
  * Added a Vitest suite to confirm `opusplan[1m]` support is recognized and that output includes the `opusplan[1m]` marker
* **Documentation**
  * Updated the Unreleased changelog with this `opusplan1m` compatibility fix
<!-- end of auto-generated comment: release notes by coderabbit.ai -->