### PR TITLE
Escape non-ASCII thinker symbols as \uXXXX to fix spinner mojibake on native installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Escape non-ASCII thinker symbols as `\uXXXX` to fix custom spinner mojibake on native binary installs (#853) - @StreamDemon
+
 ## [v4.3.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.0) - 2026-06-29
 
 - Add input chevron color patch (#634) - @VitalyOstanin

--- a/src/patches/helpers.test.ts
+++ b/src/patches/helpers.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
-import { findBoxComponent } from './helpers';
+import { escapeNonAscii, findBoxComponent } from './helpers';
+
+describe('escapeNonAscii', () => {
+  it('escapes non-ASCII code points as \\uXXXX and leaves ASCII untouched', () => {
+    expect(escapeNonAscii('·✢*')).toBe('\\u00b7\\u2722*');
+    expect(escapeNonAscii('plain ascii 123')).toBe('plain ascii 123');
+  });
+
+  it('produces output with no bytes > 127', () => {
+    const out = escapeNonAscii(JSON.stringify(['·', '✽', 'x']));
+    // eslint-disable-next-line no-control-regex
+    expect(/[^\x00-\x7f]/.test(out)).toBe(false);
+  });
+
+  it('escapes each surrogate half of an astral code point', () => {
+    // 🎉 (U+1F389) is a surrogate pair; both halves become \uXXXX and still
+    // reconstruct the emoji when the JS source is parsed.
+    expect(escapeNonAscii('🎉')).toBe('\\ud83c\\udf89');
+  });
+});
 
 describe('findBoxComponent', () => {
   it('finds the Box component rendered via the JSX runtime (jsx("ink-box"))', () => {

--- a/src/patches/helpers.ts
+++ b/src/patches/helpers.ts
@@ -1,5 +1,21 @@
 import { escapeIdent } from '.';
 
+/**
+ * Escapes every non-ASCII code unit as a `\uXXXX` sequence so injected source
+ * stays pure ASCII. Native Claude Code installs embed cli.js as a Latin-1 Bun
+ * module (the clean module has zero bytes > 127); injecting literal UTF-8 there
+ * is decoded one byte per code point at runtime → mojibake (e.g. "✢" → "â").
+ * `\uXXXX` escapes produce the same string in JS regardless of module encoding.
+ */
+export const escapeNonAscii = (text: string): string => {
+  // eslint-disable-next-line no-control-regex
+  const nonAscii = /[^\x00-\x7f]/g;
+  return text.replace(
+    nonAscii,
+    c => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`
+  );
+};
+
 export const findChalkVar = (fileContents: string): string | undefined => {
   // Find chalk variable using the counting method
   const chalkPattern =

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -86,6 +86,7 @@ import { compareVersions } from '../systemPromptSync';
 
 export { showDiff, showPositionalDiff, globalReplace } from './patchDiffing';
 export {
+  escapeNonAscii,
   findChalkVar,
   getModuleLoaderFunction,
   getReactModuleNameNonBun,

--- a/src/patches/thinkerSymbolChars.test.ts
+++ b/src/patches/thinkerSymbolChars.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { writeThinkerSymbolChars } from './thinkerSymbolChars';
+
+// Native Claude Code installs embed cli.js as a Latin-1 Bun module in which every
+// non-ASCII character is stored as a `\uXXXX` escape (the clean module has zero
+// bytes > 127). Injecting literal UTF-8 (via a naive JSON.stringify) is decoded
+// one byte per code point at runtime → mojibake (e.g. "✢" renders as "â").
+// The patch must therefore emit non-ASCII symbols as `\uXXXX` escapes so the
+// injected source stays pure ASCII.
+describe('writeThinkerSymbolChars', () => {
+  // A minimal bundle whose spinner array uses the escaped form CC actually ships.
+  const bundle =
+    'let A=["\\u00b7","\\u2722","*","\\u2733","\\u2736","\\u273b"];B()';
+
+  it('replaces the spinner array with the custom symbols', () => {
+    const out = writeThinkerSymbolChars(bundle, ['·', '✢', '*']);
+    expect(out).not.toBeNull();
+    expect(out).not.toBe(bundle);
+  });
+
+  it('emits non-ASCII symbols as \\uXXXX escapes, never literal UTF-8', () => {
+    const out = writeThinkerSymbolChars(bundle, ['·', '✢', '*', '✶', '✻', '✽']);
+    expect(out).not.toBeNull();
+    // The injected source must contain no byte > 127, or it mojibakes on native
+    // (Latin-1) installs.
+    // eslint-disable-next-line no-control-regex
+    expect(/[^\x00-\x7f]/.test(out!)).toBe(false);
+    // and the symbols must be present in their escaped form
+    expect(out).toContain('"\\u00b7"'); // ·
+    expect(out).toContain('"\\u2722"'); // ✢
+    expect(out).toContain('"*"'); // ASCII passes through untouched
+  });
+});

--- a/src/patches/thinkerSymbolChars.ts
+++ b/src/patches/thinkerSymbolChars.ts
@@ -1,6 +1,6 @@
 // Please see the note about writing patches in ./index
 
-import { LocationResult, showDiff } from './index';
+import { LocationResult, escapeNonAscii, showDiff } from './index';
 
 export const writeThinkerSymbolChars = (
   oldFile: string,
@@ -25,7 +25,10 @@ export const writeThinkerSymbolChars = (
     return null;
   }
 
-  const symbolsJson = JSON.stringify(symbols);
+  // Emit non-ASCII code points as `\uXXXX` escapes. Native installs store cli.js
+  // as a Latin-1 Bun module, so literal UTF-8 would mojibake at runtime. See
+  // escapeNonAscii in ./helpers.
+  const symbolsJson = escapeNonAscii(JSON.stringify(symbols));
 
   // Sort locations by start index in descending order to apply from end to beginning.
   const sortedLocations = locations.sort((a, b) => b.startIndex - a.startIndex);


### PR DESCRIPTION
Fixes #852.

## Problem
On **native binary** installs a custom non-ASCII thinking spinner (e.g. `thinkingStyle.phases = ["·","✢","*","✶","✻","✽"]`) renders as mojibake — a bare `â` instead of the glyph — even though the patch reports ✓.

## Root cause
Claude Code's native binary embeds `cli.js` as a **Latin-1** Bun module: the clean module is 100% ASCII (every non-ASCII char is stored as `\uXXXX`; **0 bytes > 127**, verified by extracting it). `thinkerSymbolChars` injected the symbols with `JSON.stringify(symbols)`, which emits **literal UTF-8** (e.g. `✢` → `E2 9C A2`). `content.ts` writes the module back as UTF-8 but preserves the module's Latin-1 `encoding` tag, so Bun decodes those multibyte sequences one byte per code point at runtime → `E2` → `â`.

This is the same reason sibling patches (`tableFormat`, `hideStartupClawd`) already emit `\uXXXX` escapes rather than literal Unicode.

## Fix
Add a shared `escapeNonAscii` helper (`src/patches/helpers.ts`) that rewrites every non-ASCII code unit as `\uXXXX`, and use it in `thinkerSymbolChars` so the injected array stays pure ASCII (`["·","✢","*","✶","✻","✽"]`). `\uXXXX` escapes produce the same string in JS regardless of module encoding, so this is correct for both native (Latin-1) and npm (UTF-8) installs.

## Verification
- New unit tests: `escapeNonAscii` (incl. surrogate pairs) and `thinkerSymbolChars` asserting the output contains **no byte > 127**.
- End-to-end against the real 2.1.199 native binary: extracted the clean JS, ran the fixed patch (output stays at **0** non-ASCII code units), repacked into the binary, and **extracted it back** — the spinner array is stored as `✢` etc. with **0 bytes > 127**, and the repacked binary runs (`2.1.199 (Claude Code)`).

Only `thinkerSymbolChars` is changed here (the reported bug). The same class latently affects any patch that injects user text via `JSON.stringify` (`patchesAppliedIndication`'s `✓`/`┃`, and `thinkingVerbs`/`themes`/`toolsets` if a user picks non-ASCII values) — noted in #852 for the maintainer to decide whether to sweep the rest or escape at the `content.ts` write boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-ASCII spinner symbols being displayed incorrectly in native binary installs by escaping them safely.
  * Ensured emoji and other special characters are preserved in escaped form, preventing garbled output.
* **Tests**
  * Added coverage for non-ASCII escaping and symbol serialization.
  * Expanded verification for existing helper behavior to confirm ASCII text remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->