### PR TITLE
Fix findBoxComponent, userMessageDisplay, and patchesAppliedIndication for Claude Code's JSX automatic runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix `userMessageDisplay` and `patchesAppliedIndication` patches for Claude Code's JSX automatic runtime, and make `findBoxComponent` JSX-aware (#834) - @StreamDemon
+
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 
 - Fix crash when a system prompt's search regex is too complex to compile, which aborted the entire `--apply` on Node <=22 (#753) - @StreamDemon

--- a/src/patches/helpers.test.ts
+++ b/src/patches/helpers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { findBoxComponent } from './helpers';
+
+describe('findBoxComponent', () => {
+  it('finds the Box component rendered via the JSX runtime (jsx("ink-box"))', () => {
+    // CC >=2.1.x rest-style Box: layout defaults applied to the rest param `I`,
+    // then `X.jsx("ink-box",{...,style:I,children:T})` (children is a prop and
+    // `style` is no longer the last prop).
+    const src =
+      'function Bx({children:T,ref:R,...I}){' +
+      '"margin","padding","gap",' +
+      'I.flexWrap??="nowrap",I.flexDirection??="row",I.flexGrow??=0,I.flexShrink??=1,' +
+      'I.overflowX=I.overflowX??I.overflow??"visible",I.overflowY=I.overflowY??I.overflow??"visible",' +
+      'Q.jsx("ink-box",{ref:R,style:I,children:T})}';
+    expect(findBoxComponent(src)).toBe('Bx');
+  });
+
+  it('still finds the Box component via legacy createElement("ink-box")', () => {
+    const src =
+      'function Bx2({children:T,flexWrap:W}){return q.createElement("ink-box",{style:s},T)}';
+    expect(findBoxComponent(src)).toBe('Bx2');
+  });
+
+  it('returns undefined when no Box component is present', () => {
+    expect(findBoxComponent('const x=1;function f(){return null}')).toBe(
+      undefined
+    );
+  });
+});

--- a/src/patches/helpers.ts
+++ b/src/patches/helpers.ts
@@ -370,8 +370,12 @@ export const findBoxComponent = (fileContents: string): string | undefined => {
   // Method 5: Find Box by rest-style layout defaults (CC 2.1.138+)
   // Avoid ScrollBox-like wrappers by requiring generic Box layout defaults,
   // integer style warnings, forwarded children, and no sticky/scroll behavior.
+  // CC >=2.1.x renders the element via the React JSX automatic runtime, so the
+  // tail is now `X.jsx("ink-box",{...,style:I,children:T})` (children is a prop,
+  // and `style` is no longer the last prop) rather than the old
+  // `X.createElement("ink-box",{...,style:I},T)`. Accept both forms.
   const restStyleBoxPattern =
-    /function ([$\w]+)\(\{children:([$\w]+),ref:[$\w]+.{0,600}?\.\.\.([$\w]+)\}\)\{.{0,2500}?"margin".{0,2500}?"padding".{0,1200}?"gap".{0,1200}?\3\.flexWrap\?\?="nowrap",\3\.flexDirection\?\?="row",\3\.flexGrow\?\?=0,\3\.flexShrink\?\?=1,\3\.overflowX=\3\.overflowX\?\?\3\.overflow\?\?"visible",\3\.overflowY=\3\.overflowY\?\?\3\.overflow\?\?"visible",[$\w]+(?:\.default)?\.createElement\("ink-box",\{[^}]*style:\3\},\2\)/;
+    /function ([$\w]+)\(\{children:([$\w]+),ref:[$\w]+.{0,600}?\.\.\.([$\w]+)\}\)\{.{0,2500}?"margin".{0,2500}?"padding".{0,1200}?"gap".{0,1200}?\3\.flexWrap\?\?="nowrap",\3\.flexDirection\?\?="row",\3\.flexGrow\?\?=0,\3\.flexShrink\?\?=1,\3\.overflowX=\3\.overflowX\?\?\3\.overflow\?\?"visible",\3\.overflowY=\3\.overflowY\?\?\3\.overflow\?\?"visible",[$\w]+(?:\.default)?\.(?:createElement|jsxs?)\("ink-box",\{[^}]*style:\3[^}]*\}/;
   const restStyleBoxMatch = fileContents.match(restStyleBoxPattern);
   if (restStyleBoxMatch) {
     return (

--- a/src/patches/patchesAppliedIndication.ts
+++ b/src/patches/patchesAppliedIndication.ts
@@ -37,12 +37,32 @@ export const findVersionOutputLocation = (
  */
 const findTweakccVersionLocations = (
   fileContents: string
-): {
-  varInsertIndex: number;
-  refInsertIndex: number;
-  reactVar: string;
-  textComponent: string;
-} | null => {
+):
+  | { jsx: true; insertIndex: number; jsxVar: string; textComponent: string }
+  | {
+      jsx?: false;
+      varInsertIndex: number;
+      refInsertIndex: number;
+      reactVar: string;
+      textComponent: string;
+    }
+  | null => {
+  // CC >=2.1.x compiles the header with the React JSX automatic runtime:
+  //   _=X.jsxs(TEXT,{children:[BOLD," ",X.jsxs(TEXT,{dimColor:!0,children:["v",VER]})]})
+  // Insert the tweakcc version as a sibling child right after the version element
+  // (before the outer children-array `]`).
+  const jsxVersionPattern =
+    /([$\w]+)\.jsxs?\(([$\w]+),\{dimColor:!0,children:\["v",[$\w]+\]\}\)/;
+  const jsxMatch = fileContents.match(jsxVersionPattern);
+  if (jsxMatch && jsxMatch.index !== undefined) {
+    return {
+      jsx: true,
+      insertIndex: jsxMatch.index + jsxMatch[0].length,
+      jsxVar: jsxMatch[1],
+      textComponent: jsxMatch[2],
+    };
+  }
+
   // Find: createElement(TEXT,{bold:!0},"Claude Code"),CACHE[N]=x;else x=CACHE[N];
   // This gives us the position right after the x assignment block — where we insert our var
   const boldPattern =
@@ -322,6 +342,52 @@ const applyIndicatorPatchesListPatch = (
 const findPatchesListLocation = (
   fileContents: string
 ): LocationResult | null => {
+  // CC >=2.1.x JSX automatic runtime: the header row lives inside a column box
+  //   HDR=X.jsxs(TEXT,{children:[...,X.jsxs(TEXT,{dimColor:!0,children:["v",VER]})...]})
+  //   ...X.jsxs(BOX,{flexDirection:"column",children:[HDR,...]})
+  // Insert the patches list as the last child of that column array. identifiers
+  // carries [jsxVar, boxVar] to signal jsx mode to the codegen.
+  const jsxVerMatch = fileContents.match(
+    /([$\w]+)\.jsxs?\([$\w]+,\{dimColor:!0,children:\["v",[$\w]+\]\}\)/
+  );
+  if (jsxVerMatch && jsxVerMatch.index !== undefined) {
+    const jsxVar = jsxVerMatch[1];
+    // Header row var = nearest `VAR=<jsxVar>.jsxs(TEXT,{children:[` before the version element.
+    const hdrAssignRe = new RegExp(
+      `([$\\w]+)=${escapeIdent(jsxVar)}\\.jsxs\\([$\\w]+,\\{children:\\[`,
+      'g'
+    );
+    let hdrVar: string | undefined;
+    let m: RegExpExecArray | null;
+    while ((m = hdrAssignRe.exec(fileContents)) !== null) {
+      if (m.index > jsxVerMatch.index) break;
+      hdrVar = m[1];
+    }
+    if (hdrVar) {
+      // Match the column box whose FIRST child is exactly the header row var
+      // (require `,`/`]` after it so we don't match a longer var like `_A`).
+      // Scope to a window just after the header so a far-away `[_,...]` column
+      // (e.g. the IDE-warning box) can't be picked instead.
+      const colRe = new RegExp(
+        `${escapeIdent(jsxVar)}\\.jsxs\\(([$\\w]+),\\{flexDirection:"column",children:\\[${escapeIdent(hdrVar)}(?:,[^\\]]*)?\\]`
+      );
+      const windowStart = jsxVerMatch.index;
+      const windowStr = fileContents.slice(windowStart, windowStart + 6000);
+      const colMatch = windowStr.match(colRe);
+      if (colMatch && colMatch.index !== undefined) {
+        const boxVar = colMatch[1];
+        // Insert before the `]` that closes the column children array.
+        const insertIndex =
+          windowStart + colMatch.index + colMatch[0].length - 1;
+        return {
+          startIndex: insertIndex,
+          endIndex: insertIndex,
+          identifiers: [jsxVar, boxVar],
+        };
+      }
+    }
+  }
+
   // 1. Find the version display area (may already be modified by PATCH 2)
   // Find the "Claude Code" that's near dimColor:!0},"v" (the header version display)
   const versionDisplayPattern =
@@ -509,6 +575,24 @@ export const writePatchesAppliedIndication = (
       console.error(
         'patch: patchesAppliedIndication: patch 2 skipped (header version pattern changed)'
       );
+    } else if (locs.jsx) {
+      // JSX runtime: insert the tweakcc version as a sibling child in the header
+      // children array, right after the version element (jsx takes children as a
+      // prop, so we can't reuse the classic createElement(type,props,...children)).
+      const tweakccEl = `${locs.jsxVar}.jsx(${locs.textComponent},{children:${chalkVar}.hex("#FF8400").bold("+ tweakcc v${tweakccVersion}")})`;
+      const refCode = `," ",${tweakccEl}`;
+      const oldContent2 = content;
+      content =
+        content.slice(0, locs.insertIndex) +
+        refCode +
+        content.slice(locs.insertIndex);
+      showDiff(
+        oldContent2,
+        content,
+        refCode,
+        locs.insertIndex,
+        locs.insertIndex
+      );
     } else {
       // Step 1: Insert variable declaration after the "Claude Code" bold element
       const varName = '_tw';
@@ -562,6 +646,39 @@ export const writePatchesAppliedIndication = (
     if (!patchesListLoc) {
       console.error(
         'patch: patchesAppliedIndication: patch 3 skipped (version display pattern changed by PATCH 2)'
+      );
+    } else if (
+      patchesListLoc.identifiers &&
+      patchesListLoc.identifiers.length === 2
+    ) {
+      // JSX automatic runtime: build the list with jsx-convention calls (children
+      // as a prop) using the module's jsx var and the column's box, since the
+      // React var has no `.createElement` on these bundles. Insert as the last
+      // child of the header's column array.
+      const [jsxVar, listBox] = patchesListLoc.identifiers;
+      const rows: string[] = [];
+      rows.push(
+        `${jsxVar}.jsxs(${listBox},{children:[${jsxVar}.jsx(${textComponent},{color:"success",bold:true,children:"┃ "}),${jsxVar}.jsx(${textComponent},{color:"success",bold:true,children:"✓ tweakcc patches are applied"})]})`
+      );
+      for (let item of patchesApplies) {
+        item = item.replace('CHALK_VAR', chalkVar);
+        rows.push(
+          `${jsxVar}.jsxs(${listBox},{children:[${jsxVar}.jsx(${textComponent},{color:"success",bold:true,children:"┃ "}),${jsxVar}.jsx(${textComponent},{dimColor:true,children:\`  * ${item}\`})]})`
+        );
+      }
+      const listEl = `${jsxVar}.jsxs(${listBox},{flexDirection:"column",children:[${rows.join(',')}]})`;
+      const patchesListCode = `,${listEl}`;
+      const oldContent3 = content;
+      content =
+        content.slice(0, patchesListLoc.startIndex) +
+        patchesListCode +
+        content.slice(patchesListLoc.endIndex);
+      showDiff(
+        oldContent3,
+        content,
+        patchesListCode,
+        patchesListLoc.startIndex,
+        patchesListLoc.endIndex
       );
     } else {
       const lines = [];

--- a/src/patches/userMessageDisplay.ts
+++ b/src/patches/userMessageDisplay.ts
@@ -150,8 +150,10 @@ export const writeUserMessageDisplay = (
 
   // CC 2.1.138: child display is memoized before the parent Box call.
   // Replace only the child assignment so React compiler cache bookkeeping remains intact.
+  // CC >=2.1.x renders via the JSX automatic runtime, so the assignment is
+  // `B=X.jsx(SUB,{text:VAR,...})` rather than `B=X.createElement(SUB,{text:VAR,...})`.
   const memoizedChildPattern =
-    /(No content found in user prompt message.{0,1200}?)([$\w]+)=([$\w]+(?:\.default)?\.createElement)\([$\w]+,\{text:([$\w]+),useBriefLayout:[$\w]+,timestamp:[$\w]+\}\)/;
+    /(No content found in user prompt message.{0,1200}?)([$\w]+)=([$\w]+(?:\.default)?\.(?:createElement|jsxs?))\([$\w]+,\{text:([$\w]+),useBriefLayout:[$\w]+,timestamp:[$\w]+\}\)/;
 
   const oldMatch = oldFile.match(pattern);
   const newMatch = oldMatch ? null : oldFile.match(newPattern);
@@ -267,11 +269,26 @@ export const writeUserMessageDisplay = (
 
   const chalkFormattedString = `${chalkChain}(${formattedMessage})`;
 
-  // Build replacement: match[1] + createElement(Box, boxProps, createElement(Text, null, chalkFormattedString))
+  // Build replacement: Box(border/padding) wrapping Text(chalk-formatted message).
   const replacementPrefix = memoizedChildMatch ? `${match[2]}=` : '';
-  const replacement =
-    match[1] +
-    `${replacementPrefix}${createElementFn}(${resolvedBoxComponent},${boxAttrsObjStr},${createElementFn}(${textComponent},null,${chalkFormattedString}))`;
+
+  // CC's JSX automatic runtime (jsx/jsxs) passes children as a prop, and the
+  // captured call var has no `.createElement`, so emit jsx-convention calls
+  // there. Older bundles use the classic createElement(type, props, ...children).
+  const isJsxRuntime = /\.jsxs?$/.test(createElementFn);
+  let elementTree: string;
+  if (isJsxRuntime) {
+    const textEl = `${createElementFn}(${textComponent},{children:${chalkFormattedString}})`;
+    const boxProps =
+      boxAttrsObjStr === 'null'
+        ? `{children:${textEl}}`
+        : `${boxAttrsObjStr.slice(0, -1)},children:${textEl}}`;
+    elementTree = `${createElementFn}(${resolvedBoxComponent},${boxProps})`;
+  } else {
+    elementTree = `${createElementFn}(${resolvedBoxComponent},${boxAttrsObjStr},${createElementFn}(${textComponent},null,${chalkFormattedString}))`;
+  }
+
+  const replacement = match[1] + `${replacementPrefix}${elementTree}`;
 
   const startIndex = match.index;
   const endIndex = startIndex + match[0].length;


### PR DESCRIPTION
## Problem

On Claude Code 2.1.x the UI is compiled with the React **JSX automatic runtime** (`jsx`/`jsxs`), and the React var available on the bundle has **no `.createElement`**. This broke a `createElement`-shaped helper and two patches that depend on it:

- **`findBoxComponent`** — all detection methods anchored on `createElement("ink-box"…)`; CC now renders `X.jsx("ink-box",{…,style:I,children:T})` (children is a prop, `style` no longer last).
- **`user-message-display`** — its memoized-child anchor was `createElement`-based, *and* its replacement emitted `createElement(...)` (which fails since the call var has no `.createElement`). It silently no-op'd.
- **`patches-applied-indication`** — PATCH 2 (compact header version) and PATCH 3 (patches-applied list) both anchored on / emitted `createElement`. The "tweakcc version" only partly showed and the **patches list was dead**.

Verified against JS extracted from an installed CC `2.1.195` native binary (~6601 `jsx(` / ~3176 `jsxs(` vs ~41 `.createElement(`).

## Fix

- **`findBoxComponent`** (Method 5): accept `(?:createElement|jsxs?)("ink-box",…)` and the children-as-prop shape.
- **`user-message-display`**: make the memoized-child anchor jsx-aware and add a **jsx-convention codegen branch** — `X.jsx(Box,{…,children:X.jsx(Text,{children:CHALK})})` — preserving the React-compiler memo cache bookkeeping.
- **`patches-applied-indication`**:
  - PATCH 2: detect the jsx header (`X.jsxs(Text,{children:[…,X.jsxs(Text,{dimColor:!0,children:["v",VER]})]})`) and insert the tweakcc version as a sibling child.
  - PATCH 3: locate the header's column box (`X.jsxs(Box,{flexDirection:"column",children:[HDR,…]})`) and append the patches list as its last child, emitting jsx-convention calls.

## Verification

- All three patches apply correctly against the real 2.1.195 bundle, with the tweakcc version + patches list rendered, and **`node --check` passes on the full patched bundle** (this patch's historical failure mode is breaking bundle syntax).
- New unit tests for `findBoxComponent` (jsx + legacy `createElement` forms); full suite green (`287 passed`); `tsc` + `eslint` clean.

Part of #822. Closes #824.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for apps built with the newer React JSX automatic runtime.
  * Broader compatibility across differing bundle output formats for UI patching.

* **Bug Fixes**
  * Improved detection of the Box wrapper component in JSX-generated code.
  * Updated user message and “patches applied” indicators to render correctly with JSX automatic-runtime output.

* **Tests**
  * Added automated coverage to verify Box component detection works for both JSX runtime and legacy element creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->