### PR TITLE
Fix thinker-symbol-width and thinker-format patches for Claude Code's JSX automatic runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix thinker-symbol-width and thinker-format patches for Claude Code's JSX automatic runtime (#835) - @StreamDemon
+
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 
 - Fix crash when a system prompt's search regex is too complex to compile, which aborted the entire `--apply` on Node <=22 (#753) - @StreamDemon

--- a/src/patches/thinkerFormat.test.ts
+++ b/src/patches/thinkerFormat.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { writeThinkerFormat } from './thinkerFormat';
+
+describe('writeThinkerFormat', () => {
+  it('rewrites the format via the global fallback when the spinner props are not adjacent (CC 2.1.195+)', () => {
+    // CC 2.1.195 stopped rendering spinnerTip/overrideMessage as an adjacent
+    // object literal, so the section-scoped passes miss; only the format
+    // expression itself remains, and it is globally unique.
+    const input =
+      'let L=y===void 0,M=L?x?.find(E=>E.status!=="pending"):void 0,' +
+      '[B]=KJ.useState(()=>HL(zpt())),' +
+      '$=(a??M?.activeForm??M?.subject??(h||B))+"\\u2026";KJ.useEffect(()=>{});';
+
+    const result = writeThinkerFormat(input, '{} thinking');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      '$=`${a??M?.activeForm??M?.subject??(h||B)} thinking`'
+    );
+    expect(result).not.toContain('+"\\u2026"');
+  });
+
+  it('still uses the section-scoped path when spinnerTip/overrideMessage are adjacent (older Claude Code)', () => {
+    const input =
+      'spinnerTip:Q,mode:Z,overrideMessage:W,' +
+      'x'.repeat(310) +
+      ',N=(Y??C?.activeForm??L)+"\\u2026";';
+
+    const result = writeThinkerFormat(input, '{} working');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('N=`${Y??C?.activeForm??L} working`');
+  });
+
+  it('does not act when the active-form expression is ambiguous (multiple matches)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const input =
+      ',$=(a??M?.activeForm??x)+"\\u2026";,Y=(b??N?.activeForm??z)+"\\u2026";';
+
+    const result = writeThinkerFormat(input, '{} thinking');
+
+    expect(result).toBeNull();
+    spy.mockRestore();
+  });
+});

--- a/src/patches/thinkerFormat.test.ts
+++ b/src/patches/thinkerFormat.test.ts
@@ -4,10 +4,11 @@ import { writeThinkerFormat } from './thinkerFormat';
 
 describe('writeThinkerFormat', () => {
   it('rewrites the format via the global fallback when the spinner props are not adjacent (CC 2.1.195+)', () => {
-    // CC 2.1.195 stopped rendering spinnerTip/overrideMessage as an adjacent
-    // object literal, so the section-scoped passes miss; only the format
-    // expression itself remains, and it is globally unique.
+    // spinnerTip/overrideMessage still live in the component but are no longer
+    // adjacent to the format expression, so the scoped passes miss; the global
+    // fallback must still anchor to that surrounding context.
     const input =
+      'spinnerTipsEnabled:!0,foo:bar,overrideMessage:W,' +
       'let L=y===void 0,M=L?x?.find(E=>E.status!=="pending"):void 0,' +
       '[B]=KJ.useState(()=>HL(zpt())),' +
       '$=(a??M?.activeForm??M?.subject??(h||B))+"\\u2026";KJ.useEffect(()=>{});';
@@ -19,6 +20,19 @@ describe('writeThinkerFormat', () => {
       '$=`${a??M?.activeForm??M?.subject??(h||B)} thinking`'
     );
     expect(result).not.toContain('+"\\u2026"');
+  });
+
+  it('does not act when the spinner context is absent (avoids rewriting unrelated bundle code)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // A lone `,x=(…activeForm…)+"…"` with no spinnerTip/overrideMessage nearby
+    // must NOT be rewritten — uniqueness alone is not enough.
+    const input = 'q=1,r=(a??b?.activeForm??c)+"\\u2026";s=2;';
+
+    const result = writeThinkerFormat(input, '{} thinking');
+
+    expect(result).toBeNull();
+    spy.mockRestore();
   });
 
   it('still uses the section-scoped path when spinnerTip/overrideMessage are adjacent (older Claude Code)', () => {
@@ -33,11 +47,12 @@ describe('writeThinkerFormat', () => {
     expect(result).toContain('N=`${Y??C?.activeForm??L} working`');
   });
 
-  it('does not act when the active-form expression is ambiguous (multiple matches)', () => {
+  it('does not act when the active-form expression is ambiguous (multiple matches in spinner context)', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const input =
-      ',$=(a??M?.activeForm??x)+"\\u2026";,Y=(b??N?.activeForm??z)+"\\u2026";';
+      'spinnerTipsEnabled:!0,overrideMessage:W,' +
+      'x=1,$=(a??M?.activeForm??x)+"\\u2026",Y=(b??N?.activeForm??z)+"\\u2026";';
 
     const result = writeThinkerFormat(input, '{} thinking');
 

--- a/src/patches/thinkerFormat.ts
+++ b/src/patches/thinkerFormat.ts
@@ -89,13 +89,25 @@ const getThinkerFormatLocation = (oldFile: string): LocationResult | null => {
   // CC 2.1.195+ no longer renders the spinner props (spinnerTip/overrideMessage)
   // as an adjacent object literal, so `approxAreaMatch` can no longer scope the
   // search and the section-based passes above never fire. The format expression
-  // itself is unchanged and globally unique, e.g.
-  // `$=(a??M?.activeForm??M?.subject??(h||B))+"…"`. Fall back to a global
-  // `formatPatternOld` search restricted to the active-form expression; only act
-  // on a single, unambiguous match.
+  // itself is unchanged, e.g. `$=(a??M?.activeForm??M?.subject??(h||B))+"…"`.
+  // Fall back to a global `formatPatternOld` search, but keep it anchored to the
+  // spinner component (those props still live nearby, just not adjacent) the
+  // same way the `formatPatternNew` global path above does, and only act on a
+  // single, unambiguous match.
   const formatPatternOldGlobal = new RegExp(formatPatternOld.source, 'g');
   const oldFormatMatches = [...oldFile.matchAll(formatPatternOldGlobal)].filter(
-    match => match.index != undefined && match[3]?.includes('.activeForm')
+    match => {
+      if (match.index == undefined || !match[3]?.includes('.activeForm')) {
+        return false;
+      }
+      const context = oldFile.slice(
+        Math.max(0, match.index - 2500),
+        match.index + 1000
+      );
+      return (
+        context.includes('spinnerTip') && context.includes('overrideMessage:')
+      );
+    }
   );
 
   if (oldFormatMatches.length === 1) {

--- a/src/patches/thinkerFormat.ts
+++ b/src/patches/thinkerFormat.ts
@@ -86,6 +86,28 @@ const getThinkerFormatLocation = (oldFile: string): LocationResult | null => {
     };
   }
 
+  // CC 2.1.195+ no longer renders the spinner props (spinnerTip/overrideMessage)
+  // as an adjacent object literal, so `approxAreaMatch` can no longer scope the
+  // search and the section-based passes above never fire. The format expression
+  // itself is unchanged and globally unique, e.g.
+  // `$=(a??M?.activeForm??M?.subject??(h||B))+"…"`. Fall back to a global
+  // `formatPatternOld` search restricted to the active-form expression; only act
+  // on a single, unambiguous match.
+  const formatPatternOldGlobal = new RegExp(formatPatternOld.source, 'g');
+  const oldFormatMatches = [...oldFile.matchAll(formatPatternOldGlobal)].filter(
+    match => match.index != undefined && match[3]?.includes('.activeForm')
+  );
+
+  if (oldFormatMatches.length === 1) {
+    const formatMatch = oldFormatMatches[0];
+    return {
+      startIndex: formatMatch.index! + formatMatch[1].length + 1, // + 1 for the comma
+      endIndex:
+        formatMatch.index! + formatMatch[1].length + formatMatch[2].length + 1, // + 1 for the comma
+      identifiers: [formatMatch[3]],
+    };
+  }
+
   if (searchStart === undefined) {
     console.error('patch: thinker format: failed to find approxAreaMatch');
   }

--- a/src/patches/thinkerSymbolWidth.test.ts
+++ b/src/patches/thinkerSymbolWidth.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { writeThinkerSymbolWidthLocation } from './thinkerSymbolWidth';
+
+describe('writeThinkerSymbolWidthLocation', () => {
+  it('rewrites every memoized JSX-runtime spinner symbol box (CC 2.1.195+)', () => {
+    // The React Compiler emits one memoized copy of the spinner symbol box per
+    // render branch, each spreading the same unbraced layout run.
+    const input =
+      'k=K4.jsx(U,{"aria-hidden":!0,flexWrap:"wrap",height:1,width:2,children:I});' +
+      'A=K4.jsx(U,{"aria-hidden":!0,flexWrap:"wrap",height:1,width:2,children:K4.jsx(w,{color:h,children:dJa})});' +
+      'u=$f.jsx(U,{ref:r,"aria-hidden":!0,flexWrap:"wrap",height:1,width:2,children:c});';
+
+    const result = writeThinkerSymbolWidthLocation(input, 4);
+
+    expect(result).not.toBeNull();
+    expect(result!.match(/flexWrap:"wrap",height:1,width:4/g)).toHaveLength(3);
+    expect(result).not.toContain('width:2');
+  });
+
+  it('still rewrites the old braced object form (older Claude Code)', () => {
+    const input = 'X.createElement(U,{flexWrap:"wrap",height:1,width:2},I)';
+
+    const result = writeThinkerSymbolWidthLocation(input, 3);
+
+    expect(result).toContain('{flexWrap:"wrap",height:1,width:3}');
+  });
+
+  it('returns null when no spinner symbol box is present', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = writeThinkerSymbolWidthLocation('const x=1;', 4);
+
+    expect(result).toBeNull();
+    spy.mockRestore();
+  });
+});

--- a/src/patches/thinkerSymbolWidth.ts
+++ b/src/patches/thinkerSymbolWidth.ts
@@ -1,39 +1,29 @@
 // Please see the note about writing patches in ./index
 
-import { LocationResult, showDiff } from './index';
+import { globalReplace } from './index';
 
-const getThinkerSymbolWidthLocation = (
-  oldFile: string
-): LocationResult | null => {
-  const widthPattern = /\{flexWrap:"wrap",height:1,width:2\}/;
-  const match = oldFile.match(widthPattern);
-
-  if (!match || match.index == undefined) {
-    console.error('patch: thinker symbol width: failed to find match');
-    return null;
-  }
-
-  return {
-    startIndex: match.index,
-    endIndex: match.index + match[0].length,
-  };
-};
+// Claude Code 2.1.195 migrated the spinner symbol box to the JSX automatic
+// runtime and React-Compiler memoization, so the old braced anchor
+// `{flexWrap:"wrap",height:1,width:2}` no longer exists. The box is now spread
+// inside a memoized `jsx` call as `…,flexWrap:"wrap",height:1,width:2,children:…`
+// and the compiler emits one copy per render branch (≈10). Match the unbraced
+// run and rewrite every copy. The unbraced run is also a substring of the old
+// braced form, so this stays compatible with older Claude Code versions (where
+// it matches the single braced occurrence).
+const widthPattern = /flexWrap:"wrap",height:1,width:2/;
 
 export const writeThinkerSymbolWidthLocation = (
   oldFile: string,
   width: number
 ): string | null => {
-  const location = getThinkerSymbolWidthLocation(oldFile);
-  if (!location) {
+  if (!widthPattern.test(oldFile)) {
+    console.error('patch: thinker symbol width: failed to find match');
     return null;
   }
 
-  const newCss = `{flexWrap:"wrap",height:1,width:${width}}`;
-  const newFile =
-    oldFile.slice(0, location.startIndex) +
-    newCss +
-    oldFile.slice(location.endIndex);
-
-  showDiff(oldFile, newFile, newCss, location.startIndex, location.endIndex);
-  return newFile;
+  return globalReplace(
+    oldFile,
+    new RegExp(widthPattern.source, 'g'),
+    `flexWrap:"wrap",height:1,width:${width}`
+  );
 };


### PR DESCRIPTION
## Problem

On Claude Code 2.1.195 the UI is compiled with the React **JSX automatic runtime** (`jsx`/`jsxs`) plus React-Compiler memoization, which reshaped the anchors two thinker patches depend on:

- **`thinker-symbol-width`** — anchored on the braced layout object `{flexWrap:"wrap",height:1,width:2}`. CC now spreads that run inside a memoized `jsx` call (`…,"aria-hidden":!0,flexWrap:"wrap",height:1,width:2,children:…`) and the compiler emits **one copy per render branch (~10)**, so the old exact-braced anchor matches nothing (hard `null`).
- **`thinker-format`** — its search was scoped by an `approxAreaMatch` that keyed off adjacent `spinnerTip:…,…,overrideMessage:…` props. CC no longer renders those as an adjacent object literal, so the scope locator returns `undefined`, the search section becomes empty, and every downstream pass fails (hard `null`). The format expression itself is unchanged and still present, e.g. `$=(a??M?.activeForm??M?.subject??(h||B))+"…"`.

Verified against JS extracted from installed CC `2.1.195` **and** `2.1.193` native binaries.

## Fix

- **`thinker-symbol-width`**: match the **unbraced** run `flexWrap:"wrap",height:1,width:2` and `globalReplace` every memoized copy. The unbraced run is also a substring of the old braced form, so this stays compatible with older Claude Code (where it matches the single braced occurrence).
- **`thinker-format`**: add a **global fallback** that runs the existing `formatPatternOld` over the whole bundle, restricted to the active-form expression (the captured group contains `.activeForm`), and only acts on a single unambiguous match. It is purely additive — it fires only after the existing section-scoped passes miss, so older versions are unaffected.

## Verification

- Both patches apply correctly against the real `2.1.195` **and** `2.1.193` bundles — symbol-width rewrites all 10 memoized copies (0 left at `width:2`); format becomes `` $=`${a??M?.activeForm??M?.subject??(h||B)} thinking` `` — and **`node --check` passes on the full patched bundle**.
- New unit tests for both patches (JSX-runtime form, legacy/older form, and the ambiguity guard); full suite green (`293 passed`); `tsc` + `eslint` clean.

Part of #822. Closes #825.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility so thinker-format and thinker-symbol-width patches work across newer and older Claude Code layouts.
  * Added a global fallback rewrite path for thinker-format when scoped matching fails, and better disambiguation to prevent incorrect rewrites.
  * Updated thinker-symbol-width rewriting to reliably update all matching spinner symbol box width occurrences.
  * Suppressed noisy error output and ensured ambiguous matches fail gracefully without side effects.
* **Tests**
  * Added Vitest coverage for thinker-format and thinker-symbol-width, including fallback and edge/failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->