### PR TITLE
Fix hide-startup-clawd patch for Claude Code's JSX automatic runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add input chevron color patch (#634) - @VitalyOstanin
 - Fix verbose-property patch for Claude Code's JSX automatic runtime (#833) - @StreamDemon
 - Fix `userMessageDisplay` and `patchesAppliedIndication` patches for Claude Code's JSX automatic runtime, and make `findBoxComponent` JSX-aware (#834) - @StreamDemon
+- Fix hide-startup-clawd patch for Claude Code's JSX automatic runtime (#836) - @StreamDemon
 
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 

--- a/src/patches/hideStartupClawd.test.ts
+++ b/src/patches/hideStartupClawd.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { writeHideStartupClawd } from './hideStartupClawd';
+
+describe('writeHideStartupClawd', () => {
+  it('nulls the wrapper that renders the inner component via the JSX runtime (CC 2.1.195+)', () => {
+    const input =
+      'function Inner(e){return X.jsx("text",{children:"▛███▜"})}' +
+      'function Wrap(e){if(t)return X.jsx(Inner,{pose:o});return X.jsx("art",{})}';
+
+    const result = writeHideStartupClawd(input);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('function Wrap(e){return null;');
+    // The inner component is left untouched; the pre-fix bug nulled it instead,
+    // hiding only the Apple-Terminal branch while the ASCII art still rendered.
+    expect(result).not.toContain('function Inner(e){return null;');
+  });
+
+  it('still nulls a legacy createElement wrapper (older Claude Code)', () => {
+    const input =
+      'function Inner(e){return X.createElement("text",null,"▛███▜")}' +
+      'function Wrap(e){return X.createElement(Inner,{pose:o})}';
+
+    const result = writeHideStartupClawd(input);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('function Wrap(e){return null;');
+  });
+
+  it('matches an inner component name containing `$` (regex-escaped)', () => {
+    const input =
+      'function $f(e){return X.jsx("text",{children:"▛███▜"})}' +
+      'function Wrap(e){return X.jsx($f,{pose:o})}';
+
+    const result = writeHideStartupClawd(input);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('function Wrap(e){return null;');
+  });
+
+  it('returns null when no Clawd art is present', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = writeHideStartupClawd('function f(){return 1}');
+
+    expect(result).toBeNull();
+    spy.mockRestore();
+  });
+});

--- a/src/patches/hideStartupClawd.ts
+++ b/src/patches/hideStartupClawd.ts
@@ -14,7 +14,7 @@ import { showDiff } from './index';
  * Steps:
  * 1. Find the inner component by looking for '▛███▜' (Clawd ASCII art)
  * 2. Trace back to find the inner function name
- * 3. Find the wrapper function that createElement's the inner component
+ * 3. Find the wrapper function that renders the inner component
  * 4. Return the wrapper function body start index
  */
 const findStartupClawdComponents = (oldFile: string): number[] => {
@@ -46,17 +46,26 @@ const findStartupClawdComponents = (oldFile: string): number[] => {
 
   const innerFuncName = lastFunctionMatch[1];
 
-  // Find the wrapper function that directly createElement's the inner component.
-  // Iterate all functions and find one where createElement(INNER,) appears
-  // before any nested function definition.
+  // Find the wrapper function that directly renders the inner component.
+  // Iterate all functions and find one where the inner component is rendered
+  // before any nested function definition. CC 2.1.195+ renders it via the JSX
+  // automatic runtime (`X.jsx(INNER,…)`) rather than `createElement(INNER,…)`,
+  // so accept either shape (innerFuncName may contain `$`, so escape it).
   const wrapperFuncPattern = /function ([$\w]+)\([^)]*\)\{/g;
+  const innerCallPattern = new RegExp(
+    `(?:createElement|jsxs?)\\(${innerFuncName.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&'
+    )},`
+  );
   let wrapperExec: RegExpExecArray | null;
   let wrapperMatch: { index: number; length: number } | null = null;
   while ((wrapperExec = wrapperFuncPattern.exec(oldFile)) !== null) {
     const bodyStart = wrapperExec.index + wrapperExec[0].length;
     const body = oldFile.slice(bodyStart, bodyStart + 500);
-    const elemIdx = body.indexOf(`createElement(${innerFuncName},`);
-    if (elemIdx === -1) continue;
+    const innerCallMatch = innerCallPattern.exec(body);
+    if (!innerCallMatch) continue;
+    const elemIdx = innerCallMatch.index;
     const nextFuncIdx = body.indexOf('function ');
     if (nextFuncIdx !== -1 && nextFuncIdx < elemIdx) continue;
     wrapperMatch = { index: wrapperExec.index, length: wrapperExec[0].length };


### PR DESCRIPTION
## Problem

On Claude Code 2.1.195 the startup-Clawd wrapper is compiled with the React **JSX automatic runtime**, so `hideStartupClawd`'s wrapper-detection sub-anchor — a literal `body.indexOf(\`createElement(${innerFuncName},\`)` — matches nothing:

- The wrapper now renders the inner Apple-Terminal component via `X.jsx(INNER,{pose:o})`, not `createElement(INNER,…)`.
- Because the wrapper scan finds no match, the patch falls back to nulling the **inner** component instead of the wrapper. That hides only the Apple-Terminal Clawd; the wrapper's `else` branch (the ASCII-art Clawd) still renders. So the patch *appears* to apply but silently does the wrong thing (masked).

This is not new to 2.1.195 — 2.1.193 already renders it the same way (`QR.jsx(n5p,…)`), so the regression predates the migration.

## Fix

Swap the literal `createElement(INNER,` substring search for a render-agnostic regex that accepts both the legacy and JSX-runtime shapes:

```
(?:createElement|jsxs?)\(<escaped-innerFuncName>,
```

`innerFuncName` comes from `[$\w]+` and can contain `$` (a regex metachar), so it's escaped. The regex is built once before the scan loop. The existing "nested-function-first" ordering guard is unchanged, and the patch still only inserts the literal `return null;` (no React codegen needed). Keeping `createElement` as an alternative means this also repairs older builds and 2.1.193.

## Verification

- Applies against the real `2.1.195` **and** `2.1.193` bundles; the insertion now lands on the **wrapper** (`function rQ(e){…`@2.1.195, `function nJ(e){…`@2.1.193), which hides **both** the Apple-Terminal and ASCII-art branches. `node --check` passes on the full patched bundle.
- New unit tests: JSX-runtime wrapper, legacy `createElement` wrapper, an inner name containing `$` (escaping), and the no-art null case. Full suite green; `tsc` + `eslint` clean.

Part of #822. Closes #831.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of startup wrapper patterns by supporting both classic React element calls and the newer JSX runtime.
  * Correctly identifies wrapped components (including names with special characters) while preserving the inner component and safely falling back when no wrapper is found.
* **Tests**
  * Added Vitest coverage for wrapper detection across JSX runtime and older createElement-based patterns, plus no-match behavior.
* **Documentation**
  * Updated the Unreleased changelog with an additional bullet for the startup wrapper fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->