### PR TITLE
Fix verbose-property patch for Claude Code's JSX automatic runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Add input chevron color patch (#634) - @VitalyOstanin
+- Fix verbose-property patch for Claude Code's JSX automatic runtime (#833) - @StreamDemon
 - Fix `userMessageDisplay` and `patchesAppliedIndication` patches for Claude Code's JSX automatic runtime, and make `findBoxComponent` JSX-aware (#834) - @StreamDemon
 
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26

--- a/src/patches/verboseProperty.test.ts
+++ b/src/patches/verboseProperty.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { writeVerboseProperty } from './verboseProperty';
+
+// Spinner element props used by the primary anchor's lookaheads.
+const spinnerProps =
+  'mode:e,responseLengthRef:o,spinnerSuffix:d,verbose:p,columns:f,thinkingStatus:m,isCompacting:h';
+
+describe('writeVerboseProperty', () => {
+  it('forces verbose:true on the JSX automatic-runtime form (jsx)', () => {
+    const input = `const a=1;Q.jsx(HJa,{${spinnerProps}});const b=2;`;
+    const result = writeVerboseProperty(input);
+    expect(result).not.toBeNull();
+    expect(result).toContain('verbose:true');
+    expect(result).not.toContain('verbose:p');
+  });
+
+  it('forces verbose:true on the JSX automatic-runtime form (jsxs)', () => {
+    const input = `Q.jsxs(HJa,{${spinnerProps}})`;
+    const result = writeVerboseProperty(input);
+    expect(result).not.toBeNull();
+    expect(result).toContain('verbose:true');
+  });
+
+  it('still handles the legacy createElement form', () => {
+    const input = `R.createElement(HJa,{${spinnerProps}})`;
+    const result = writeVerboseProperty(input);
+    expect(result).not.toBeNull();
+    expect(result).toContain('verbose:true');
+  });
+
+  it('handles the legacy spinnerTip/overrideMessage fallback (jsx)', () => {
+    const input =
+      'Q.jsx(Sp,{foo:1,spinnerTip:t,overrideMessage:m,verbose:p})';
+    const result = writeVerboseProperty(input);
+    expect(result).not.toBeNull();
+    expect(result).toContain('verbose:true');
+  });
+
+  it('returns null when no spinner element is present', () => {
+    expect(writeVerboseProperty('const x=1;Q.jsx(Other,{foo:1})')).toBeNull();
+  });
+});

--- a/src/patches/verboseProperty.test.ts
+++ b/src/patches/verboseProperty.test.ts
@@ -30,8 +30,7 @@ describe('writeVerboseProperty', () => {
   });
 
   it('handles the legacy spinnerTip/overrideMessage fallback (jsx)', () => {
-    const input =
-      'Q.jsx(Sp,{foo:1,spinnerTip:t,overrideMessage:m,verbose:p})';
+    const input = 'Q.jsx(Sp,{foo:1,spinnerTip:t,overrideMessage:m,verbose:p})';
     const result = writeVerboseProperty(input);
     expect(result).not.toBeNull();
     expect(result).toContain('verbose:true');

--- a/src/patches/verboseProperty.ts
+++ b/src/patches/verboseProperty.ts
@@ -3,10 +3,13 @@
 import { LocationResult, showDiff } from './index';
 
 const getVerbosePropertyLocation = (oldFile: string): LocationResult | null => {
+  // CC >=2.1.x compiles the UI with the React JSX automatic runtime, so the
+  // spinner element is emitted as `X.jsx(C,{...})` / `X.jsxs(C,{...})` rather
+  // than `X.createElement(C,{...})`. Accept all three call forms.
   const createElementPattern =
-    /(?:[$\w]+\.)?createElement\([$\w]+,\{(?=[^}]*responseLengthRef:)(?=[^}]*spinnerSuffix:)(?=[^}]*thinkingStatus:)(?=[^}]*isCompacting:)[^}]*verbose:[^,}]+[^}]*\}/;
+    /(?:[$\w]+\.)?(?:createElement|jsxs?)\([$\w]+,\{(?=[^}]*responseLengthRef:)(?=[^}]*spinnerSuffix:)(?=[^}]*thinkingStatus:)(?=[^}]*isCompacting:)[^}]*verbose:[^,}]+[^}]*\}/;
   const legacyCreateElementPattern =
-    /createElement\([$\w]+,\{[^}]+spinnerTip[^}]+overrideMessage[^}]+\}/;
+    /(?:createElement|jsxs?)\([$\w]+,\{[^}]+spinnerTip[^}]+overrideMessage[^}]+\}/;
   const createElementMatch =
     oldFile.match(createElementPattern) ??
     oldFile.match(legacyCreateElementPattern);


### PR DESCRIPTION
## Problem

`verbose-property` is an **always-applied** patch, so it fails for every user on Claude Code 2.1.x. CC compiles its UI with the React **JSX automatic runtime** — the spinner element is now emitted as `X.jsx(C,{…})` / `X.jsxs(C,{…})` rather than `X.createElement(C,{…})`, so both anchors in `getVerbosePropertyLocation` miss and `writeVerboseProperty` returns `null`.

Verified against an extracted CC `2.1.195` bundle: the spinner is `$f.jsx(HJa,{…responseLengthRef:…,spinnerSuffix:…,verbose:…,thinkingStatus:…,isCompacting:…})` (the bundle has ~6601 `jsx(` vs ~41 `.createElement(`).

## Fix

Accept all three call forms in both anchors: `(?:createElement|jsxs?)`. The lookahead set (`responseLengthRef` / `spinnerSuffix` / `thinkingStatus` / `isCompacting` + `verbose`) keeps the match unique to the spinner element.

Confirmed on the real 2.1.195 bundle: the patch now applies and sets `verbose:true` exactly once, on the spinner element's props (`…spinnerSuffix:d,verbose:true,columns:C,thinkingStatus…`).

## Tests

Adds `src/patches/verboseProperty.test.ts` covering the `jsx`, `jsxs`, and legacy `createElement` forms, the `spinnerTip`/`overrideMessage` fallback, and the no-match case.

Part of #822. Closes #823.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verbose-property patching for React’s JSX automatic runtime by supporting modern JSX call forms (`jsx`/`jsxs`) alongside legacy element patterns.
* **Tests**
  * Added unit tests to confirm verbose is injected when the appropriate spinner arguments are present, and that no replacement occurs when no spinner element is detected.
* **Documentation**
  * Updated the **Unreleased** changelog entry with the latest fix details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->