### PR TITLE
Make channels-mode tolerate the removed ChannelsNotice warning banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add input chevron color patch (#634) - @VitalyOstanin
 - Fix verbose-property patch for Claude Code's JSX automatic runtime (#833) - @StreamDemon
 - Fix `userMessageDisplay` and `patchesAppliedIndication` patches for Claude Code's JSX automatic runtime, and make `findBoxComponent` JSX-aware (#834) - @StreamDemon
+- Make channels-mode tolerate the removed ChannelsNotice "Experimental" warning banner so `--apply` no longer reports a spurious failure (#837) - @StreamDemon
 
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 

--- a/src/patches/channelsMode.test.ts
+++ b/src/patches/channelsMode.test.ts
@@ -2,10 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { writeChannelsMode } from './channelsMode';
 
-// Minimal synthetic bundle carrying the four anchors the channels-mode patch
-// still relies on (the two flag gates, the gate-function capability check, and
-// the server dev-flag warning). The "Experimental" notice banner is omitted to
-// mirror CC 2.1.193+.
 const GATES =
   'function a(){return F("tengu_harbor",!1)};' +
   'function g(){return{reason:"server did not declare claude/channel capability"}};' +

--- a/src/patches/channelsMode.test.ts
+++ b/src/patches/channelsMode.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { writeChannelsMode } from './channelsMode';
+
+// Minimal synthetic bundle carrying the four anchors the channels-mode patch
+// still relies on (the two flag gates, the gate-function capability check, and
+// the server dev-flag warning). The "Experimental" notice banner is omitted to
+// mirror CC 2.1.193+.
+const GATES =
+  'function a(){return F("tengu_harbor",!1)};' +
+  'function g(){return{reason:"server did not declare claude/channel capability"}};' +
+  'function b(){return F("tengu_harbor_permissions",!1)};' +
+  'if(!x.dev)y.push({entry:x,why:"server: entries need --dangerously-load-development-channels"});';
+
+describe('writeChannelsMode', () => {
+  it('applies without logging a failure when the removed ChannelsNotice banner is absent (CC 2.1.193+)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = writeChannelsMode(GATES);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('return !0;return F("tengu_harbor",!1)');
+    expect(result).toContain('return{action:"register"};');
+    expect(result).not.toContain('server: entries need');
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it('still neutralizes the ChannelsNotice warning when present (older Claude Code)', () => {
+    const input =
+      GATES +
+      'Experimental \xb7 inbound messages will be pushed into this session, ' +
+      'this carries prompt injection risks. Restart Claude Code without F to disable.';
+
+    const result = writeChannelsMode(input);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('Channels active. Restart Claude Code without ');
+    expect(result).not.toContain('carries prompt injection risks');
+  });
+});

--- a/src/patches/channelsMode.ts
+++ b/src/patches/channelsMode.ts
@@ -154,10 +154,11 @@ const patchChannelsNotice = (file: string): string | null => {
     /Experimental[^"]*?inbound messages will be pushed into this session, this carries prompt injection risks\. Restart Claude Code without /;
   const match = file.match(pattern);
 
+  // Claude Code removed this "Experimental" banner around 2.1.193, so the
+  // anchor is legitimately absent on newer versions. Treat that as an optional
+  // no-op (the channel gates above are already bypassed) rather than logging a
+  // misleading failure during `--apply`.
   if (!match || match.index === undefined) {
-    console.error(
-      'patch: channelsMode: failed to find ChannelsNotice warning text'
-    );
     return null;
   }
 


### PR DESCRIPTION
## Problem

The channels-mode patch's Patch 4 (`patchChannelsNotice`) suppresses the ChannelsNotice banner: *"Experimental · inbound messages will be pushed into this session, this carries prompt injection risks. Restart Claude Code without {flag} to disable."*

Claude Code **removed that banner around 2.1.193**, so the anchor matches nothing on current versions. The sub-patch is already optional (`patchChannelsNotice(newFile) ?? newFile`), so the overall patch still applies and bypasses the channel gates — but it prints a misleading `patch: channelsMode: failed to find ChannelsNotice warning text` to stderr during `--apply`, which reads like a failure even though everything worked.

(The other four channels-mode anchors — the two `tengu_harbor` gates, the `gateChannelServer` capability check, and the `server: entries need …` dev-flag warning — all still match on 2.1.195.)

## Fix

Treat the absent banner as an expected optional no-op: return `null` without logging when the warning isn't found. The suppression itself is unchanged, so older Claude Code (where the banner still exists) is unaffected.

## Verification

- `writeChannelsMode` applies cleanly against the real `2.1.195` **and** `2.1.193` bundles with **no stderr output** — the gates are bypassed, the server dev-flag warning is removed, and the absent banner is silently skipped. `node --check` passes on the patched bundle.
- New unit tests: applies without logging when the banner is absent (2.1.193+), and still neutralizes the banner when present (older Claude Code). Full suite green; `tsc` + `eslint` clean.

Part of #822. Closes #832.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel-mode patching to tolerate the absence of the “Experimental” ChannelsNotice warning banner in newer versions, preventing spurious `--apply` failures.
* **Tests**
  * Added Vitest coverage for channel-mode output for both missing vs. present warning banner scenarios, including expected messaging and console error behavior.
* **Documentation**
  * Updated the Unreleased changelog with the channel-mode warning-tolerance fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->