### PR TITLE
Fix system prompt application on Claude Code 2.1.179: match Latin-1 \xHH escapes

### DIFF
--- a/src/systemPromptSync.ts
+++ b/src/systemPromptSync.ts
@@ -1048,9 +1048,18 @@ const escapeNonAsciiForRegex = (text: string): string => {
   // eslint-disable-next-line no-control-regex
   return text.replace(/[^\x00-\x7F]/g, char => {
     const codePoint = char.charCodeAt(0);
-    const escaped = `\\\\u${codePoint.toString(16).padStart(4, '0')}`;
-    // Match either the literal character OR the escaped version
-    return `(?:${char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}|${escaped})`;
+    const literal = char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // Match the literal char OR its escaped forms. Minified bundles store BMP
+    // non-ASCII as \uXXXX, but Latin-1 chars (0x80–0xFF) are emitted as \xHH
+    // (2-digit hex, e.g. "·" -> \xB7, "×" -> \xD7). The search regex's 'i' flag
+    // handles upper/lowercase hex. Without the \xHH alternative, any prompt
+    // containing such a character (·, ×, °, é, …) fails to match on recent
+    // Claude Code builds, so the whole prompt is skipped.
+    const alts = [literal, `\\\\u${codePoint.toString(16).padStart(4, '0')}`];
+    if (codePoint >= 0x80 && codePoint <= 0xff) {
+      alts.push(`\\\\x${codePoint.toString(16).padStart(2, '0')}`);
+    }
+    return `(?:${alts.join('|')})`;
   });
 };
 
@@ -1066,7 +1075,7 @@ const escapeNonAsciiChars = (text: string): string => {
   });
 };
 
-const buildSearchRegexFromPieces = (
+export const buildSearchRegexFromPieces = (
   pieces: string[],
   ccVersion: string,
   buildTime?: string

--- a/src/tests/systemPromptSync.test.ts
+++ b/src/tests/systemPromptSync.test.ts
@@ -275,6 +275,37 @@ Content only.`;
     });
   });
 
+  describe('buildSearchRegexFromPieces (cli.js search regex)', () => {
+    // Regression test for the Latin-1 \xHH locator bug: minified Claude Code
+    // bundles store Latin-1 chars (0x80–0xFF) as 2-digit hex escapes (e.g.
+    // "·" -> \xB7, "×" -> \xD7), not as \uXXXX. The search regex must match the
+    // literal char, the \uXXXX form, AND the \xHH form (case-insensitive),
+    // otherwise any prompt containing such a char fails to apply.
+    it('matches Latin-1 chars stored as \\xHH, \\uXXXX, or literal', () => {
+      const pattern = promptSync.buildSearchRegexFromPieces(
+        ['a · b × c'],
+        '2.1.179'
+      );
+      const re = new RegExp(pattern, 'si');
+      // \xB7 / \xD7 as they appear literally in a minified Bun bundle:
+      expect(re.test('a \\xB7 b \\xD7 c')).toBe(true);
+      // · / × form:
+      expect(re.test('a \\u00b7 b \\u00d7 c')).toBe(true);
+      // literal characters (template-literal source):
+      expect(re.test('a · b × c')).toBe(true);
+    });
+
+    it('still matches non-Latin-1 chars via \\uXXXX or literal', () => {
+      const pattern = promptSync.buildSearchRegexFromPieces(
+        ['x — y'],
+        '2.1.179'
+      );
+      const re = new RegExp(pattern, 'si');
+      expect(re.test('x \\u2014 y')).toBe(true); // em dash, escaped
+      expect(re.test('x — y')).toBe(true); // em dash, literal
+    });
+  });
+
   describe('extractUserCustomizations', () => {
     it('should extract what user put in place of minified identifiers', () => {
       const pieces = [


### PR DESCRIPTION
## Problem

On Claude Code **2.1.179**, `tweakcc --apply` fails to apply ~10 system prompts, each logged as:

```
Could not find system prompt "Skill: /catch-up periodic heartbeat" in cli.js (using regex ...)
```

The affected prompts all contain a **Latin-1 character** (U+0080–U+00FF) — most commonly `·` (middle dot, in the `<title> · <time> · <attendees>` notification format), but also `×`, `°`, etc.

## Root cause

`escapeNonAsciiForRegex` (in `src/systemPromptSync.ts`) builds the cli.js search regex by matching each non-ASCII char as **either the literal char or its `\uXXXX` escape**:

```js
const escaped = `\\\\u${codePoint.toString(16).padStart(4, '0')}`;
return `(?:${literal}|${escaped})`;
```

But recent Bun-compiled Claude Code bundles store **Latin-1 chars as 2-digit `\xHH` escapes**, not `\uXXXX` — e.g. `·` is emitted as `\xB7`, `×` as `\xD7`. Because the regex only offered the `\uXXXX` form, any prompt containing such a char failed to match and the whole prompt was skipped.

Verified directly against a 2.1.179 `unpack`: the middle dot appears only as `\xB7` (zero occurrences of `·` or a literal `·`).

This is independent of the `patches-applied-indication` UI abort that `main` already handles; both had to be resolved for `--apply` to fully succeed on 2.1.179.

## Fix

Add the `\xHH` alternative for codepoints `0x80`–`0xFF`. The search regex's existing `i` flag already covers upper/lowercase hex (`\xb7` vs `\xB7`):

```js
const alts = [literal, `\\\\u${codePoint.toString(16).padStart(4, '0')}`];
if (codePoint >= 0x80 && codePoint <= 0xff) {
  alts.push(`\\\\x${codePoint.toString(16).padStart(2, '0')}`);
}
return `(?:${alts.join('|')})`;
```

## Result

On a real Claude Code 2.1.179 install, this takes `--apply` from **10 "could not find" → 0**: every system prompt now locates and applies.

## Tests

- Exported `buildSearchRegexFromPieces` and added regression tests asserting a piece containing `·`/`×` matches the `\xHH`, `\uXXXX`, **and** literal forms — and that non-Latin-1 chars (e.g. `—`) still match via `\uXXXX`/literal.
- `pnpm lint` and `pnpm test` pass (277 tests).

Complements #785 (Text component detection for 2.1.170) and #798 (opusplan1m for 2.1.175+).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Unicode and UTF-8 escape handling to ensure prompts are correctly recognized regardless of how special characters are encoded by upstream bundles, preventing prompt skipping issues.

* **Tests**
  * Added comprehensive test coverage for Unicode character escape variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->