### PR TITLE
Fix input-chevron-color anchor for CC 2.1.199 (isScreenReader field + 3-term guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix input-chevron-color patch for Claude Code 2.1.199 (chevron component gained an `isScreenReader` field and a third guard term) (#855) - @StreamDemon
+
 ## [v4.3.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.0) - 2026-06-29
 
 - Add input chevron color patch (#634) - @VitalyOstanin

--- a/src/patches/inputChevronColor.test.ts
+++ b/src/patches/inputChevronColor.test.ts
@@ -32,8 +32,6 @@ describe('writeInputChevronColor', () => {
   });
 
   it('handles the CC 2.1.199 shape (isScreenReader field + extra pointer var + 3-term guard)', () => {
-    // 2.1.199 inserts `isScreenReader:r` into the destructure, an extra
-    // `a=r?"$":ct.pointer` assignment, and a third `||t[2]!==a` guard term.
     const input =
       'var z=1,{isLoading:n,isScreenReader:r,themeColor:o}=e,i=o??void 0,a=r?"$":ct.pointer,l;' +
       'if(t[0]!==i||t[1]!==n||t[2]!==a)' +

--- a/src/patches/inputChevronColor.test.ts
+++ b/src/patches/inputChevronColor.test.ts
@@ -31,6 +31,20 @@ describe('writeInputChevronColor', () => {
     expect(result).toBeNull();
   });
 
+  it('handles the CC 2.1.199 shape (isScreenReader field + extra pointer var + 3-term guard)', () => {
+    // 2.1.199 inserts `isScreenReader:r` into the destructure, an extra
+    // `a=r?"$":ct.pointer` assignment, and a third `||t[2]!==a` guard term.
+    const input =
+      'var z=1,{isLoading:n,isScreenReader:r,themeColor:o}=e,i=o??void 0,a=r?"$":ct.pointer,l;' +
+      'if(t[0]!==i||t[1]!==n||t[2]!==a)' +
+      'l=yQe.jsxs(w,{color:i,dimColor:n,children:[a,"\\xA0"]}),t[0]=i;else l=t[3]';
+    const result = writeInputChevronColor(input, 'red');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('color:n?i:"red",dimColor:!1');
+    expect(result).not.toContain('color:i,dimColor:n');
+  });
+
   it('works with different identifier names', () => {
     const input =
       'var a=1,{isLoading:X$,themeColor:Y$}=Z$,W$=Y$??void 0,V$;' +

--- a/src/patches/inputChevronColor.ts
+++ b/src/patches/inputChevronColor.ts
@@ -5,8 +5,14 @@ export const writeInputChevronColor = (
   file: string,
   resolvedColor: string
 ): string | null => {
+  // CC 2.1.199 inserts `isScreenReader:r` between isLoading and themeColor, adds
+  // an extra `a=r?"$":ct.pointer` assignment after `color=themeColor??void 0`,
+  // and a third `||t[2]!==a` guard term. Tolerate additional destructured fields
+  // (`(?:[$\w]+:[$\w]+,)*`), any extra assignments before the `;` (`[^;]*`), and
+  // extra guard terms (`[^)]*`), while still capturing isLoading (1), themeColor
+  // (2), and the resolved-color var (3).
   const pattern =
-    /,\{isLoading:([$\w]+),themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[$\w]+;if\([$\w]+\[0\]!==\3\|\|[$\w]+\[1\]!==\1\)[$\w]+=[$\w]+\.jsxs\([$\w]+,\{color:\3,dimColor:\1,children:/;
+    /,\{isLoading:([$\w]+),(?:[$\w]+:[$\w]+,)*themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[^;]*;if\([^)]*\[0\]!==\3[^)]*\|\|[^)]*\[1\]!==\1[^)]*\)[$\w]+=[$\w]+\.jsxs\([$\w]+,\{color:\3,dimColor:\1,children:/;
 
   const match = file.match(pattern);
 

--- a/src/patches/inputChevronColor.ts
+++ b/src/patches/inputChevronColor.ts
@@ -5,12 +5,6 @@ export const writeInputChevronColor = (
   file: string,
   resolvedColor: string
 ): string | null => {
-  // CC 2.1.199 inserts `isScreenReader:r` between isLoading and themeColor, adds
-  // an extra `a=r?"$":ct.pointer` assignment after `color=themeColor??void 0`,
-  // and a third `||t[2]!==a` guard term. Tolerate additional destructured fields
-  // (`(?:[$\w]+:[$\w]+,)*`), any extra assignments before the `;` (`[^;]*`), and
-  // extra guard terms (`[^)]*`), while still capturing isLoading (1), themeColor
-  // (2), and the resolved-color var (3).
   const pattern =
     /,\{isLoading:([$\w]+),(?:[$\w]+:[$\w]+,)*themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[^;]*;if\([^)]*\[0\]!==\3[^)]*\|\|[^)]*\[1\]!==\1[^)]*\)[$\w]+=[$\w]+\.jsxs\([$\w]+,\{color:\3,dimColor:\1,children:/;
 


### PR DESCRIPTION
Fixes #846.

## Problem
`input-chevron-color` reports ✗ on recent CC (confirmed on **2.1.199**, native binary, Linux x64). The chevron idle color isn't applied.

## Root cause
CC 2.1.199 restructured the chevron component. The patch's anchor expected:

```js
{isLoading:X,themeColor:Y}=Z,W=Y??void 0,V;if(t[0]!==W||t[1]!==X)...jsxs(...,{color:W,dimColor:X,children:
```

but 2.1.199 emits:

```js
{isLoading:n,isScreenReader:r,themeColor:o}=e,i=o??void 0,a=r?"$":ct.pointer,l;
if(t[0]!==i||t[1]!==n||t[2]!==a)l=yQe.jsxs(w,{color:i,dimColor:n,children:[a,"\xA0"]}),...
```

Three changes broke the regex: (1) a new `isScreenReader:r` field sits between `isLoading` and `themeColor`; (2) an extra `a=r?"$":ct.pointer` assignment appears after `color=themeColor??void 0`; (3) a third `||t[2]!==a` guard term was added.

## Fix
Loosen the anchor to tolerate extra destructured fields (`(?:[$\w]+:[$\w]+,)*`), extra assignments before the `;` (`[^;]*`), and extra guard terms (`[^)]*`) — still capturing isLoading, themeColor, and the resolved-color var. The `color:X,dimColor:Y` → `color:isLoading?resolved:CUSTOM,dimColor:!1` rewrite is unchanged, so behavior is preserved.

## Verification
- Existing tests still pass; added a test for the exact 2.1.199 shape.
- Against the real 2.1.199 native bundle, the rewrite now lands at the chevron:
  `…t[2]!==a)l=yQe.jsxs(w,{color:n?i:"ansi:blue",dimColor:!1,children:[a,…`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of the input-chevron color patch with newer Claude Code patterns (including screen-reader-related state and additional guard terms), ensuring the correct `color`/`dimColor` rewrite still applies.
* **Tests**
  * Added a Vitest case covering the newer input-chevron pattern to prevent regressions in the patched color logic.
* **Documentation**
  * Updated the Unreleased changelog entry to reflect the input-chevron color fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->