### PR TITLE
Fix agents-md async reader anchor for CC 2.1.199 (reader refactored into stat+read helper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix agents-md patch for Claude Code 2.1.199 (the async CLAUDE.md reader was refactored into a stat+read helper) (#856) - @StreamDemon
+
 ## [v4.3.0](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.0) - 2026-06-29
 
 - Add input chevron color patch (#634) - @VitalyOstanin

--- a/src/patches/agentsMd.test.ts
+++ b/src/patches/agentsMd.test.ts
@@ -62,10 +62,6 @@ describe('agentsMd', () => {
       expect(result).toBeNull();
     });
 
-    // CC 2.1.199 refactored the async reader: the read moved into a helper
-    // (aN, which stats then readFiles) and a regular-file/size guard was added.
-    // A missing CLAUDE.md makes aN's stat throw ENOENT → the reader's catch, so
-    // the AGENTS.md reroute must be injected there.
     const asyncReader199 =
       'async function aya(e,t,n){try{let r=Vt(),o=await aN(r,e,Ypo);' +
       'if(o===null)return T(`[CLAUDE.md] skipping ${e}: not a regular file or exceeds ${Ypo} byte limit`),{info:null,includePaths:[]};' +

--- a/src/patches/agentsMd.test.ts
+++ b/src/patches/agentsMd.test.ts
@@ -61,5 +61,33 @@ describe('agentsMd', () => {
       const result = writeAgentsMd('not a valid file', altNames);
       expect(result).toBeNull();
     });
+
+    // CC 2.1.199 refactored the async reader: the read moved into a helper
+    // (aN, which stats then readFiles) and a regular-file/size guard was added.
+    // A missing CLAUDE.md makes aN's stat throw ENOENT → the reader's catch, so
+    // the AGENTS.md reroute must be injected there.
+    const asyncReader199 =
+      'async function aya(e,t,n){try{let r=Vt(),o=await aN(r,e,Ypo);' +
+      'if(o===null)return T(`[CLAUDE.md] skipping ${e}: not a regular file or exceeds ${Ypo} byte limit`),{info:null,includePaths:[]};' +
+      'return FHp(o,e,t,n)}catch(r){return jHp(r,e),{info:null,includePaths:[]}}}';
+
+    it('handles the CC 2.1.199 async reader (reroute injected into catch)', () => {
+      const result = writeAgentsMd(asyncReader199, altNames);
+      expect(result).not.toBeNull();
+      expect(result).toContain('async function aya(e,t,n,didReroute)');
+      expect(result).toContain('endsWith("/CLAUDE.md")');
+      expect(result).toContain('AGENTS.md');
+      // recursion passes the extra params through + didReroute=true
+      expect(result).toContain('await aya(altPath,t,n,true)');
+      // original success + skip branches are preserved
+      expect(result).toContain('return FHp(o,e,t,n)');
+      expect(result).toContain('if(o===null)return T(');
+      // reroute sits before the original error-handler return in the catch
+      const catchIdx = result!.indexOf('catch(r){');
+      const rerouteIdx = result!.indexOf('!didReroute', catchIdx);
+      const errReturnIdx = result!.indexOf('return jHp(r,e)', catchIdx);
+      expect(rerouteIdx).toBeGreaterThan(catchIdx);
+      expect(rerouteIdx).toBeLessThan(errReturnIdx);
+    });
   });
 });

--- a/src/patches/agentsMd.ts
+++ b/src/patches/agentsMd.ts
@@ -16,12 +16,71 @@ export const writeAgentsMd = (
   file: string,
   altNames: string[]
 ): string | null => {
-  // Try the new async pattern first (CC >=2.1.83)
+  // Try the CC >=2.1.199 async pattern first (reader refactored into a stat+read
+  // helper with a regular-file/size guard).
+  const async2199 = writeAgentsMdAsync2199(file, altNames);
+  if (async2199) return async2199;
+
+  // Then the CC 2.1.83–2.1.198 async pattern (inline readFile).
   const asyncResult = writeAgentsMdAsync(file, altNames);
   if (asyncResult) return asyncResult;
 
   // Fall back to the old sync pattern (CC <=2.1.69)
   return writeAgentsMdSync(file, altNames);
+};
+
+/**
+ * CC >=2.1.199 async reader. The read moved into a helper (`aN`, which stats the
+ * path then readFiles) and a regular-file/size guard was added:
+ *
+ *   async function aya(e,t,n){try{let r=Vt(),o=await aN(r,e,Ypo);
+ *     if(o===null)return T(`[CLAUDE.md] ...`),{info:null,includePaths:[]};
+ *     return FHp(o,e,t,n)}catch(r){return jHp(r,e),{info:null,includePaths:[]}}}
+ *
+ * A missing CLAUDE.md makes `aN`'s `stat` throw ENOENT, which propagates to this
+ * catch — so that's where the AGENTS.md reroute is injected. The `o===null`
+ * branch (not a regular file / too big) is intentionally left untouched.
+ */
+const writeAgentsMdAsync2199 = (
+  file: string,
+  altNames: string[]
+): string | null => {
+  const pattern =
+    /async function ([$\w]+)\(([$\w]+),([$\w]+),([$\w]+)\)\{try\{let [$\w]+=[$\w]+\(\),([$\w]+)=await [$\w]+\(([$\w]+),\2,[$\w]+\);if\(\5===null\)return [$\w]+\(`\[CLAUDE\.md\][^`]*`\),\{info:null,includePaths:\[\]\};return [$\w]+\(\5,\2,\3,\4\)\}catch\(([$\w]+)\)\{return ([$\w]+)\(\7,\2\),\{info:null,includePaths:\[\]\}\}\}/;
+
+  const m = file.match(pattern);
+  if (!m || m.index === undefined) return null;
+
+  const funcName = m[1]; // aya
+  const pathParam = m[2]; // e (the CLAUDE.md path)
+  const p2 = m[3]; // t
+  const p3 = m[4]; // n
+  const catchVar = m[7]; // r
+  const errorHandler = m[8]; // jHp
+
+  const altNamesJson = JSON.stringify(altNames);
+
+  const oldSig = `async function ${funcName}(${pathParam},${p2},${p3})`;
+  const newSig = `async function ${funcName}(${pathParam},${p2},${p3},didReroute)`;
+
+  const oldCatch = `catch(${catchVar}){return ${errorHandler}(${catchVar},${pathParam}),{info:null,includePaths:[]}}`;
+  const reroute =
+    `if(!didReroute&&(${pathParam}.endsWith("/CLAUDE.md")||${pathParam}.endsWith("\\\\CLAUDE.md"))){` +
+    `for(let alt of ${altNamesJson}){let altPath=${pathParam}.slice(0,-9)+alt;` +
+    `try{let _r=await ${funcName}(altPath,${p2},${p3},true);if(_r.info)return _r}catch{}}}`;
+  const newCatch = `catch(${catchVar}){${reroute}return ${errorHandler}(${catchVar},${pathParam}),{info:null,includePaths:[]}}`;
+
+  let fn = m[0];
+  fn = fn.replace(oldSig, newSig);
+  fn = fn.replace(oldCatch, newCatch);
+
+  const startIndex = m.index;
+  const endIndex = startIndex + m[0].length;
+  const newFile = file.slice(0, startIndex) + fn + file.slice(endIndex);
+
+  showDiff(file, newFile, fn, startIndex, endIndex);
+
+  return newFile;
 };
 
 const writeAgentsMdAsync = (

--- a/src/patches/agentsMd.ts
+++ b/src/patches/agentsMd.ts
@@ -16,31 +16,15 @@ export const writeAgentsMd = (
   file: string,
   altNames: string[]
 ): string | null => {
-  // Try the CC >=2.1.199 async pattern first (reader refactored into a stat+read
-  // helper with a regular-file/size guard).
   const async2199 = writeAgentsMdAsync2199(file, altNames);
   if (async2199) return async2199;
 
-  // Then the CC 2.1.83–2.1.198 async pattern (inline readFile).
   const asyncResult = writeAgentsMdAsync(file, altNames);
   if (asyncResult) return asyncResult;
 
-  // Fall back to the old sync pattern (CC <=2.1.69)
   return writeAgentsMdSync(file, altNames);
 };
 
-/**
- * CC >=2.1.199 async reader. The read moved into a helper (`aN`, which stats the
- * path then readFiles) and a regular-file/size guard was added:
- *
- *   async function aya(e,t,n){try{let r=Vt(),o=await aN(r,e,Ypo);
- *     if(o===null)return T(`[CLAUDE.md] ...`),{info:null,includePaths:[]};
- *     return FHp(o,e,t,n)}catch(r){return jHp(r,e),{info:null,includePaths:[]}}}
- *
- * A missing CLAUDE.md makes `aN`'s `stat` throw ENOENT, which propagates to this
- * catch — so that's where the AGENTS.md reroute is injected. The `o===null`
- * branch (not a regular file / too big) is intentionally left untouched.
- */
 const writeAgentsMdAsync2199 = (
   file: string,
   altNames: string[]
@@ -51,12 +35,12 @@ const writeAgentsMdAsync2199 = (
   const m = file.match(pattern);
   if (!m || m.index === undefined) return null;
 
-  const funcName = m[1]; // aya
-  const pathParam = m[2]; // e (the CLAUDE.md path)
-  const p2 = m[3]; // t
-  const p3 = m[4]; // n
-  const catchVar = m[7]; // r
-  const errorHandler = m[8]; // jHp
+  const funcName = m[1];
+  const pathParam = m[2];
+  const p2 = m[3];
+  const p3 = m[4];
+  const catchVar = m[7];
+  const errorHandler = m[8];
 
   const altNamesJson = JSON.stringify(altNames);
 


### PR DESCRIPTION
Fixes #851.

## Problem
`agents-md` ("AGENTS.md (and others)") reports ✗ on CC 2.1.199 (native binary); alternative memory filenames aren't picked up. (Worked on 2.1.185 — a fresh regression.)

## Root cause
`writeAgentsMdAsync` expected the async CLAUDE.md reader to `readFile` inline. On 2.1.199 the read was refactored into a helper and gained a regular-file/size guard:

```js
async function aN(e,t,n){let r=await e.stat(t);if(!r.isFile()||r.size>n)return null;return await e.readFile(t,{encoding:"utf8"})}

async function aya(e,t,n){try{let r=Vt(),o=await aN(r,e,Ypo);
  if(o===null)return T(`[CLAUDE.md] skipping ${e}: ...`),{info:null,includePaths:[]};
  return FHp(o,e,t,n)}catch(r){return jHp(r,e),{info:null,includePaths:[]}}}
```

There's no inline `readFile(…,{encoding:"utf-8"})` in `aya` anymore, so the old async pattern missed → the code fell back to the sync matcher, which also found nothing (`failed to find fs expression`).

A **missing** CLAUDE.md makes `aN`'s `stat` throw ENOENT, which propagates to `aya`'s `catch` — so that's where the AGENTS.md reroute belongs (the `o===null` branch is only the not-a-regular-file / too-big case).

## Fix
Add `writeAgentsMdAsync2199`, tried before the older async and sync matchers. It matches the new `aya` shape (capturing the function name, path param, pass-through params, catch var, and error handler via backreferences tying the structure together), then injects the reroute loop into the catch and adds a `didReroute` guard param — the same rerouting strategy the patch has always used. Older async/sync installs are untouched (existing matchers remain as fallbacks).

## Verification
- Existing sync-path tests still pass; added a test for the 2.1.199 `aya` shape.
- Against the real 2.1.199 native bundle the patch applies (Δ +233) and produces a well-formed function:

```js
async function aya(e,t,n,didReroute){try{let r=Vt(),o=await aN(r,e,Ypo);if(o===null)return T(`[CLAUDE.md] skipping ${e}: ...`),{info:null,includePaths:[]};return FHp(o,e,t,n)}catch(r){if(!didReroute&&(e.endsWith("/CLAUDE.md")||e.endsWith("\\CLAUDE.md"))){for(let alt of ["AGENTS.md",...]){let altPath=e.slice(0,-9)+alt;try{let _r=await aya(altPath,t,n,true);if(_r.info)return _r}catch{}}}return jHp(r,e),{info:null,includePaths:[]}}}
```

(braces balanced, original branches preserved, recursion guarded by `didReroute`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `CLAUDE.md` patching for newer Claude Code (e.g., CC 2.1.199) with reroute support when reads fail, and stronger handling for alternate filename/path endings.
  * Added a version-specific async patch step before the existing async/sync fallback chain.
* **Tests**
  * Added coverage for the CC 2.1.199 async-reader scenario, asserting signature updates and correct reroute/fallback behavior.
* **Documentation**
  * Updated the changelog under **Unreleased** with the latest fix entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->