### PR TITLE
Fix toolsets patch for Claude Code's JSX automatic runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix thinker-symbol-width and thinker-format patches for Claude Code's JSX automatic runtime (#835) - @StreamDemon
 - Fix hide-startup-clawd patch for Claude Code's JSX automatic runtime (#836) - @StreamDemon
 - Fix suppress-rate-limit-options, suppress-line-numbers, and suppress-native-installer-warning patches for Claude Code 2.1.195 (#838) - @StreamDemon
+- Fix toolsets patch for Claude Code's JSX automatic runtime (#841) - @StreamDemon
 
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 

--- a/src/patches/toolsets.test.ts
+++ b/src/patches/toolsets.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import {
   addCurrentToolsetAtToolChangeComponentScope,
+  findCurrentToolsetInjectionSpan,
   findSelectComponentName,
   insertShiftTabAppStateVar,
   writeToolsetFieldToAppState,
   appendToolsetToModeDisplay,
+  appendToolsetToShortcutsDisplay,
   writeComputeToolsFilter,
   writePrintToolsFilter,
   writeSubagentResolvedToolContextFix,
@@ -224,6 +226,24 @@ describe('toolsets missing state.toolset fallback', () => {
     );
   });
 
+  it('finds the statusline insertion point with the jsx-runtime bash hint', () => {
+    const file =
+      appStateAccessors +
+      'function Status(props){return jsxRT.jsx(w,{color:"bashBorder",children:"! for shell mode"})}';
+
+    const result = insertShiftTabAppStateVar(
+      file,
+      'default',
+      'accept-only',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      `let currentToolset=useAppState(state => ${modeAwareFallback});`
+    );
+  });
+
   it('initializes app state toolset as undefined so the mode binding applies at load', () => {
     const file = 'state={thinkingEnabled:FDH(),promptSuggestionEnabled:rX()}';
 
@@ -236,10 +256,12 @@ describe('toolsets missing state.toolset fallback', () => {
     expect(result).not.toContain('toolset:"');
   });
 
-  it('appends the live toolset to every mode display site', () => {
+  it('appends the live toolset to every in-scope mode display site', () => {
     const file =
+      'function Footer(){let currentToolset=getToolset();' +
       'let k6=el(y,{},sym(mode)," ",title(mode).toLowerCase()," on",hint);' +
-      'let NH=el(y,{},sym(mode)," ",title(mode).toLowerCase()," on",chord);';
+      'let NH=el(y,{},sym(mode)," ",title(mode).toLowerCase()," on",chord);' +
+      'return k6}';
 
     const result = appendToolsetToModeDisplay(file);
 
@@ -250,6 +272,38 @@ describe('toolsets missing state.toolset fallback', () => {
         /title\(mode\)\.toLowerCase\(\),currentToolset\?` on \[\$\{currentToolset\}\]`:""/g
       )
     ).toHaveLength(2);
+  });
+
+  it('does not append the toolset to mode sites outside the currentToolset scope', () => {
+    const file =
+      'function Footer(){let currentToolset=getToolset();' +
+      'inside(mode).toLowerCase()," on";return null}' +
+      'outside(mode).toLowerCase()," on";';
+
+    const result = appendToolsetToModeDisplay(file);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      'inside(mode).toLowerCase(),currentToolset?` on [${currentToolset}]`:""'
+    );
+    expect(result).toContain('outside(mode).toLowerCase()," on"');
+  });
+
+  it('appends the toolset only to in-scope "? for shortcuts" sites', () => {
+    const file =
+      'function Footer(){let currentToolset=getToolset();' +
+      'jsxRT.jsx(w,{children:"? for shortcuts"});return null}' +
+      'jsxRT.jsx(w,{children:"? for shortcuts"});';
+
+    const result = appendToolsetToShortcutsDisplay(file);
+
+    expect(result).not.toBeNull();
+    expect(
+      result!.match(
+        /currentToolset\?`\? for shortcuts \[\$\{currentToolset\}\]`:"\? for shortcuts"/g
+      )
+    ).toHaveLength(1);
+    expect(result).toContain('jsxRT.jsx(w,{children:"? for shortcuts"})');
   });
 
   it('uses the mode-aware fallback in the tool-change component scope', () => {
@@ -268,6 +322,56 @@ describe('toolsets missing state.toolset fallback', () => {
     expect(result).toContain(
       `const currentToolset = useAppState(state => ${modeAwareFallback});`
     );
+  });
+
+  it('finds the tool-change scope when the analytics call is comma-sequenced', () => {
+    const file =
+      appStateAccessors +
+      'wrap(arg,function(evt){track("tengu_ext_at_mentioned",{}),next(evt)})';
+
+    const result = addCurrentToolsetAtToolChangeComponentScope(
+      file,
+      'default',
+      'accept-only',
+      'plan-only'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toContain(
+      `const currentToolset = useAppState(state => ${modeAwareFallback});`
+    );
+  });
+});
+
+describe('findCurrentToolsetInjectionSpan', () => {
+  it('returns the enclosing function body span of the marker', () => {
+    const file =
+      'a();function F(){let currentToolset=x;body({k:1});return 0}tail();';
+
+    const span = findCurrentToolsetInjectionSpan(file);
+
+    expect(span).not.toBeNull();
+    expect(span!.start).toBe(file.indexOf('let currentToolset='));
+    expect(file.slice(span!.start, span!.end + 1)).toBe(
+      'let currentToolset=x;body({k:1});return 0}'
+    );
+  });
+
+  it('ignores braces inside string literals when walking out of the function', () => {
+    const file = 'function F(){let currentToolset=g("}{}");return 1}after();';
+
+    const span = findCurrentToolsetInjectionSpan(file);
+
+    expect(span).not.toBeNull();
+    expect(file.slice(span!.start, span!.end + 1)).toBe(
+      'let currentToolset=g("}{}");return 1}'
+    );
+  });
+
+  it('returns null when no marker is present', () => {
+    expect(
+      findCurrentToolsetInjectionSpan('function F(){return 1}')
+    ).toBeNull();
   });
 });
 
@@ -438,5 +542,28 @@ describe('findSelectComponentName', () => {
       'return R.createElement(Box,{children:items.map(option=>option.label)})}';
 
     expect(findSelectComponentName(input)).toBe('MenuSelect');
+  });
+
+  it('finds a Select rendered via the jsx runtime', () => {
+    const input =
+      'jsxRT.jsx(GenericSelect,{options:selectOptions,onChange:onSelect,onCancel:onCancel,isDisabled:!1});';
+
+    expect(findSelectComponentName(input)).toBe('GenericSelect');
+  });
+
+  it('finds a jsx-bodied Select from its signature when no createElement is present', () => {
+    const input =
+      'function MenuSelect({options:items,onChange:onPick,onCancel:onClose,placeholder:hint}){' +
+      'return jsxRT.jsx(Box,{children:items.map(option=>option.label)})}';
+
+    expect(findSelectComponentName(input)).toBe('MenuSelect');
+  });
+
+  it('skips the recommended-settings prompt rendered via jsx', () => {
+    const input =
+      'jsxRT.jsx(YesNoPrompt,{options:yesNoOptions,onChange:onYes,onCancel:onNo,children:"Yes, use recommended settings"});' +
+      'jsxRT.jsx(GenericSelect,{options:selectOptions,onChange:onSelect,onCancel:onCancel});';
+
+    expect(findSelectComponentName(input)).toBe('GenericSelect');
   });
 });

--- a/src/patches/toolsets.test.ts
+++ b/src/patches/toolsets.test.ts
@@ -368,6 +368,18 @@ describe('findCurrentToolsetInjectionSpan', () => {
     );
   });
 
+  it('ignores braces inside template literals when walking out of the function', () => {
+    const file =
+      'function F(){let currentToolset=x;let label=` on [${currentToolset}]`;return label}after();';
+
+    const span = findCurrentToolsetInjectionSpan(file);
+
+    expect(span).not.toBeNull();
+    expect(file.slice(span!.start, span!.end + 1)).toBe(
+      'let currentToolset=x;let label=` on [${currentToolset}]`;return label}'
+    );
+  });
+
   it('returns null when no marker is present', () => {
     expect(
       findCurrentToolsetInjectionSpan('function F(){return 1}')

--- a/src/patches/toolsets.ts
+++ b/src/patches/toolsets.ts
@@ -23,10 +23,10 @@ import { Toolset } from '../types';
 export const findSelectComponentName = (
   fileContents: string
 ): string | null => {
-  const createElementPattern =
-    /\.createElement\(([$\w]+),\{(?=[^}]{0,240}options:)(?=[^}]{0,240}onChange:)[^}]{0,360}\}/g;
+  const selectRenderPattern =
+    /\.(?:createElement|jsxs?)\(([$\w]+),\{(?=[^}]{0,240}options:)(?=[^}]{0,240}onChange:)[^}]{0,360}\}/g;
 
-  for (const match of fileContents.matchAll(createElementPattern)) {
+  for (const match of fileContents.matchAll(selectRenderPattern)) {
     const window = fileContents.slice(
       match.index,
       Math.min(fileContents.length, match.index + match[0].length + 180)
@@ -48,7 +48,10 @@ export const findSelectComponentName = (
         match.index,
         Math.min(fileContents.length, match.index + match[0].length + 1200)
       );
-      if (/\.createElement\(/.test(body) && !/return\s*\{/.test(body)) {
+      if (
+        /\.createElement\(|\.jsxs?\(/.test(body) &&
+        !/return\s*\{/.test(body)
+      ) {
         return match[1];
       }
     }
@@ -987,7 +990,8 @@ export const findShiftTabAppStateVarInsertionPoint = (
 ): number | null => {
   // Search for the bash mode indicator.
   // CC <2.1.140 used "! for bash mode"; CC >=2.1.140 renamed it to "! for shell mode".
-  const bashModePattern = /\{color:"bashBorder"\},"! for (?:bash|shell) mode"/;
+  const bashModePattern =
+    /\{color:"bashBorder"(?:\},|,children:)"! for (?:bash|shell) mode"/;
   const match = oldFile.match(bashModePattern);
 
   if (!match || match.index === undefined) {
@@ -1074,15 +1078,54 @@ export const insertShiftTabAppStateVar = (
 };
 
 /**
+ * Find the [start, end] span of the function body that contains the injected
+ * `let currentToolset=` marker (placed by insertShiftTabAppStateVar). The
+ * mode/shortcuts display rewrites are scoped to this span so every
+ * `currentToolset` read stays lexically inside the function that defines it:
+ * CC's JSX automatic-runtime refactor split the footer across functions, so a
+ * global rewrite could otherwise emit an out-of-scope read (ReferenceError at
+ * render). The walk skips braces inside string/template literals.
+ */
+export const findCurrentToolsetInjectionSpan = (
+  fileContents: string
+): { start: number; end: number } | null => {
+  const start = fileContents.indexOf('let currentToolset=');
+  if (start === -1) {
+    return null;
+  }
+
+  let depth = 1;
+  let inString: string | null = null;
+  let escape = false;
+  for (let i = start; i < fileContents.length; i++) {
+    const c = fileContents[i];
+    if (inString) {
+      if (escape) escape = false;
+      else if (c === '\\') escape = true;
+      else if (c === inString) inString = null;
+    } else if (c === '"' || c === "'" || c === '`') {
+      inString = c;
+    } else if (c === '{') {
+      depth++;
+    } else if (c === '}') {
+      depth--;
+      if (depth === 0) {
+        return { start, end: i };
+      }
+    }
+  }
+
+  return null;
+};
+
+/**
  * Append the toolset name to the mode display text
  */
 export const appendToolsetToModeDisplay = (oldFile: string): string | null => {
-  // Find every site where the mode text is rendered:
-  //   tl(Y).toLowerCase(), " on"
-  // Newer CC versions render the footer mode line from more than one of
-  // these sites (e.g. a variant with the "(shift+tab to cycle)" chord), so
-  // patch all of them. insertShiftTabAppStateVar defines `currentToolset`
-  // (a live app-state selector) in the enclosing component scope.
+  // Find every site where the mode text is rendered: tl(Y).toLowerCase(), " on"
+  // Newer CC versions render the footer mode line from more than one of these
+  // sites, but only those inside the function where insertShiftTabAppStateVar
+  // defined `currentToolset` may read it.
   const modeDisplayPattern = /([$\w]+)\(([$\w]+)\)\.toLowerCase\(\)," on"/g;
   const matches = Array.from(oldFile.matchAll(modeDisplayPattern));
 
@@ -1093,8 +1136,26 @@ export const appendToolsetToModeDisplay = (oldFile: string): string | null => {
     return null;
   }
 
+  const span = findCurrentToolsetInjectionSpan(oldFile);
+  if (!span) {
+    console.error(
+      'patch: toolsets: appendToolsetToModeDisplay: failed to find currentToolset injection span'
+    );
+    return oldFile;
+  }
+
+  const inScope = matches.filter(
+    m => m.index !== undefined && m.index >= span.start && m.index < span.end
+  );
+  if (inScope.length === 0) {
+    console.error(
+      'patch: toolsets: appendToolsetToModeDisplay: no mode display site within currentToolset scope; skipping'
+    );
+    return oldFile;
+  }
+
   let newFile = oldFile;
-  for (const match of [...matches].reverse()) {
+  for (const match of [...inScope].reverse()) {
     if (match.index === undefined) continue;
     const tlFunction = match[1];
     const modeVar = match[2];
@@ -1105,14 +1166,7 @@ export const appendToolsetToModeDisplay = (oldFile: string): string | null => {
       newFile.slice(match.index + match[0].length);
   }
 
-  if (newFile === oldFile) {
-    console.error(
-      'patch: toolsets: appendToolsetToModeDisplay: failed to modify mode display'
-    );
-    return null;
-  }
-
-  const lastMatch = matches[matches.length - 1];
+  const lastMatch = inScope[inScope.length - 1];
   showDiff(
     oldFile,
     newFile,
@@ -1132,34 +1186,51 @@ export const appendToolsetToShortcutsDisplay = (
 ): string | null => {
   const shortcutsPattern = /"\? for shortcuts"/g;
   const matches = Array.from(oldFile.matchAll(shortcutsPattern));
-
-  // Use the last match (there are two in 2.0.37, 1 in .41).
-  const match = matches.at(-1);
-  if (!match || match.index === undefined) {
+  if (matches.length === 0) {
     console.error(
       "patch: toolsets: appendToolsetToShortcutsDisplay: could not find '? for shortcuts'"
     );
     return null;
   }
 
-  // Replace with the new pattern that includes toolset
-  const oldText = match[0];
-  const newText = `currentToolset?\`? for shortcuts [\${currentToolset}]\`:"? for shortcuts"`;
-
-  const newFile = oldFile.replace(oldText, newText);
-  if (newFile === oldFile) {
+  // Only rewrite occurrences inside the function where insertShiftTabAppStateVar
+  // defined `currentToolset` (the footer is split across functions on CC's JSX
+  // runtime); a rewrite outside that scope would ReferenceError at render.
+  const span = findCurrentToolsetInjectionSpan(oldFile);
+  if (!span) {
     console.error(
-      'patch: toolsets: appendToolsetToShortcutsDisplay: failed to modify shortcuts display'
+      'patch: toolsets: appendToolsetToShortcutsDisplay: failed to find currentToolset injection span'
     );
-    return null;
+    return oldFile;
   }
 
+  const inScope = matches.filter(
+    m => m.index !== undefined && m.index >= span.start && m.index < span.end
+  );
+  if (inScope.length === 0) {
+    console.error(
+      'patch: toolsets: appendToolsetToShortcutsDisplay: no shortcuts site within currentToolset scope; skipping'
+    );
+    return oldFile;
+  }
+
+  const newText = `currentToolset?\`? for shortcuts [\${currentToolset}]\`:"? for shortcuts"`;
+  let newFile = oldFile;
+  for (const match of [...inScope].reverse()) {
+    if (match.index === undefined) continue;
+    newFile =
+      newFile.slice(0, match.index) +
+      newText +
+      newFile.slice(match.index + match[0].length);
+  }
+
+  const firstMatch = inScope[0];
   showDiff(
     oldFile,
     newFile,
     newText,
-    match.index,
-    match.index + oldText.length
+    firstMatch.index ?? 0,
+    (firstMatch.index ?? 0) + firstMatch[0].length
   );
 
   return newFile;
@@ -1209,7 +1280,7 @@ export const findToolChangeComponentScope = (
   fileContents: string
 ): number | null => {
   const pattern =
-    /[\w$]+\([\w$]+,function\([\w$]+\)\{[\w$]+\("tengu_ext_at_mentioned",\{\}\);/;
+    /[\w$]+\([\w$]+,function\([\w$]+\)\{[\w$]+\("tengu_ext_at_mentioned",\{\}\)[;,]/;
   const match = fileContents.match(pattern);
 
   if (!match || match.index === undefined) {

--- a/src/patches/toolsets.ts
+++ b/src/patches/toolsets.ts
@@ -1078,13 +1078,7 @@ export const insertShiftTabAppStateVar = (
 };
 
 /**
- * Find the [start, end] span of the function body that contains the injected
- * `let currentToolset=` marker (placed by insertShiftTabAppStateVar). The
- * mode/shortcuts display rewrites are scoped to this span so every
- * `currentToolset` read stays lexically inside the function that defines it:
- * CC's JSX automatic-runtime refactor split the footer across functions, so a
- * global rewrite could otherwise emit an out-of-scope read (ReferenceError at
- * render). The walk skips braces inside string/template literals.
+ * Find the function-body span holding the injected `let currentToolset=` marker.
  */
 export const findCurrentToolsetInjectionSpan = (
   fileContents: string
@@ -1122,10 +1116,6 @@ export const findCurrentToolsetInjectionSpan = (
  * Append the toolset name to the mode display text
  */
 export const appendToolsetToModeDisplay = (oldFile: string): string | null => {
-  // Find every site where the mode text is rendered: tl(Y).toLowerCase(), " on"
-  // Newer CC versions render the footer mode line from more than one of these
-  // sites, but only those inside the function where insertShiftTabAppStateVar
-  // defined `currentToolset` may read it.
   const modeDisplayPattern = /([$\w]+)\(([$\w]+)\)\.toLowerCase\(\)," on"/g;
   const matches = Array.from(oldFile.matchAll(modeDisplayPattern));
 
@@ -1193,9 +1183,6 @@ export const appendToolsetToShortcutsDisplay = (
     return null;
   }
 
-  // Only rewrite occurrences inside the function where insertShiftTabAppStateVar
-  // defined `currentToolset` (the footer is split across functions on CC's JSX
-  // runtime); a rewrite outside that scope would ReferenceError at render.
   const span = findCurrentToolsetInjectionSpan(oldFile);
   if (!span) {
     console.error(


### PR DESCRIPTION
## Problem

On Claude Code 2.1.195 the `toolsets` patch is dead: `writeToolsets()` aborts at its first kill-shot, `findSelectComponentName`. CC migrated its UI to React's JSX automatic runtime (`jsx`/`jsxs` instead of `X.createElement(...)`, with children moved inside the props object as `children:`), which broke several `toolsets` finders anchored on the old `createElement` shape. Once `findSelectComponentName` is fixed, two further finders fail in turn:

- `findSelectComponentName` — both the strategy-1 render anchor and the strategy-2 body guard required `.createElement(`; the Select now renders via `jsx`.
- `findShiftTabAppStateVarInsertionPoint` — the bash-mode hint moved from `{color:"bashBorder"},"! for … mode"` to `{color:"bashBorder",children:"! for … mode"}`.
- `findToolChangeComponentScope` — the `tengu_ext_at_mentioned` analytics call is now comma-sequenced, so the anchor's trailing `;` no longer matches.

(These regressed by 2.1.193, where the JSX-runtime migration landed.)

## Fix

Finder/anchor repair only — **no codegen rewrite**, all anchors stay backward-compatible:

- `findSelectComponentName`: accept `jsx`/`jsxs` render anchors in addition to `.createElement`, and widen the strategy-2 body guard to `/\.createElement\(|\.jsxs?\(/`. The "recommended settings" exclusion and the signature patterns are unchanged.
- `findShiftTabAppStateVarInsertionPoint`: match the bash hint in both its JSX (`,children:"…"`) and legacy (`},"…"`) forms.
- `findToolChangeComponentScope`: allow a trailing `;` or `,` (`\{\}\)[;,]`).

**Why the injected `createElement` UI is kept as-is:** `getReactVar` resolves to `vBi = __toESM(require_react(), 1)` — the full React **19.2** namespace, whose `createElement` export is still a callable function at runtime (CC's *compiler* stopped emitting `createElement`, but React still ships it; CC's own code uses the sibling export `vBi.createContext(...)`). Rewriting to `jsx` would require capturing a module-scope jsx var at a *fresh* insertion point, where there is no reliable one (jsx/jsxs are per-chunk, version-unstable esbuild vars) — so keeping `createElement` is both the smaller diff and the more robust choice.

**Scope-coherence hardening:** CC's JSX-runtime refactor split the footer across functions. `insertShiftTabAppStateVar` defines `let currentToolset=…` in one function, while `appendToolsetToModeDisplay` / `appendToolsetToShortcutsDisplay` rewrite consumer sites to *read* it. A new `findCurrentToolsetInjectionSpan` helper scopes those rewrites to the function that defines `currentToolset`, so every read stays in lexical scope — otherwise an out-of-scope read would `ReferenceError` at render. (Both in-scope `"? for shortcuts"` sites are now decorated, consistent with the mode-line which already rewrites all in-scope sites; out-of-function sites are excluded by construction.)

## Verification

Ran the real `writeToolsets` against freshly-extracted **2.1.195** and **2.1.193** bundles with a full config (exercising the mode-change / step-8 path). On both:

- applies (was `null`); injects the toolset component, the `toolset` slash command, and `let currentToolset=`;
- `findSelectComponentName` returns the real Select (`K6i`@195 / `v4i`@193);
- **scope coherence, independently checked:** the mode-line and shortcuts rewrite counts match the in-scope anchor counts derived from a *separate*, bash-hint-anchored span (2 mode + 2 shortcuts), and the one out-of-scope `"? for shortcuts"` site stays bare — i.e. no out-of-scope `currentToolset` read is emitted;
- `node --check` passes on the patched bundle.

Added 10 unit tests (jsx Select render + jsx body guard + recommended-settings exclusion; jsx bash hint; comma-sequenced tool-change scope; injection-span helper; in-scope vs out-of-scope mode/shortcuts rewrites). Full suite green; lint clean.

The injected `createElement` UI's live render is covered by the React-19-export reasoning above rather than a runtime render test.

Part of #822. Closes #829.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of toolset UI patching across varying render formats, including mode/shortcuts/bash indicators.
  * Tightened scoping so injected toolset text only rewrites within the correct `currentToolset` area.
  * Enhanced detection for Select and JSX automatic-runtime render patterns.
* **Tests**
  * Expanded coverage for toolset injection, in-scope/out-of-scope rewriting, and injection-span detection (including string/template literal brace handling).
* **Documentation**
  * Added a changelog entry for the latest toolsets patch fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->