### PR TITLE
Fix auto-accept-plan-mode patch for Claude Code's JSX automatic runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix thinker-symbol-width and thinker-format patches for Claude Code's JSX automatic runtime (#835) - @StreamDemon
 - Fix hide-startup-clawd patch for Claude Code's JSX automatic runtime (#836) - @StreamDemon
 - Fix suppress-rate-limit-options, suppress-line-numbers, and suppress-native-installer-warning patches for Claude Code 2.1.195 (#838) - @StreamDemon
+- Fix auto-accept-plan-mode patch for Claude Code's JSX automatic runtime (#842) - @StreamDemon
 
 ## [v4.2.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.2.0) - 2026-06-26
 

--- a/src/patches/autoAcceptPlanMode.test.ts
+++ b/src/patches/autoAcceptPlanMode.test.ts
@@ -17,4 +17,40 @@ describe('writeAutoAcceptPlanMode', () => {
       'h("yes-accept-edits-keep-context");return null;return R.default.createElement'
     );
   });
+
+  it('injects before the component return for the JSX-runtime memoized layout', () => {
+    // Mirrors CC 2.1.195: a single plan-approval select after the title (its
+    // onImagePaste/pastedContents/onRemoveImage props come from an embedded text
+    // input), an inner memoized callback whose return sits BEFORE the title, and the
+    // component's true top-level tail `else kr=t[105];return kr}` AFTER the title.
+    const input =
+      'function xEc(e){let t=Mc.c(106);' +
+      'let it;if(t[66]!==e)it=(q)=>{if(q)return q;return 0},t[66]=e,t[67]=it;else it=t[66];' +
+      'let vt;if(t[80]!==e)vt=R.jsx(Lf,{color:"planMode",title:"Ready to code?",children:xt}),t[80]=e,t[82]=vt;else vt=t[82];' +
+      'let Dn;if(t[88]!==Ie)Dn=(Mr)=>void Ie(Mr),t[88]=Ie,t[89]=Dn;else Dn=t[89];' +
+      'let nn;if(t[90]!==Ze)nn=R.jsx(Sr,{options:N,onChange:Dn,onCancel:Ze,onImagePaste:K,pastedContents:d,onRemoveImage:J}),t[90]=Ze,t[95]=nn;else nn=t[95];' +
+      'let kr;if(t[102]!==tt)kr=R.jsxs(U,{flexDirection:"column",tabIndex:0,autoFocus:!0,onKeyDown:tt,children:[vt,nn]}),t[102]=tt,t[105]=kr;else kr=t[105];return kr}';
+
+    const result = writeAutoAcceptPlanMode(input);
+
+    expect(result).not.toBeNull();
+    // Lands at the component's top-level return, not the inner callback before the title.
+    expect(result).toContain(
+      'else kr=t[105];Dn("yes-accept-edits-keep-context");return null;return kr}'
+    );
+    expect(result).toContain('it=(q)=>{if(q)return q;return 0}');
+  });
+
+  it('is idempotent on the JSX-runtime layout', () => {
+    const input =
+      'function xEc(e){let t=Mc.c(106);' +
+      'let vt;if(t[80]!==e)vt=R.jsx(Lf,{color:"planMode",title:"Ready to code?",children:xt}),t[80]=e,t[82]=vt;else vt=t[82];' +
+      'let Dn;if(t[88]!==Ie)Dn=(Mr)=>void Ie(Mr),t[88]=Ie,t[89]=Dn;else Dn=t[89];' +
+      'let nn;if(t[90]!==Ze)nn=R.jsx(Sr,{options:N,onChange:Dn,onCancel:Ze,onImagePaste:K,pastedContents:d,onRemoveImage:J}),t[90]=Ze,t[95]=nn;else nn=t[95];' +
+      'let kr;if(t[102]!==tt)kr=R.jsxs(U,{flexDirection:"column",tabIndex:0,autoFocus:!0,onKeyDown:tt,children:[vt,nn]}),t[102]=tt,t[105]=kr;else kr=t[105];return kr}';
+
+    const once = writeAutoAcceptPlanMode(input);
+    expect(once).not.toBeNull();
+    expect(writeAutoAcceptPlanMode(once as string)).toBe(once);
+  });
 });

--- a/src/patches/autoAcceptPlanMode.ts
+++ b/src/patches/autoAcceptPlanMode.ts
@@ -14,7 +14,10 @@
 
 import { showDiff } from './index';
 
-const findEnclosingFunctionReturn = (
+// Fallback for layouts with no createElement anchor: walk the function enclosing the
+// "Ready to code?" title and return the offset of its last top-level `return`.
+// String-aware so braces inside strings/template literals don't skew the depth count.
+const findComponentReturnInjectionPoint = (
   oldFile: string,
   readyIdx: number
 ): number | null => {
@@ -25,25 +28,31 @@ const findEnclosingFunctionReturn = (
   if (openBrace === -1 || openBrace > readyIdx) return null;
 
   let depth = 0;
+  let inString: string | null = null;
+  let escape = false;
+  let lastTopLevelReturn = -1;
   for (let index = openBrace; index < oldFile.length; index++) {
     const char = oldFile[index];
+    if (inString) {
+      if (escape) escape = false;
+      else if (char === '\\') escape = true;
+      else if (char === inString) inString = null;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      inString = char;
+      continue;
+    }
     if (char === '{') depth++;
     else if (char === '}') {
       depth--;
-      if (depth === 0) {
-        const functionTail = oldFile.slice(openBrace, index + 1);
-        const returnPattern = /return [$\w]+(?:\.default)?\.createElement/g;
-        let match: RegExpExecArray | null;
-        let lastMatch: RegExpExecArray | null = null;
-        while ((match = returnPattern.exec(functionTail)) !== null) {
-          lastMatch = match;
-        }
-        return lastMatch ? openBrace + lastMatch.index : null;
-      }
+      if (depth === 0) break;
+    } else if (depth === 1 && oldFile.startsWith('return ', index)) {
+      lastTopLevelReturn = index;
     }
   }
 
-  return null;
+  return lastTopLevelReturn === -1 ? null : lastTopLevelReturn;
 };
 
 const patchPlanModePrompts = (file: string): string => {
@@ -194,89 +203,29 @@ export const writeAutoAcceptPlanMode = (oldFile: string): string | null => {
     return null;
   }
 
-  // Find the injection point: just before the return that renders "Ready to code?"
-  // Look for the return statement with createElement containing title:"Ready to code?"
-  //
-  // CC <=2.1.69: }}}))))});return React.createElement(Fragment,null,React.createElement(COMP,{color:"planMode",title:"Ready to code?"
-  // CC >=2.1.83: return React.createElement(Box,{...},React.createElement(COMP,{color:"planMode",title:"Ready to code?"
+  // Inject just before the component's top-level return. Primary: the
+  // React-Compiler-memoized tail `else <v>=t[<n>];return <v>}` (backreference avoids
+  // an unrelated memo slot); fallback: the enclosing function's last top-level return.
+  const memoTailMatch = oldFile
+    .slice(readyIdx, readyIdx + 3000)
+    .match(/else ([$\w]+)=t\[\d+\];return \1\}/);
 
-  // Try the legacy pattern (after Exit plan mode conditional)
-  const legacyReturnPattern =
-    /(\}\}\)\)\)\);)(return [$\w]+\.default\.createElement\([$\w]+\.default\.Fragment,null,[$\w]+\.default\.createElement\([$\w]+,\{color:"planMode",title:"Ready to code\?")/;
+  const injectionIdx =
+    memoTailMatch && memoTailMatch.index !== undefined
+      ? readyIdx + memoTailMatch.index + memoTailMatch[0].indexOf('return ')
+      : findComponentReturnInjectionPoint(oldFile, readyIdx);
 
-  const legacyMatch = oldFile.match(legacyReturnPattern);
-
-  if (legacyMatch && legacyMatch.index !== undefined) {
-    const insertion = `${acceptFuncName}("yes-accept-edits-keep-context");return null;`;
-    const replacement = legacyMatch[1] + insertion + legacyMatch[2];
-    const startIndex = legacyMatch.index;
-    const endIndex = startIndex + legacyMatch[0].length;
-
-    const newFile =
-      oldFile.slice(0, startIndex) + replacement + oldFile.slice(endIndex);
-
-    showDiff(oldFile, newFile, replacement, startIndex, endIndex);
-    return patchPlanModePrompts(newFile);
+  if (injectionIdx === null) {
+    console.error(
+      'patch: autoAcceptPlanMode: failed to find component return before "Ready to code?"'
+    );
+    return null;
   }
 
-  // CC >=2.1.83: Find "return React.createElement(Box,{...title:"Ready to code?"
-  // The return is preceded by various patterns, find it by searching backwards from readyIdx.
-  // Newer bundles can place a long prop list before the title, so keep this
-  // wider than the old 500-byte window and fall back to function-level search.
-  const returnSearchStart = Math.max(0, readyIdx - 2500);
-  const beforeReady = oldFile.slice(returnSearchStart, readyIdx);
-
-  // Look for the return statement start
-  const returnMatch = beforeReady.match(
-    /(return [$\w]+\.default\.createElement\([$\w]+,\{flexDirection:"column",tabIndex:0,autoFocus:!0.{0,200}[$\w]+\.default\.createElement\([$\w]+,\{color:"planMode",title:")$/
-  );
-
-  if (!returnMatch) {
-    // Simpler approach: find "return" before "Ready to code?" that starts the component tree
-    const simpleReturnIdx = beforeReady.lastIndexOf('return ');
-    if (simpleReturnIdx === -1) {
-      const enclosingReturnIdx = findEnclosingFunctionReturn(oldFile, readyIdx);
-      if (enclosingReturnIdx === null) {
-        console.error(
-          'patch: autoAcceptPlanMode: failed to find return before "Ready to code?"'
-        );
-        return null;
-      }
-
-      const insertion = `${acceptFuncName}("yes-accept-edits-keep-context");return null;`;
-      const newFile =
-        oldFile.slice(0, enclosingReturnIdx) +
-        insertion +
-        oldFile.slice(enclosingReturnIdx);
-
-      showDiff(
-        oldFile,
-        newFile,
-        insertion,
-        enclosingReturnIdx,
-        enclosingReturnIdx
-      );
-      return patchPlanModePrompts(newFile);
-    }
-
-    const absoluteReturnIdx = returnSearchStart + simpleReturnIdx;
-    const insertion = `${acceptFuncName}("yes-accept-edits-keep-context");return null;`;
-
-    const newFile =
-      oldFile.slice(0, absoluteReturnIdx) +
-      insertion +
-      oldFile.slice(absoluteReturnIdx);
-
-    showDiff(oldFile, newFile, insertion, absoluteReturnIdx, absoluteReturnIdx);
-    return patchPlanModePrompts(newFile);
-  }
-
-  const absoluteStart = Math.max(0, readyIdx - 500) + returnMatch.index!;
   const insertion = `${acceptFuncName}("yes-accept-edits-keep-context");return null;`;
-
   const newFile =
-    oldFile.slice(0, absoluteStart) + insertion + oldFile.slice(absoluteStart);
+    oldFile.slice(0, injectionIdx) + insertion + oldFile.slice(injectionIdx);
 
-  showDiff(oldFile, newFile, insertion, absoluteStart, absoluteStart);
+  showDiff(oldFile, newFile, insertion, injectionIdx, injectionIdx);
   return patchPlanModePrompts(newFile);
 };

--- a/src/patches/autoAcceptPlanMode.ts
+++ b/src/patches/autoAcceptPlanMode.ts
@@ -206,9 +206,7 @@ export const writeAutoAcceptPlanMode = (oldFile: string): string | null => {
   // Inject just before the component's top-level return. Primary: the
   // React-Compiler-memoized tail `else <v>=t[<n>];return <v>}` (backreference avoids
   // an unrelated memo slot); fallback: the enclosing function's last top-level return.
-  const memoTailMatch = oldFile
-    .slice(readyIdx, readyIdx + 3000)
-    .match(/else ([$\w]+)=t\[\d+\];return \1\}/);
+  const memoTailMatch = afterReady.match(/else ([$\w]+)=t\[\d+\];return \1\}/);
 
   const injectionIdx =
     memoTailMatch && memoTailMatch.index !== undefined


### PR DESCRIPTION
## Problem

`auto-accept-plan-mode` is broken on CC 2.1.195 (JSX automatic runtime). The precise `createElement(...)` injection anchor is gone, so the patch's `lastIndexOf('return ')` fallback injected `<handler>(...);return null;` at a **garbage location** — the tail of an inner memoized callback ~1,059 chars *before* the `title:"Ready to code?"` locator — instead of the dialog component's true top-level return ~1,802 chars *after* it. The patch *applied* (no error) but silently did nothing, and could corrupt that inner callback.

### Correcting the issue's diagnosis

Measured against the pristine `2.1.195.orig` bundle (and confirmed on `2.1.193`), #830's original "wrong handler / two selects" framing is inaccurate:

- There is **exactly one** plan-approval select, and it sits **after** the title: `iy.jsx(Sr,{options:N,onChange:Dn,onCancel:Ze,onImagePaste:K,…})`. The `onImagePaste`/`pastedContents`/`onRemoveImage` props are present because one of its options is an embedded text input ("No, keep planning") — not a separate "prompt-input box".
- `value:"yes-accept-edits"` lives ~11,078 chars *before* the title, inside the `Hhm()` options *builder* — not a second select.
- `onChange:Dn`, where `Dn=(Mr)=>void Ie(Mr)`, already delegates to the real handler, so the existing `onChange:…,onCancel` extraction was **already correct**. The only real defect is the injection point.

(#830 has been updated to reflect this.)

## Fix

Keep the handler extraction and the prompt/permission rewrites (all their anchors still match on 2.1.195 + 2.1.193). Replace only the injection-point logic:

- **Primary:** the React-Compiler memoized tail `else <v>=t[<n>];return <v>}` — a backreference keeps it from matching an unrelated memo slot. Lands at `else kr=t[105];return kr}` (2.1.195) and `else Ir=t[105];return Ir}` (2.1.193).
- **Fallback:** a string-aware walk of the enclosing function for its last top-level `return` (covers non-memoized / legacy `createElement` layouts and keeps the existing test green).

This drops the `createElement` anchors and the `lastIndexOf('return ')` fallback. Calling the dispatch during render (`<handler>(...);return null;`) is the patch's pre-existing mechanism, restored at the correct location.

## Verification

- Ran the real `writeAutoAcceptPlanMode` against the extracted 2.1.195 (`.orig`) and 2.1.193 bundles: the injection lands at the component's top-level return (`else kr=t[105];Dn("yes-accept-edits-keep-context");return null;return kr}`, and the `wn`/`Ir` equivalent on 2.1.193); the permission anchors (`permission_exit_plan_mode_v2` default → allow, `checkPermissions` → allow) and prompt rewrites still apply; and `node --check` passes on the full patched bundle for both versions.
- Tests: kept the `createElement` fallback case; added a JSX-runtime memoized fixture (asserts injection at the top-level return, not the inner callback before the title) and an idempotency check. `pnpm run lint` + `pnpm run test` green.

Part of #822. Closes #830.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the plan-mode auto-accept patch for JSX automatic runtime output, ensuring the acceptance step is inserted at the correct top-level return (including memoized layouts).
  * Avoids injecting near nested returns.
  * Maintains idempotency when the patch is applied repeatedly.
* **Tests**
  * Added new test cases for JSX-runtime scenarios and verified that re-running the patch produces identical results.
* **Documentation**
  * Updated the changelog with the latest auto-accept-plan-mode fix entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->