### PR TITLE
Fix crash when a system prompt regex is too complex to compile (#753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix crash when a system prompt's search regex is too complex to compile, which aborted the entire `--apply` on Node <=22 (#753) - @StreamDemon
+
 ## [v4.1.1](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.1.1) - 2026-06-17
 
 - Fix system prompt application on Claude Code 2.1.179: match Latin-1 \xHH escapes (#808) - @lukehutch

--- a/src/patches/systemPrompts.test.ts
+++ b/src/patches/systemPrompts.test.ts
@@ -474,5 +474,61 @@ describe('systemPrompts.ts', () => {
       expect(result.results[0].skipped).toBe(true);
       expect(result.results[0].applied).toBe(false);
     });
+
+    it('should skip a prompt whose regex fails to compile instead of throwing', async () => {
+      const mockPromptData = buildMockPromptData({
+        promptId: 'uncompilable-prompt',
+        prompt: { name: 'Uncompilable Prompt', content: 'unused' },
+        regex: '(', // invalid pattern: new RegExp('(', 'si') throws (unterminated group)
+        getInterpolatedContent: () => 'unused',
+        pieces: ['unused'],
+      });
+
+      setupMocks(mockPromptData);
+
+      const cliContent = 'desc:"some content"';
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe(cliContent);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].applied).toBe(false);
+      expect(result.results[0].details).toContain('too complex');
+    });
+
+    it('should continue applying remaining prompts after one regex fails to compile', async () => {
+      const badPrompt = buildMockPromptData({
+        promptId: 'bad-prompt',
+        prompt: { name: 'Bad Prompt', content: 'unused' },
+        regex: '(',
+        getInterpolatedContent: () => 'unused',
+        pieces: ['unused'],
+      });
+      const goodPrompt = buildMockPromptData({
+        promptId: 'good-prompt',
+        prompt: { name: 'Good Prompt', content: 'New content' },
+        regex: 'Original text',
+        getInterpolatedContent: () => 'New content',
+        pieces: ['Original text'],
+      });
+
+      vi.mocked(promptSync.loadSystemPromptsWithRegex).mockResolvedValue([
+        badPrompt,
+        goodPrompt,
+      ]);
+      vi.mocked(systemPromptHashIndex.setAppliedHash).mockResolvedValue();
+
+      const cliContent = 'desc:"Original text"';
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe('desc:"New content"');
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].id).toBe('bad-prompt');
+      expect(result.results[0].applied).toBe(false);
+      expect(result.results[0].details).toContain('too complex');
+      expect(result.results[1].id).toBe('good-prompt');
+      expect(result.results[1].applied).toBe(true);
+    });
   });
 });

--- a/src/patches/systemPrompts.ts
+++ b/src/patches/systemPrompts.ts
@@ -123,8 +123,31 @@ export const applySystemPrompts = async (
     }
 
     debug(`Applying system prompt: ${prompt.name}`);
-    const pattern = new RegExp(regex, 'si'); // 's' flag for dotAll mode, 'i' because of casing inconsistencies in unicode escape sequences (e.g. `\u201c` in the regex vs `\u201C` in the file)
-    const match = content.match(pattern);
+    // 's' = dotAll; 'i' for hex-case differences in unicode escapes. Guard regex
+    // construction + match: an oversized pattern (e.g. the Model Migration Guide) can
+    // overflow V8's regex stack on Node <=22 and abort the whole --apply (#753).
+    let pattern: RegExp;
+    let match: RegExpMatchArray | null;
+    try {
+      pattern = new RegExp(regex, 'si');
+      match = content.match(pattern);
+    } catch (error) {
+      console.log(
+        chalk.yellow(
+          `Skipped "${prompt.name}": regex too complex to compile (${
+            error instanceof Error ? error.message : String(error)
+          })`
+        )
+      );
+      results.push({
+        id: promptId,
+        name: prompt.name,
+        group: PatchGroup.SYSTEM_PROMPTS,
+        applied: false,
+        details: 'regex too complex',
+      });
+      continue;
+    }
 
     if (match && match.index !== undefined) {
       // Generate the interpolated content using the actual variables from the match


### PR DESCRIPTION
## Summary

On Node <=22, `applySystemPrompts` crashes with a regex stack overflow when a
system prompt's generated search pattern is large enough — e.g. the Model
Migration Guide (~138 KB pattern) or Building LLM-powered applications (~80 KB).
`new RegExp(regex, 'si')` is unguarded, so the throw aborts the entire `--apply`
and **no patches land** (`changesApplied: false`), even ones that already
succeeded earlier in the run. Reported in #753.

This implements the defensive guard suggested by @arikyeo in that issue.

## Changes

- Wrap the per-prompt regex construction and `content.match` in a try/catch in
  `applySystemPrompts`. On failure: log a warning, push a `PatchResult` with
  `applied: false, details: 'regex too complex'`, and `continue` to the next
  prompt instead of letting the throw abort the run.
- No behavior change for any prompt whose regex compiles.

## Testing

- [x] Tests added/updated — `src/patches/systemPrompts.test.ts`: one test proves an
  uncompilable pattern is skipped (not thrown); another proves a later prompt still
  applies after an earlier one fails.
- [x] All existing tests pass — full `vitest run`: 276 passed, 5 skipped. `tsc --noEmit`,
  `eslint src`, `prettier --check`, and `build:dev` all clean.
- [ ] The Node <=22 stack-overflow itself is runtime-specific (validated per #753 on
  Node 22); the guard is covered deterministically on Node 24 via an invalid-pattern test.

## Related Issues

Closes #753


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when a system prompt uses a search pattern too complex to compile.
  * `--apply` now skips the problematic prompt and continues processing the rest instead of stopping early.
  * Improved reporting so skipped prompts are clearly marked as not applied, while valid prompts still apply normally.

* **Documentation**
  * Updated the changelog with the latest crash fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->