### PR TITLE
Fix suppress-rate-limit-options, suppress-line-numbers, and suppress-native-installer-warning patches for Claude Code 2.1.195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix verbose-property patch for Claude Code's JSX automatic runtime (#833) - @StreamDemon
 - Fix `userMessageDisplay` and `patchesAppliedIndication` patches for Claude Code's JSX automatic runtime, and make `findBoxComponent` JSX-aware (#834) - @StreamDemon
 - Fix thinker-symbol-width and thinker-format patches for Claude Code's JSX automatic runtime (#835) - @StreamDemon
+- Fix suppress-rate-limit-options, suppress-line-numbers, and suppress-native-installer-warning patches for Claude Code 2.1.195 (#838) - @StreamDemon
 
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 

--- a/src/patches/suppressLineNumbers.test.ts
+++ b/src/patches/suppressLineNumbers.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { writeSuppressLineNumbers } from './suppressLineNumbers';
+
+describe('writeSuppressLineNumbers', () => {
+  const formatter =
+    'function f({content:J,startLine:G}){if(!J)return"";let L=J.split(/\\r?\\n/);return L.map(x=>x).join("")}function g(){}';
+  const p1 =
+    '"- Results are returned using cat -n format, with line numbers starting at 1"';
+  const p2 =
+    '`${oYr}. Each line is the line number, a single separator (a tab or \\`:\\`), then the verbatim file content (including any leading whitespace).`';
+
+  it('neutralizes the formatter and rewrites both read-tool prompt lines', () => {
+    const result = writeSuppressLineNumbers(
+      formatter + ';var X=' + p1 + ',Y=' + p2 + ';'
+    );
+    expect(result).not.toBeNull();
+    expect(result).toContain('if(!J)return"";return J}');
+    expect(result).toContain(
+      'Results are returned as raw file content without line-number prefixes'
+    );
+    expect(result).toContain(
+      'Results are raw file content without line-number prefixes.'
+    );
+    expect(result).not.toContain('Each line is the line number');
+  });
+
+  it('rewrites the p2 prompt line whose inner backticks are escaped', () => {
+    const result = writeSuppressLineNumbers(formatter + ';var Y=' + p2 + ';');
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('Each line is the line number');
+  });
+
+  it('returns null when the formatter signature is absent', () => {
+    expect(writeSuppressLineNumbers('no matching content here')).toBeNull();
+  });
+});

--- a/src/patches/suppressLineNumbers.test.ts
+++ b/src/patches/suppressLineNumbers.test.ts
@@ -8,6 +8,8 @@ describe('writeSuppressLineNumbers', () => {
     '"- Results are returned using cat -n format, with line numbers starting at 1"';
   const p2 =
     '`${oYr}. Each line is the line number, a single separator (a tab or \\`:\\`), then the verbatim file content (including any leading whitespace).`';
+  const p2Unescaped =
+    '`${oYr}. Each line is the line number, a single separator (a tab or `:`), then the verbatim file content (including any leading whitespace).`';
 
   it('neutralizes the formatter and rewrites both read-tool prompt lines', () => {
     const result = writeSuppressLineNumbers(
@@ -26,6 +28,14 @@ describe('writeSuppressLineNumbers', () => {
 
   it('rewrites the p2 prompt line whose inner backticks are escaped', () => {
     const result = writeSuppressLineNumbers(formatter + ';var Y=' + p2 + ';');
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('Each line is the line number');
+  });
+
+  it('also rewrites the p2 prompt line with unescaped separator backticks', () => {
+    const result = writeSuppressLineNumbers(
+      formatter + ';var Y=' + p2Unescaped + ';'
+    );
     expect(result).not.toBeNull();
     expect(result).not.toContain('Each line is the line number');
   });

--- a/src/patches/suppressLineNumbers.ts
+++ b/src/patches/suppressLineNumbers.ts
@@ -10,7 +10,7 @@ const patchReadToolPrompt = (file: string): string => {
       '"- Results are returned as raw file content without line-number prefixes"',
     ],
     [
-      /`\$\{[$\w]+\}\. Each line is the line number, a single separator \(a tab or `:`\), then the verbatim file content \(including any leading whitespace\)\.`/g,
+      /`\$\{[$\w]+\}\. Each line is the line number, a single separator \(a tab or \\?`:\\?`\), then the verbatim file content \(including any leading whitespace\)\.`/g,
       '`Results are raw file content without line-number prefixes.`',
     ],
   ];

--- a/src/patches/suppressNativeInstallerWarning.test.ts
+++ b/src/patches/suppressNativeInstallerWarning.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { writeSuppressNativeInstallerWarning } from './suppressNativeInstallerWarning';
+
+describe('writeSuppressNativeInstallerWarning', () => {
+  const winPush =
+    's.push({message:`Native installation exists but ${p} is not in your PATH. Add it by opening: System Properties.`,userActionRequired:!0,type:"path"})';
+  const unixPush =
+    's.push({message:`Native installation exists but ~/.local/bin is not in your PATH. Run: echo X >> ${g} && source ${g}`,userActionRequired:!0,type:"path"})';
+
+  it('removes both the Windows and Unix startup warning pushes', () => {
+    const input =
+      'if(u){let p=a;' + winPush + '}else{let p=b,g=c;' + unixPush + '}';
+    const result = writeSuppressNativeInstallerWarning(input);
+    expect(result).not.toBeNull();
+    expect(result).toBe('if(u){let p=a;}else{let p=b,g=c;}');
+    expect(result).not.toContain('Native installation exists but');
+  });
+
+  it('removes the legacy npm-to-native startup banner', () => {
+    const input =
+      'log("Claude Code has switched from npm to native installer. Run `claude install` or see https://docs.anthropic.com/en/docs/claude-code/getting-started for more options.")';
+    const result = writeSuppressNativeInstallerWarning(input);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('switched from npm to native installer');
+  });
+
+  it('returns null when no native installer warning is present', () => {
+    expect(writeSuppressNativeInstallerWarning('unrelated content')).toBeNull();
+  });
+});

--- a/src/patches/suppressNativeInstallerWarning.ts
+++ b/src/patches/suppressNativeInstallerWarning.ts
@@ -1,11 +1,8 @@
 import { showDiff } from './index';
 
 const WARNING_PATTERNS = [
+  /[$\w]+\.push\(\{message:`Native installation exists but [^`]*`,userActionRequired:!0,type:"path"\}\)/g,
   /Claude Code has switched from npm to native installer\. Run `claude install` or see https:\/\/docs\.anthropic\.com\/en\/docs\/claude-code\/getting-started for more options\./g,
-  /installMethod is native, but directory [^"'`\n;]+/g,
-  /installMethod is native, but claude command (?:is missing or invalid|not found) at [^"'`\n;]+/g,
-  /Native installation exists but ~\/\.local\/bin is not in your PATH(?:\. Run: echo 'export PATH="\$HOME\/\.local\/bin:\$PATH"' >> [^"'`\n;]+ then open a new terminal or run: source [^"'`\n;]+)?/g,
-  /Run: echo 'export PATH="\$HOME\/\.local\/bin:\$PATH"' >> [^"'`\n;]+ then open a new terminal or run: source [^"'`\n;]+/g,
 ];
 
 export const writeSuppressNativeInstallerWarning = (

--- a/src/patches/suppressRateLimitOptions.test.ts
+++ b/src/patches/suppressRateLimitOptions.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { writeSuppressRateLimitOptions } from './suppressRateLimitOptions';
+
+describe('writeSuppressRateLimitOptions', () => {
+  it('nulls the callback at both renderer call sites (with and without agentDefinitions)', () => {
+    const input =
+      'X.jsx(A,{screen:st,streamingToolUses:cs,showAllInTranscript:vt,agentDefinitions:oe,onOpenRateLimitOptions:Ern,isLoading:Se});' +
+      'X.jsx(B,{agentDefinitions:oe,streamingToolUses:Fhr,showAllInTranscript:vt,onOpenRateLimitOptions:Ern,isLoading:Se});';
+    const result = writeSuppressRateLimitOptions(input);
+    expect(result).not.toBeNull();
+    expect(
+      (result!.match(/onOpenRateLimitOptions:\(\)=>\{\}/g) || []).length
+    ).toBe(2);
+    expect(result).not.toContain('onOpenRateLimitOptions:Ern');
+  });
+
+  it('nulls call sites but preserves the props destructuring definition', () => {
+    const def =
+      'function C(e){let t=z.c(37),{screen:n,showAllInTranscript:u=!1,agentDefinitions:d,onOpenRateLimitOptions:p,hideLogo:f=!1}=e}';
+    const call =
+      'X.jsx(A,{showAllInTranscript:vt,agentDefinitions:oe,onOpenRateLimitOptions:Ern,isLoading:Se})';
+    const result = writeSuppressRateLimitOptions(def + ';' + call);
+    expect(result).not.toBeNull();
+    expect(result).toContain('onOpenRateLimitOptions:p,hideLogo:f=!1');
+    expect(
+      (result!.match(/onOpenRateLimitOptions:\(\)=>\{\}/g) || []).length
+    ).toBe(1);
+  });
+
+  it('is render-agnostic (matches a legacy createElement call site)', () => {
+    const input =
+      'A.createElement(B,{showAllInTranscript:u,agentDefinitions:d,onOpenRateLimitOptions:cb})';
+    const result = writeSuppressRateLimitOptions(input);
+    expect(result).not.toBeNull();
+    expect(result).toContain('onOpenRateLimitOptions:()=>{}');
+  });
+
+  it('returns null when no call site is present', () => {
+    expect(writeSuppressRateLimitOptions('no relevant content')).toBeNull();
+  });
+});

--- a/src/patches/suppressRateLimitOptions.test.ts
+++ b/src/patches/suppressRateLimitOptions.test.ts
@@ -35,6 +35,15 @@ describe('writeSuppressRateLimitOptions', () => {
     expect(result).toContain('onOpenRateLimitOptions:()=>{}');
   });
 
+  it('matches minified $-prefixed identifiers', () => {
+    const input =
+      'X.jsx($A,{showAllInTranscript:$vt,agentDefinitions:$oe,onOpenRateLimitOptions:$ne,isLoading:$se})';
+    const result = writeSuppressRateLimitOptions(input);
+    expect(result).not.toBeNull();
+    expect(result).toContain('onOpenRateLimitOptions:()=>{}');
+    expect(result).not.toContain('onOpenRateLimitOptions:$ne');
+  });
+
   it('returns null when no call site is present', () => {
     expect(writeSuppressRateLimitOptions('no relevant content')).toBeNull();
   });

--- a/src/patches/suppressRateLimitOptions.ts
+++ b/src/patches/suppressRateLimitOptions.ts
@@ -6,8 +6,7 @@ export const writeSuppressRateLimitOptions = (
   oldFile: string
 ): string | null => {
   const patterns = [
-    /\.createElement.{0,500},showAllInTranscript:[$\w]+,agentDefinitions:[$\w]+,onOpenRateLimitOptions:([$\w]+)/g,
-    /\.createElement\([\w$]+,\{messages:[\w$]+,tools:[\w$]+,commands:[\w$]+,verbose:!0,toolJSX:null,inProgressToolUseIDs:[\w$]+,isMessageSelectorVisible:!1,conversationId:[\w$]+,screen:[\w$]+,agentDefinitions:[\w$]+,streamingToolUses:[\w$]+,showAllInTranscript:[\w$]+,onOpenRateLimitOptions:([\w$]+)/g,
+    /showAllInTranscript:[$\w]+,(?:agentDefinitions:[$\w]+,)?onOpenRateLimitOptions:([$\w]+)/g,
   ];
 
   let newFile = oldFile;


### PR DESCRIPTION
## Problem

Three "suppress" patches broke on recent Claude Code (2.1.193+/2.1.195):

- **suppress-rate-limit-options** — anchored on `.createElement(...)` call sites. CC migrated to the JSX automatic runtime (`.jsx`/`.jsxs`) and reordered the props, so both patterns missed and the patch returned `null`.
- **suppress-line-numbers** — the second Read-tool prompt rewrite never matched. Its anchor expects a literal `` `:` `` inside the prompt, but that text lives in a template literal, so the inner backticks are escaped in the bundle (`` \`:\` ``). The formatter and the first prompt rewrite still applied; only this line silently no-op'd.
- **suppress-native-installer-warning** — the startup PATH warning is now emitted as `s.push({message:`Native installation exists but …`,userActionRequired:!0,type:"path"})` with separate Windows and Unix branches. The existing string-blanking patterns only blanked the Unix message's first sentence (leaving the rest behind) and missed Windows entirely.

## Fix

- **suppress-rate-limit-options** — replace the two `.createElement`-anchored patterns with a single render-agnostic anchor: `showAllInTranscript:VAR,(agentDefinitions:VAR,)?onOpenRateLimitOptions:(VAR)`. It nulls the callback at both the normal and the virtual-scroll transcript renderers, and the `=!1` default on the props *definition* naturally excludes that site (so the destructuring is never corrupted). This matches both the old `createElement` and the new `jsx` layouts.
- **suppress-line-numbers** — match the escaped inner backticks so the prompt rewrite applies again.
- **suppress-native-installer-warning** — remove the whole startup `push({…,type:"path"})` for both platforms. The legacy npm→native banner pattern is kept for older CC; the 2.1.146–2.1.158 `claude doctor` string-blanking patterns are dropped — they match nothing on current CC and are outside this patch's stated "at startup" scope.

## Verification

Ran each `writeXxx` against freshly extracted **2.1.195** and **2.1.193** bundles:

- suppress-rate-limit-options: `null` → applies; exactly **2** `onOpenRateLimitOptions:()=>{}` injected; props definition untouched.
- suppress-native-installer-warning: startup-push count **2 → 0** on both branches (Windows + Unix).
- suppress-line-numbers: both prompt rewrites now apply.
- `node --check` passes on the fully patched bundle (the native-installer fix changes control flow, not just a string).

Added focused unit tests for all three patches (10 cases). `pnpm lint` and `pnpm test` are green (full suite passing).

Part of #822. Closes #828.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patching compatibility so suppressions work across more variations of prompt and startup message formatting.
  * Refined removal of native installer warnings to match additional related message text while preserving surrounding content.
  * Updated line-number and rate-limit option suppression to handle alternate syntaxes and safely return when no matches are found.
* **Tests**
  * Added unit tests covering prompt rewriting, native warning stripping, alternate syntax cases, and no-match behavior.
* **Documentation**
  * Updated the changelog with the latest fix entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->