### PR TITLE
Use an in-house Link component instead of ink-link because the latter doesn't declare react in its dep list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apply mode-bound toolsets at program load and add `TWEAKCC_TOOLSET_DEFAULT`, `TWEAKCC_TOOLSET_ALLOW_EDITS`, `TWEAKCC_TOOLSET_PLAN`, and `TWEAKCC_TOOLSET_AUTO` env overrides (#778) - @basekevin
 - Make agents without explicit `tools:` frontmatter respect the active toolset (#778) - @basekevin
 - Fix opusplan1m for Claude Code 2.1.175+ (#798) - @basekevin
+- Use an in-house Link component instead of ink-link because the latter doesn't declare react in its dep list (#800) - @bl-ue
 
 ## [v4.0.14](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.0.14) - 2026-06-03
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@types/node": "^20.19.10",
-    "@types/react": "^18.3.23",
+    "@types/react": "^19.1.1",
     "@types/which": "^3.0.4",
     "eslint": "^9.33.0",
     "eslint-plugin-react": "^7.37.5",
@@ -79,10 +79,10 @@
     "globby": "^14.1.0",
     "gray-matter": "^4.0.3",
     "ink": "^6.1.0",
-    "ink-link": "^4.1.0",
     "node-lief": "^1.3.0",
     "oxfmt": "^0.28.0",
     "react": "^19.1.1",
+    "terminal-link": "^3.0.0",
     "which": "^6.0.0"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,7 @@ importers:
         version: 4.0.3
       ink:
         specifier: ^6.1.0
-        version: 6.1.0(@types/react@18.3.23)(react@19.1.1)
-      ink-link:
-        specifier: ^4.1.0
-        version: 4.1.0(ink@6.1.0(@types/react@18.3.23)(react@19.1.1))
+        version: 6.1.0(@types/react@19.2.17)(react@19.1.1)
       node-lief:
         specifier: ^1.3.0
         version: 1.3.0
@@ -41,6 +38,9 @@ importers:
       react:
         specifier: ^19.1.1
         version: 19.1.1
+      terminal-link:
+        specifier: ^3.0.0
+        version: 3.0.0
       which:
         specifier: ^6.0.0
         version: 6.0.0
@@ -52,8 +52,8 @@ importers:
         specifier: ^20.19.10
         version: 20.19.10
       '@types/react':
-        specifier: ^18.3.23
-        version: 18.3.23
+        specifier: ^19.1.1
+        version: 19.2.17
       '@types/which':
         specifier: ^3.0.4
         version: 3.0.4
@@ -639,11 +639,8 @@ packages:
   '@types/node@20.19.10':
     resolution: {integrity: sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
-  '@types/react@18.3.23':
-    resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/which@3.0.4':
     resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
@@ -936,8 +933,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1314,12 +1311,6 @@ packages:
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
-
-  ink-link@4.1.0:
-    resolution: {integrity: sha512-3nNyJXum0FJIKAXBK8qat2jEOM41nJ1J60NRivwgK9Xh92R5UMN/k4vbz0A9xFzhJVrlf4BQEmmxMgXkCE1Jeg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      ink: '>=4'
 
   ink@6.1.0:
     resolution: {integrity: sha512-YQ+lbMD79y3FBAJXXZnuRajLEgaMFp102361eY5NrBIEVCi9oFo7gNZU4z2LBWlcjZFiTt7jetlkIbKCCH4KJA==}
@@ -2644,12 +2635,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/prop-types@15.7.15': {}
-
-  '@types/react@18.3.23':
+  '@types/react@19.2.17':
     dependencies:
-      '@types/prop-types': 15.7.15
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@types/which@3.0.4': {}
 
@@ -3000,7 +2988,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3481,13 +3469,7 @@ snapshots:
 
   indent-string@5.0.0: {}
 
-  ink-link@4.1.0(ink@6.1.0(@types/react@18.3.23)(react@19.1.1)):
-    dependencies:
-      ink: 6.1.0(@types/react@18.3.23)(react@19.1.1)
-      prop-types: 15.8.1
-      terminal-link: 3.0.0
-
-  ink@6.1.0(@types/react@18.3.23)(react@19.1.1):
+  ink@6.1.0(@types/react@19.2.17)(react@19.1.1):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.1.3
       ansi-escapes: 7.0.0
@@ -3515,7 +3497,7 @@ snapshots:
       ws: 8.18.3
       yoga-layout: 3.2.1
     optionalDependencies:
-      '@types/react': 18.3.23
+      '@types/react': 19.2.17
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4546,5 +4528,3 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoga-layout@3.2.1: {}
-
-time: {}

--- a/src/ui/components/Link.tsx
+++ b/src/ui/components/Link.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { Transform, Text } from 'ink';
+import terminalLink from 'terminal-link';
+
+interface LinkProps {
+  url: string;
+  fallback?: boolean;
+  children: React.ReactNode;
+}
+
+const Link: React.FC<LinkProps> = ({ children, url, fallback = true }) => (
+  <Transform transform={text => terminalLink(text, url, { fallback })}>
+    <Text>{children}</Text>
+  </Transform>
+);
+
+export default Link;

--- a/src/ui/components/MainView.tsx
+++ b/src/ui/components/MainView.tsx
@@ -1,11 +1,11 @@
 import * as os from 'node:os';
 
 import { Box, Text } from 'ink';
-import Link from 'ink-link';
 
 import { MainMenuItem } from '@/types';
 import { CONFIG_DIR } from '@/config';
 
+import Link from './Link';
 import Header from './Header';
 import PiebaldAnnouncement from './PiebaldAnnouncement';
 import MainMenu from './MainMenu';

--- a/src/ui/components/PiebaldAnnouncement.tsx
+++ b/src/ui/components/PiebaldAnnouncement.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from 'ink';
-import Link from 'ink-link';
+
+import Link from './Link';
 
 // Generated with `chafa <path> -f symbols -s 20 --bg=#ff8400`.
 // Changed the `\x1b[38;2;R;G;B;48;2;R;G;Bm` pattern to separate


### PR DESCRIPTION
It declares it in its `devDependencies` list but not `dependencies`, so in a strict pnpm setting it fails.

Closes #792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated React framework to v19.1.1 for improved compatibility and performance.

* **Improvements**
  * Enhanced internal link component implementation for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->