### PR TITLE
Fix table-format, token-count-rounding, and context-limit patches for Claude Code 2.1.195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix thinker-symbol-width and thinker-format patches for Claude Code's JSX automatic runtime (#835) - @StreamDemon
 - Fix hide-startup-clawd patch for Claude Code's JSX automatic runtime (#836) - @StreamDemon
 - Fix suppress-rate-limit-options, suppress-line-numbers, and suppress-native-installer-warning patches for Claude Code 2.1.195 (#838) - @StreamDemon
+- Fix table-format, token-count-rounding, and context-limit patches for Claude Code 2.1.195 (#839) - @StreamDemon
 
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 

--- a/src/patches/contextLimit.test.ts
+++ b/src/patches/contextLimit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { writeContextLimit } from './contextLimit';
+
+describe('writeContextLimit', () => {
+  const ENV = '(+process.env.CLAUDE_CODE_CONTEXT_LIMIT||200000)';
+
+  it('overrides both 200000 constants in the CC >=2.1.193 dual tuple', () => {
+    // Real 2.1.195 shape: var YOt=200000,Pte=200000,Evi=20000,Wkd=32000,qkd=128000;
+    const input = 'var $Pt=200000,Aee=200000,thi=20000,Yfd=32000,Xfd=128000;';
+
+    const result = writeContextLimit(input);
+
+    expect(result).toBe(
+      `var $Pt=${ENV},Aee=${ENV},thi=20000,Yfd=32000,Xfd=128000;`
+    );
+  });
+
+  it('does not mangle $-prefixed var names via String.replace $-substitution', () => {
+    const input = 'var $1=200000,$2=200000,a=20000,b=32000,c=128000;';
+
+    const result = writeContextLimit(input);
+
+    expect(result).toBe(`var $1=${ENV},$2=${ENV},a=20000,b=32000,c=128000;`);
+  });
+
+  it('accepts the 64000 group-6 variant', () => {
+    const input = 'var A=200000,B=200000,C=20000,D=32000,E=64000;';
+
+    const result = writeContextLimit(input);
+
+    expect(result).toBe(`var A=${ENV},B=${ENV},C=20000,D=32000,E=64000;`);
+  });
+
+  it('falls back to the older single-200000 tuple', () => {
+    const input = 'var A=200000,B=20000,C=32000,D=128000;';
+
+    const result = writeContextLimit(input);
+
+    expect(result).toBe(`var A=${ENV},B=20000,C=32000,D=128000;`);
+  });
+
+  it('returns null and logs when no context-limit tuple is present', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = writeContextLimit('var x=1,y=2;');
+
+    expect(result).toBeNull();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/src/patches/contextLimit.ts
+++ b/src/patches/contextLimit.ts
@@ -2,19 +2,35 @@
 
 export const writeContextLimit = (oldFile: string): string | null => {
   const replacement = '(+process.env.CLAUDE_CODE_CONTEXT_LIMIT||200000)';
-  const pattern =
-    /var ([\w$]+)=200000,([\w$]+)=20000,([\w$]+)=32000,([\w$]+)=(128000|64000);/;
-  const match = oldFile.match(pattern);
 
-  if (!match) {
-    console.error(
-      'patch: contextLimit: failed to find context limit constants'
+  // CC >=2.1.193 split the context window into two 200000 constants: the
+  // window SIZE (used for %-left/threshold math, with a 1e6 alternative) and
+  // the model-default / auto-compact THRESHOLD. Override both so the env var
+  // keeps them consistent; both default to 200000 so behavior is unchanged
+  // when the env var is unset. A replacement function is used (rather than a
+  // template-string replacement) so minified `$`-containing var names are not
+  // mangled by String.prototype.replace's `$` substitution.
+  const dualPattern =
+    /var ([\w$]+)=200000,([\w$]+)=200000,([\w$]+)=20000,([\w$]+)=32000,([\w$]+)=(128000|64000);/;
+  if (dualPattern.test(oldFile)) {
+    return oldFile.replace(
+      dualPattern,
+      (_m, v1, v2, v3, v4, v5, lit) =>
+        `var ${v1}=${replacement},${v2}=${replacement},${v3}=20000,${v4}=32000,${v5}=${lit};`
     );
-    return null;
   }
 
-  return oldFile.replace(
-    pattern,
-    `var ${match[1]}=${replacement},${match[2]}=20000,${match[3]}=32000,${match[4]}=${match[5]};`
-  );
+  // Older CC: a single 200000 context-window constant.
+  const singlePattern =
+    /var ([\w$]+)=200000,([\w$]+)=20000,([\w$]+)=32000,([\w$]+)=(128000|64000);/;
+  if (singlePattern.test(oldFile)) {
+    return oldFile.replace(
+      singlePattern,
+      (_m, v1, v2, v3, v4, lit) =>
+        `var ${v1}=${replacement},${v2}=20000,${v3}=32000,${v4}=${lit};`
+    );
+  }
+
+  console.error('patch: contextLimit: failed to find context limit constants');
+  return null;
 };

--- a/src/patches/tableFormat.ts
+++ b/src/patches/tableFormat.ts
@@ -278,7 +278,7 @@ export const writeTableFormat = (
     {
       const before = newFile;
       const tableRendererPattern =
-        /function [$\w]+\([^)]*\)\{[\s\S]{0,1600}?let ([$\w]+)="(?:\\u2502|│)";[\s\S]{0,1600}?\1\+=" "\+[$\w]+\+" (?:\\u2502|│)"/;
+        /function [$\w]+\([^)]*\)\{[\s\S]{0,1600}?let ([$\w]+)="(?:\\u2502|│)";[\s\S]{0,1600}?\1\+=" "\+[$\w]+(?:\((?:[^()]|\([^()]*\))*\))?\+" (?:\\u2502|│)"/;
       const tableRendererMatch = newFile.match(tableRendererPattern);
       if (tableRendererMatch && tableRendererMatch.index !== undefined) {
         const start = tableRendererMatch.index;

--- a/src/patches/tokenCountRounding.test.ts
+++ b/src/patches/tokenCountRounding.test.ts
@@ -46,4 +46,26 @@ describe('writeTokenCountRounding', () => {
     expect(result).not.toContain('D$=fr_(OH)/1000)*1000)');
     expect(result).toContain('D$=fr_(OH)');
   });
+
+  it('wraps the token expression for the JSX children-array form (CC >=2.1.195)', () => {
+    // CC 2.1.195 dropped key:"tokens" and moved the count into a JSX children array.
+    const input =
+      'let Ee=t?O:ae.current,me=Yi(I),pe=rn(me),ge=ce,he=ou(ge),ie=`${nt.arrowDown} ${he} tokens`,le=rn(ie),B$=Mf.jsxs(w,{dimColor:!0,children:[he," tokens"]});';
+
+    const result = writeTokenCountRounding(input, 1000);
+
+    expect(result).toContain('he=ou(Math.round((ge)/1000)*1000)');
+    expect(result).toContain('children:[he," tokens"]');
+  });
+
+  it('children-array form: wraps only the backreferenced token decl', () => {
+    const input =
+      'let pe=rn(me),xe=ze(ye),ge=ce,he=ou(ge),ie=`${nt.arrowDown} ${he} tokens`,B$=Mf.jsxs(w,{dimColor:!0,children:[he," tokens"]});';
+
+    const result = writeTokenCountRounding(input, 1000);
+
+    expect(result).toContain('he=ou(Math.round((ge)/1000)*1000)');
+    expect(result).toContain('xe=ze(ye)');
+    expect(result).not.toContain('xe=ze(Math.round');
+  });
 });

--- a/src/patches/tokenCountRounding.ts
+++ b/src/patches/tokenCountRounding.ts
@@ -45,42 +45,56 @@ export const writeTokenCountRounding = (
   // a TDZ crash where `M$` is referenced while initializing itself.
   const simpleExpression = '[$\\w]+(?:\\?\\.[$\\w]+)*(?:\\([^()]*\\))?';
 
-  // Pattern 1 (CC >=2.1.83): Direct match on formatter call near key:"tokens"
-  // Matches: VAR=FUNC(EXPR),...key:"tokens"...,VAR," tokens"
-  const m1 = oldFile.match(
+  // Pattern 0 (CC >=2.1.195, JSX automatic runtime): the token display no longer
+  // carries a key:"tokens" prop; the count moved into a JSX children array.
+  // Matches: VAR=FUNC(EXPR),...children:[VAR," tokens"]
+  const m0 = oldFile.match(
     new RegExp(
-      `(([$\\w]+)=[$\\w]+\\()(${simpleExpression})(\\),.{0,2000}key:"tokens".{0,200},\\2," tokens")`
+      `(([$\\w]+)=[$\\w]+\\()(${simpleExpression})(\\),.{0,2000}children:\\[\\2," tokens"\\])`
     )
   );
 
-  if (m1 && m1.index !== undefined) {
-    [fullMatch, pre, , partToWrap, post] = m1;
-    startIndex = m1.index;
+  if (m0 && m0.index !== undefined) {
+    [fullMatch, pre, , partToWrap, post] = m0;
+    startIndex = m0.index;
   } else {
-    // Pattern 2 (CC <2.1.83): overrideMessage anchor nearby
-    const m2 = oldFile.match(
+    // Pattern 1 (CC >=2.1.83): Direct match on formatter call near key:"tokens"
+    // Matches: VAR=FUNC(EXPR),...key:"tokens"...,VAR," tokens"
+    const m1 = oldFile.match(
       new RegExp(
-        `(overrideMessage:.{0,10000},([$\\w]+)=[$\\w]+\\()(${simpleExpression})(\\),.{0,1000}key:"tokens".{0,200},\\2," tokens")`
+        `(([$\\w]+)=[$\\w]+\\()(${simpleExpression})(\\),.{0,2000}key:"tokens".{0,200},\\2," tokens")`
       )
     );
 
-    if (m2 && m2.index !== undefined) {
-      [fullMatch, pre, , partToWrap, post] = m2;
-      startIndex = m2.index;
+    if (m1 && m1.index !== undefined) {
+      [fullMatch, pre, , partToWrap, post] = m1;
+      startIndex = m1.index;
     } else {
-      // Pattern 3 (CC 1.x): older format
-      const m3 = oldFile.match(
-        /(overrideMessage:.{0,10000},key:"tokens".{0,200}[$\w]+\()(Math\.round\(.+?\))(\))/
+      // Pattern 2 (CC <2.1.83): overrideMessage anchor nearby
+      const m2 = oldFile.match(
+        new RegExp(
+          `(overrideMessage:.{0,10000},([$\\w]+)=[$\\w]+\\()(${simpleExpression})(\\),.{0,1000}key:"tokens".{0,200},\\2," tokens")`
+        )
       );
 
-      if (m3 && m3.index !== undefined) {
-        [fullMatch, pre, partToWrap, post] = m3;
-        startIndex = m3.index;
+      if (m2 && m2.index !== undefined) {
+        [fullMatch, pre, , partToWrap, post] = m2;
+        startIndex = m2.index;
       } else {
-        console.error(
-          'patch: tokenCountRounding: cannot find token count pattern in any CC format'
+        // Pattern 3 (CC 1.x): older format
+        const m3 = oldFile.match(
+          /(overrideMessage:.{0,10000},key:"tokens".{0,200}[$\w]+\()(Math\.round\(.+?\))(\))/
         );
-        return null;
+
+        if (m3 && m3.index !== undefined) {
+          [fullMatch, pre, partToWrap, post] = m3;
+          startIndex = m3.index;
+        } else {
+          console.error(
+            'patch: tokenCountRounding: cannot find token count pattern in any CC format'
+          );
+          return null;
+        }
       }
     }
   }

--- a/src/tests/tableFormat.test.ts
+++ b/src/tests/tableFormat.test.ts
@@ -87,4 +87,24 @@ describe('tableFormat patch', () => {
       expect(result).not.toContain('g<A.rows.length-1');
     });
   });
+
+  // CC 2.1.195 refactored the compact-table renderer: the cell value became a
+  // call expression with nested parens, and the vertical bar uses │
+  // escapes. This mirrors the real bundle so the widened locator is exercised.
+  describe('ascii format — 2.1.195 compact renderer (call-form cell value)', () => {
+    const jsxRendererCode = `function Wq6(I,A){let N=[];for(let B=0;B<L;B++){let $="\\u2502";for(let q=0;q<D.length;q++){let W=O[q],V=M[q],Y=B-V,z=Y>=0&&Y<W.length?W[Y]:"",K=_[q],Z=P?"center":e.align?.[q]??"left";$+=" "+_6n(z,rn(z),K,Z)+" \\u2502"}N.push($)}return N}`;
+
+    it('converts the call-form cell separator to ASCII while preserving the call', () => {
+      const result = writeTableFormat(jsxRendererCode, 'ascii');
+      expect(result).not.toBeNull();
+      expect(result).toContain('+_6n(z,rn(z),K,Z)+" |"');
+      expect(result).not.toContain('+_6n(z,rn(z),K,Z)+" \\u2502"');
+    });
+
+    it('leaves the row-leading bar untouched (out of scope)', () => {
+      const result = writeTableFormat(jsxRendererCode, 'ascii');
+      expect(result).not.toBeNull();
+      expect(result).toContain('let $="\\u2502"');
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Three display/config patches broke on Claude Code 2.1.195 (part of the JSX automatic-runtime migration, #822):

- **table-format** — the ascii compact-table renderer's cell value became a call expression with nested parens (e.g. `_6n(z,rn(z),K,Z)`), so the step-2 locator (which expected a bare identifier) no longer matched. The patch still applied its other steps, but the compact-table vertical separators silently stayed `│` instead of becoming `|`.
- **token-count-rounding** — all three patterns anchored on `key:"tokens"`, which is gone under the automatic runtime; the token count moved into a JSX children array (`children:[VAR," tokens"]`). The patch returned `null`.
- **context-limit** — a second `200000` constant was inserted into the model constant tuple (now `200000,200000,20000,32000,128000`), so the single-`200000` regex no longer matched and the patch returned `null`.

## Fix

- **table-format** — widen only the compact-renderer locator's trailing group to optionally accept a one-level-nested call. The group is optional, so the old bare-identifier form still matches; no other anchor changed.
- **token-count-rounding** — add a new first pattern for the `children:[VAR," tokens"]` form, keeping the three existing patterns as fallbacks for older Claude Code. The emitted code is unchanged (`Math.round((EXPR)/base)*base`).
- **context-limit** — match the new dual-`200000` tuple and override **both** constants (the window size used for the %-left/threshold math, and the auto-compact / prompt-too-long threshold) so they stay consistent; keep the single-`200000` regex as a fallback. Both default to `200000`, so behavior is unchanged when `CLAUDE_CODE_CONTEXT_LIMIT` is unset. Switched to a replacement function so `String.prototype.replace`'s `$` substitution cannot mangle minified `$`-containing variable names.

## Verification

- New/updated unit tests (vitest) using fixtures that mirror the real 2.1.195 forms: a call-with-nested-parens cell value, a `children:[VAR," tokens"]` token display, and the dual-`200000` tuple including a `$`-prefixed var name. `context-limit` gains a test file (it previously had none). Full suite: 336 passed.
- Ran the real `writeTableFormat` / `writeTokenCountRounding` / `writeContextLimit` against freshly-extracted pristine **2.1.195** and **2.1.193** bundles, asserting on emitted output (the converted `|` bar, the wrapped `Math.round(...)`, and the dual env-override declaration with the other constants preserved verbatim). `node --check` passes on the combined patched bundle.

Part of #822. Closes #827.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for newer app output formats so table separators, token counts, and context limits are updated correctly across more variants.
  * Fixed cases where special text markers could be altered incorrectly during replacements.
  * Added a fallback for older format patterns and clearer error reporting when no matching context-limit setting is found.

* **Tests**
  * Added coverage for newer output shapes to verify table formatting, token rounding, and context-limit updates behave as expected.

* **Chores**
  * Updated the changelog with the latest patch notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->