### PR TITLE
Fix input-box-border and input-pattern-highlighters patches for Claude Code 2.1.195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix thinker-symbol-width and thinker-format patches for Claude Code's JSX automatic runtime (#835) - @StreamDemon
 - Fix hide-startup-clawd patch for Claude Code's JSX automatic runtime (#836) - @StreamDemon
 - Fix suppress-rate-limit-options, suppress-line-numbers, and suppress-native-installer-warning patches for Claude Code 2.1.195 (#838) - @StreamDemon
+- Fix input-box-border and input-pattern-highlighters patches for Claude Code 2.1.195 (#840) - @StreamDemon
 
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 

--- a/src/patches/inputBorderBox.test.ts
+++ b/src/patches/inputBorderBox.test.ts
@@ -3,9 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { writeInputBoxBorder } from './inputBorderBox';
 
 describe('writeInputBoxBorder', () => {
-  // The main prompt + external-editor boxes spread one hoisted props object
-  // (`vie`/`TV`) whose border is borderStyle:"round" with the distinctive
-  // top-only combo borderLeft:!1,borderRight:!1,borderBottom:!0.
   const hoisted =
     'let vie=hO?{}:{borderColor:(()=>{return c})(),borderStyle:"round",borderLeft:!1,borderRight:!1,borderBottom:!0};' +
     'Jsx(Box,{flexDirection:"row",...vie,width:"100%",borderText:t,children:[]});';
@@ -24,7 +21,6 @@ describe('writeInputBoxBorder', () => {
   });
 
   it('returns null when no input border combo is present', () => {
-    // A round border without the borderLeft/Right/Bottom combo must not match.
     const other = 'let x={borderStyle:"round",marginTop:1};';
     expect(writeInputBoxBorder(other, true)).toBeNull();
   });

--- a/src/patches/inputBorderBox.test.ts
+++ b/src/patches/inputBorderBox.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { writeInputBoxBorder } from './inputBorderBox';
+
+describe('writeInputBoxBorder', () => {
+  // The main prompt + external-editor boxes spread one hoisted props object
+  // (`vie`/`TV`) whose border is borderStyle:"round" with the distinctive
+  // top-only combo borderLeft:!1,borderRight:!1,borderBottom:!0.
+  const hoisted =
+    'let vie=hO?{}:{borderColor:(()=>{return c})(),borderStyle:"round",borderLeft:!1,borderRight:!1,borderBottom:!0};' +
+    'Jsx(Box,{flexDirection:"row",...vie,width:"100%",borderText:t,children:[]});';
+
+  it('disables the border on the hoisted props object', () => {
+    const result = writeInputBoxBorder(hoisted, true);
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'borderStyle:undefined,borderLeft:!1,borderRight:!1,borderBottom:!0'
+    );
+    expect(result).not.toContain('borderStyle:"round",borderLeft:!1');
+  });
+
+  it('returns the input unchanged when removeBorder is false', () => {
+    expect(writeInputBoxBorder(hoisted, false)).toBe(hoisted);
+  });
+
+  it('returns null when no input border combo is present', () => {
+    // A round border without the borderLeft/Right/Bottom combo must not match.
+    const other = 'let x={borderStyle:"round",marginTop:1};';
+    expect(writeInputBoxBorder(other, true)).toBeNull();
+  });
+
+  it('removes the border from every box carrying the combo (older inline CC)', () => {
+    const twice =
+      'mainBox={borderColor:a,borderStyle:"round",borderLeft:!1,borderRight:!1,borderBottom:!0,width:"100%"};' +
+      'editorBox={borderColor:b,borderStyle:"round",borderLeft:!1,borderRight:!1,borderBottom:!0,width:"100%"};';
+    const result = writeInputBoxBorder(twice, true);
+    expect(result).not.toBeNull();
+    expect((result!.match(/borderStyle:undefined/g) || []).length).toBe(2);
+    expect(result).not.toContain('borderStyle:"round"');
+  });
+});

--- a/src/patches/inputBorderBox.ts
+++ b/src/patches/inputBorderBox.ts
@@ -2,20 +2,6 @@
 
 import { globalReplace } from './index';
 
-/**
- * Removes the input box border in Claude Code's PromptInput component.
- *
- * The main prompt box and the external-editor box ("Save and close editor")
- * both spread a single hoisted props object that carries the input border:
- *   vie=hO?{}:{borderColor:(()=>{...})(),borderStyle:"round",borderLeft:!1,borderRight:!1,borderBottom:!0}
- * and each box renders as Jsx(Box,{...,...vie,width:"100%",...}).
- *
- * We disable the border on that shared object by turning its borderStyle:"round"
- * into borderStyle:undefined. The borderLeft:!1,borderRight:!1,borderBottom:!0
- * trailing makes the anchor unique (the top-only input border), so a global
- * replace is safe; it also covers older CC where the main and editor boxes each
- * carried this combo inline.
- */
 export const writeInputBoxBorder = (
   oldFile: string,
   removeBorder: boolean

--- a/src/patches/inputBorderBox.ts
+++ b/src/patches/inputBorderBox.ts
@@ -1,19 +1,20 @@
 // Please see the note about writing patches in ./index
 
-import { showDiff } from './index';
+import { globalReplace } from './index';
 
 /**
  * Removes the input box border in Claude Code's PromptInput component.
  *
- * The PromptInput renders the input area in a ternary:
- *   swarmBanner ? (Fragment with ─.repeat lines using .bgColor) : (Box with borderStyle:"round" and borderText:)
+ * The main prompt box and the external-editor box ("Save and close editor")
+ * both spread a single hoisted props object that carries the input border:
+ *   vie=hO?{}:{borderColor:(()=>{...})(),borderStyle:"round",borderLeft:!1,borderRight:!1,borderBottom:!0}
+ * and each box renders as Jsx(Box,{...,...vie,width:"100%",...}).
  *
- * There's also an isExternalEditorActive path with borderStyle:"round" and "Save and close editor".
- *
- * We patch:
- * 1. The bgColor ─.repeat top and bottom lines → empty strings
- * 2. The main input Box's borderStyle:"round" → borderStyle:undefined (identified by borderText:)
- * 3. The external editor Box's borderStyle:"round" → borderStyle:undefined (identified by "Save and close editor")
+ * We disable the border on that shared object by turning its borderStyle:"round"
+ * into borderStyle:undefined. The borderLeft:!1,borderRight:!1,borderBottom:!0
+ * trailing makes the anchor unique (the top-only input border), so a global
+ * replace is safe; it also covers older CC where the main and editor boxes each
+ * carried this combo inline.
  */
 export const writeInputBoxBorder = (
   oldFile: string,
@@ -21,68 +22,16 @@ export const writeInputBoxBorder = (
 ): string | null => {
   if (!removeBorder) return oldFile;
 
-  let content = oldFile;
-  let patched = false;
+  const newFile = globalReplace(
+    oldFile,
+    /borderStyle:"round"(,borderLeft:!1,borderRight:!1,borderBottom:!0)/g,
+    (_m, trailing) => `borderStyle:undefined${trailing}`
+  );
 
-  // --- Path 1: swarmBanner branch (─.repeat lines with .bgColor) ---
-  // Bottom border: createElement(Text,{color:VAR.bgColor},"─".repeat(VAR))
-  const bottomBorderPattern =
-    /createElement\(([$\w]+),\{color:([$\w]+)\.bgColor\},"─"\.repeat\(([$\w]+)\)\)/;
-  const bottomMatch = content.match(bottomBorderPattern);
-  if (bottomMatch) {
-    const textComp = bottomMatch[1];
-    content = content.replace(
-      bottomMatch[0],
-      `createElement(${textComp},null,"")`
-    );
-
-    // Top border: createElement(Text,{color:VAR.bgColor},VAR.text?...Fragment..."─".repeat(...)..."──"):"─".repeat(VAR))
-    const topBorderPattern = new RegExp(
-      `createElement\\(${textComp},\\{color:${bottomMatch[2]}\\.bgColor\\},${bottomMatch[2]}\\.text\\?.+?"─"\\.repeat\\(${bottomMatch[3]}\\)\\)`
-    );
-    const topMatch = content.match(topBorderPattern);
-    if (topMatch) {
-      content = content.replace(
-        topMatch[0],
-        `createElement(${textComp},null,"")`
-      );
-    }
-    patched = true;
+  if (newFile === oldFile) {
+    console.error('patch: input border: failed to find input border pattern');
+    return null;
   }
 
-  // --- Path 2: Main input Box (else-branch with borderText:) ---
-  // Unique identifier: borderColor:VAR(),borderStyle:"round",...,borderText:VAR(...)
-  // The borderColor uses a function call like YB() and borderText uses a function call.
-  const mainInputPattern =
-    /(borderColor:[$\w]+\(\),)borderStyle:"round"(,borderLeft:!1,borderRight:!1,borderBottom:!0,width:"100%",borderText:)/;
-  const mainInputMatch = content.match(mainInputPattern);
-  if (mainInputMatch) {
-    content = content.replace(
-      mainInputMatch[0],
-      `${mainInputMatch[1]}borderStyle:undefined${mainInputMatch[2]}`
-    );
-    patched = true;
-  }
-
-  // --- Path 3: External editor Box ---
-  // Unique identifier: borderStyle:"round" near "Save and close editor"
-  // Pattern: borderStyle:"round",borderLeft:!1,borderRight:!1,borderBottom:!0,width:"100%"},...,"Save and close editor
-  const editorPattern =
-    /borderStyle:"round"(,borderLeft:!1,borderRight:!1,borderBottom:!0,width:"100%"\}.+?Save and close editor)/;
-  const editorMatch = content.match(editorPattern);
-  if (editorMatch) {
-    content = content.replace(
-      editorMatch[0],
-      `borderStyle:undefined${editorMatch[1]}`
-    );
-    patched = true;
-  }
-
-  if (patched) {
-    showDiff(oldFile, content, '(input border removed)', 0, 0);
-    return content;
-  }
-
-  console.error('patch: input border: failed to find input border pattern');
-  return null;
+  return newFile;
 };

--- a/src/patches/inputPatternHighlighters.test.ts
+++ b/src/patches/inputPatternHighlighters.test.ts
@@ -44,9 +44,6 @@ describe('writeInputPatternHighlighters', () => {
   });
 
   it('rewrites the JSX automatic-runtime renderer and shimmer (CC >=2.1.195)', () => {
-    // Real 2.1.195 shape: shimmer branch precedes the main renderer; both use
-    // JSXVAR.jsx(...) with key as the 3rd arg. The useMemo/warning-push block
-    // is included so writeCustomHighlighterCreation also runs.
     const input =
       'let props={inputValue:inputText,other:1};' +
       'if(x.highlight?.shimmerColor&&x.highlight.color)return M0e.jsx(w,{children:x.text.split("").map((k,D)=>M0e.jsx(OGe,{char:k,index:x.start+D,glimmerIndex:b,messageColor:x.highlight.color,shimmerColor:x.highlight.shimmerColor},D))},I);' +
@@ -58,18 +55,15 @@ describe('writeInputPatternHighlighters', () => {
     ]);
 
     expect(result).not.toBeNull();
-    // Augmented jsx renderer: forwards bold + applies the chalk `style` fn.
     expect(result).toContain(
       'bold:x.highlight?.style?void 0:x.highlight?.bold'
     );
     expect(result).toContain(
       'children:M0e.jsx(bd,{children:x.highlight?.style?x.highlight.style(x.text):x.text})'
     );
-    // Function-color guard inserted before the shimmer branch, in jsx form.
     expect(result).toContain(
       "if(typeof x.highlight?.color==='function')return M0e.jsx(w,{children:M0e.jsx(bd,{children:x.highlight.color(x.text)})},I);"
     );
-    // Creation codegen still wired, and nothing emitted via createElement.
     expect(result).toContain('matchAll(new RegExp("todo", "g"))');
     expect(result).toContain('style:(x)=>chalk(x),priority:100');
     expect(result).not.toContain('.createElement(');

--- a/src/patches/inputPatternHighlighters.test.ts
+++ b/src/patches/inputPatternHighlighters.test.ts
@@ -42,4 +42,36 @@ describe('writeInputPatternHighlighters', () => {
     expect(result).toContain('matchAll(new RegExp("todo", "g"))');
     expect(result).not.toContain('new RegExp("["');
   });
+
+  it('rewrites the JSX automatic-runtime renderer and shimmer (CC >=2.1.195)', () => {
+    // Real 2.1.195 shape: shimmer branch precedes the main renderer; both use
+    // JSXVAR.jsx(...) with key as the 3rd arg. The useMemo/warning-push block
+    // is included so writeCustomHighlighterCreation also runs.
+    const input =
+      'let props={inputValue:inputText,other:1};' +
+      'if(x.highlight?.shimmerColor&&x.highlight.color)return M0e.jsx(w,{children:x.text.split("").map((k,D)=>M0e.jsx(OGe,{char:k,index:x.start+D,glimmerIndex:b,messageColor:x.highlight.color,shimmerColor:x.highlight.shimmerColor},D))},I);' +
+      'return M0e.jsx(w,{color:x.highlight?.color,dimColor:x.highlight?.dimColor,inverse:x.highlight?.inverse,children:M0e.jsx(bd,{children:x.text})},I);' +
+      ';let ranges=Po.useMemo(()=>{let arr=[];if(a&&b&&!c)arr.push({start:s,end:s+l.length,color:"warning",priority:20})},[]);';
+
+    const result = writeInputPatternHighlighters(input, [
+      baseHighlighter({ name: 'valid', regex: 'todo', regexFlags: '' }),
+    ]);
+
+    expect(result).not.toBeNull();
+    // Augmented jsx renderer: forwards bold + applies the chalk `style` fn.
+    expect(result).toContain(
+      'bold:x.highlight?.style?void 0:x.highlight?.bold'
+    );
+    expect(result).toContain(
+      'children:M0e.jsx(bd,{children:x.highlight?.style?x.highlight.style(x.text):x.text})'
+    );
+    // Function-color guard inserted before the shimmer branch, in jsx form.
+    expect(result).toContain(
+      "if(typeof x.highlight?.color==='function')return M0e.jsx(w,{children:M0e.jsx(bd,{children:x.highlight.color(x.text)})},I);"
+    );
+    // Creation codegen still wired, and nothing emitted via createElement.
+    expect(result).toContain('matchAll(new RegExp("todo", "g"))');
+    expect(result).toContain('style:(x)=>chalk(x),priority:100');
+    expect(result).not.toContain('.createElement(');
+  });
 });

--- a/src/patches/inputPatternHighlighters.ts
+++ b/src/patches/inputPatternHighlighters.ts
@@ -36,11 +36,6 @@ const buildChalkChain = (
 // ======================================================================
 
 const writeCustomHighlighterImpl = (oldFile: string): string | null => {
-  // CC >=2.1.193 (JSX automatic runtime): the renderer is
-  //   return JSXVAR.jsx(TEXT,{color:SEG.highlight?.color,dimColor:SEG.highlight?.dimColor,
-  //     inverse:SEG.highlight?.inverse,children:JSXVAR.jsx(INNER,{children:SEG.text})},KEY)
-  // (key is the 3rd positional arg, not a prop). Try this first; on no match we
-  // fall through to the older createElement paths below.
   const jsxRenderRegex =
     /return ([$\w]+)\.jsx\(([$\w]+),\{color:([$\w]+)\.highlight\?\.color,dimColor:\3\.highlight\?\.dimColor,inverse:\3\.highlight\?\.inverse,children:\1\.jsx\(([$\w]+),\{children:\3\.text\}\)\},([$\w]+)\)/;
   const jsxMatch = oldFile.match(jsxRenderRegex);
@@ -52,9 +47,6 @@ const writeCustomHighlighterImpl = (oldFile: string): string | null => {
     const keyVar = jsxMatch[5];
     const esc = (s: string) => s.replace(/\$/g, '\\$');
 
-    // Insert a function-color guard BEFORE the shimmer branch (source order:
-    // shimmer precedes the main renderer) so function colors aren't swallowed
-    // by shimmer. The shimmer branch is now gated on shimmerColor&&color.
     const shimmerPattern = new RegExp(
       `if\\(${esc(segVar)}\\.highlight\\?\\.shimmerColor&&${esc(segVar)}\\.highlight\\.color\\)return ${esc(jsxVar)}\\.jsx\\(`
     );
@@ -72,9 +64,6 @@ const writeCustomHighlighterImpl = (oldFile: string): string | null => {
         workingFile.slice(shimmerMatch.index);
     }
 
-    // Re-find the renderer (index shifted by the guard insertion). The guard's
-    // jsx uses {children:...} not {color:...}, so jsxRenderRegex can only match
-    // the real renderer, never the inserted guard.
     const m2 = workingFile.match(jsxRenderRegex);
     if (!m2 || m2.index === undefined) {
       console.error(
@@ -88,9 +77,6 @@ const writeCustomHighlighterImpl = (oldFile: string): string | null => {
     const it = m2[4];
     const kv = m2[5];
 
-    // Mirror the createElement augmentedRenderer below, in jsx form: forward
-    // bold/italic/underline/strikethrough/backgroundColor and apply the chalk
-    // `style` function (pushed by writeCustomHighlighterCreation) when present.
     const augmentedRenderer =
       `return ${jv}.jsx(${ot},{` +
       `color:${sv}.highlight?.style?void 0:${sv}.highlight?.color,` +

--- a/src/patches/inputPatternHighlighters.ts
+++ b/src/patches/inputPatternHighlighters.ts
@@ -36,6 +36,83 @@ const buildChalkChain = (
 // ======================================================================
 
 const writeCustomHighlighterImpl = (oldFile: string): string | null => {
+  // CC >=2.1.193 (JSX automatic runtime): the renderer is
+  //   return JSXVAR.jsx(TEXT,{color:SEG.highlight?.color,dimColor:SEG.highlight?.dimColor,
+  //     inverse:SEG.highlight?.inverse,children:JSXVAR.jsx(INNER,{children:SEG.text})},KEY)
+  // (key is the 3rd positional arg, not a prop). Try this first; on no match we
+  // fall through to the older createElement paths below.
+  const jsxRenderRegex =
+    /return ([$\w]+)\.jsx\(([$\w]+),\{color:([$\w]+)\.highlight\?\.color,dimColor:\3\.highlight\?\.dimColor,inverse:\3\.highlight\?\.inverse,children:\1\.jsx\(([$\w]+),\{children:\3\.text\}\)\},([$\w]+)\)/;
+  const jsxMatch = oldFile.match(jsxRenderRegex);
+  if (jsxMatch && jsxMatch.index !== undefined) {
+    const jsxVar = jsxMatch[1];
+    const outerText = jsxMatch[2];
+    const segVar = jsxMatch[3];
+    const innerText = jsxMatch[4];
+    const keyVar = jsxMatch[5];
+    const esc = (s: string) => s.replace(/\$/g, '\\$');
+
+    // Insert a function-color guard BEFORE the shimmer branch (source order:
+    // shimmer precedes the main renderer) so function colors aren't swallowed
+    // by shimmer. The shimmer branch is now gated on shimmerColor&&color.
+    const shimmerPattern = new RegExp(
+      `if\\(${esc(segVar)}\\.highlight\\?\\.shimmerColor&&${esc(segVar)}\\.highlight\\.color\\)return ${esc(jsxVar)}\\.jsx\\(`
+    );
+
+    let workingFile = oldFile;
+    const shimmerMatch = workingFile.match(shimmerPattern);
+    if (shimmerMatch && shimmerMatch.index !== undefined) {
+      const shimmerGuard =
+        `if(typeof ${segVar}.highlight?.color==='function')` +
+        `return ${jsxVar}.jsx(${outerText},{children:` +
+        `${jsxVar}.jsx(${innerText},{children:${segVar}.highlight.color(${segVar}.text)})},${keyVar});`;
+      workingFile =
+        workingFile.slice(0, shimmerMatch.index) +
+        shimmerGuard +
+        workingFile.slice(shimmerMatch.index);
+    }
+
+    // Re-find the renderer (index shifted by the guard insertion). The guard's
+    // jsx uses {children:...} not {color:...}, so jsxRenderRegex can only match
+    // the real renderer, never the inserted guard.
+    const m2 = workingFile.match(jsxRenderRegex);
+    if (!m2 || m2.index === undefined) {
+      console.error(
+        'patch: inputPatternHighlighters: failed to re-find JSX renderer after shimmer patch'
+      );
+      return null;
+    }
+    const jv = m2[1];
+    const ot = m2[2];
+    const sv = m2[3];
+    const it = m2[4];
+    const kv = m2[5];
+
+    // Mirror the createElement augmentedRenderer below, in jsx form: forward
+    // bold/italic/underline/strikethrough/backgroundColor and apply the chalk
+    // `style` function (pushed by writeCustomHighlighterCreation) when present.
+    const augmentedRenderer =
+      `return ${jv}.jsx(${ot},{` +
+      `color:${sv}.highlight?.style?void 0:${sv}.highlight?.color,` +
+      `backgroundColor:${sv}.highlight?.style?void 0:${sv}.highlight?.backgroundColor,` +
+      `dimColor:${sv}.highlight?.dimColor,` +
+      `inverse:${sv}.highlight?.style?void 0:${sv}.highlight?.inverse,` +
+      `bold:${sv}.highlight?.style?void 0:${sv}.highlight?.bold,` +
+      `italic:${sv}.highlight?.style?void 0:${sv}.highlight?.italic,` +
+      `underline:${sv}.highlight?.style?void 0:${sv}.highlight?.underline,` +
+      `strikethrough:${sv}.highlight?.style?void 0:${sv}.highlight?.strikethrough,` +
+      `children:${jv}.jsx(${it},{children:${sv}.highlight?.style?${sv}.highlight.style(${sv}.text):${sv}.text})` +
+      `},${kv})`;
+
+    const newFile =
+      workingFile.slice(0, m2.index) +
+      augmentedRenderer +
+      workingFile.slice(m2.index + m2[0].length);
+
+    showDiff(oldFile, newFile, 'JSX shimmer guard + renderer', 0, 0);
+    return newFile;
+  }
+
   // CC <2.1.83: if(N.highlight?.color)return createElement(T,{key:E},color:N.highlight.color,...)
   const oldRegex =
     /(if\(([$\w]+)\.highlight\?\.color\))((return [$\w]+\.createElement\([$\w]+,\{key:[$\w]+),color:[$\w]+\.highlight\.color(\},[$\w]+\.createElement\([$\w]+,null,)([$\w]+\.text)(\)\)));/;


### PR DESCRIPTION
## Problem

Two input-box patches broke on Claude Code 2.1.195 (part of the JSX automatic-runtime migration, #822). Under the automatic runtime, `X.default.createElement(T,{key:K,...props},child)` becomes `JSXVAR.jsx(T,{...props,children:child},K)` — `key` moves from props to the 3rd positional arg.

- **input-box-border** — `writeInputBoxBorder()` returned `null`. The main prompt box and the external "Save and close editor" box now spread a single **hoisted props object** (`vie`/`TV`) that carries the border; the old anchors expected separate inline boxes with `borderColor:FUNC(),...,width:"100%",borderText:` (the `borderColor` is now an IIFE and `width:"100%",borderText:` moved to the spread site), plus a dead swarm-banner `createElement` path.
- **input-pattern-highlighters** — `writeInputPatternHighlighters()` returned `null` at `writeCustomHighlighterImpl failed`. That helper's renderer/shimmer anchors **and** its emitted codegen all used `createElement`.

## Fix

- **input-box-border** — replace the three old anchors with a single global replace that disables the border on the shared hoisted object, targeting its distinctive top-only combo `borderStyle:"round",borderLeft:!1,borderRight:!1,borderBottom:!0` → `borderStyle:undefined,…`. This combo appears exactly once per bundle and is spread into both boxes, so one edit removes the border from both. (The separate bash-mode border, `borderColor:…"bashBorder"…`, is intentionally left untouched, matching the original patch's scope.)
- **input-pattern-highlighters** — add a JSX-automatic-runtime branch to `writeCustomHighlighterImpl` that re-anchors the renderer and the shimmer branch and emits **jsx-convention** codegen (props spread, `children:` nesting, `key` as the 3rd arg) for the augmented renderer and the function-color guard. The existing `createElement` paths remain as fallbacks for older Claude Code. `writeCustomHighlighterCreation` (the `useMemo`/range-push codegen) is unchanged — verified it still matches on 2.1.195.

## Verification

- New unit tests: a new `inputBorderBox.test.ts` (it previously had none) and a JSX-runtime case added to `inputPatternHighlighters.test.ts` whose fixture mirrors the real 2.1.195 renderer + shimmer + the working `useMemo`/`color:"warning"`/`inputValue:` block, so the whole `writeInputPatternHighlighters` returns non-null. The existing createElement test still passes via the unchanged fallback. Full suite: 332 passed.
- Ran the real `writeInputBoxBorder` / `writeInputPatternHighlighters` (no mocks — `findChalkVar` runs for real) against freshly-extracted pristine **2.1.195** and **2.1.193** bundles, asserting on emitted output: the border combo is removed exactly once, the augmented jsx renderer forwards the style props and applies the chalk `style` function, the function-color shimmer guard is inserted, the `matchAll(...)`/`priority:100` creation codegen is present, and the highlighter codegen adds zero `createElement` calls. `node --check` passes on the combined patched bundle.

Part of #822. Closes #826.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input border removal to correctly rewrite hoisted “round” border combos (including border-style removal while preserving side settings).
  * Fixed custom highlighter transformations for newer automatic-runtime shimmer behavior with safer handling of `highlight.color`, plus preserved styling and correct child text rendering.
* **New Features**
  * Enhanced highlight prop forwarding to support additional styling: bold, italic, underline, strikethrough, background color, and inverse.
* **Tests**
  * Added/expanded automated coverage for border rewriting and the automatic-runtime shimmer transformation path.
* **Chores**
  * Updated the unreleased changelog entry for the Claude Code 2.1.195 patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->