### PR TITLE
fix: match awaited agent-color write in session-color patch

### DIFF
--- a/src/patches/sessionColor.test.ts
+++ b/src/patches/sessionColor.test.ts
@@ -6,6 +6,11 @@ const makeSaveAgentColor = () =>
   'if(Hv(K,{type:"agent-color",agentColor:$,sessionId:H}),H===V$())' +
   'WA().currentSessionAgentColor=$;c("tengu_agent_color_set",{})}';
 
+const makeAsyncSaveAgentColor = () =>
+  ';async function Mr$(H,$,q){let K=q??sT(H);' +
+  'if(await Hv(K,{type:"agent-color",agentColor:$,sessionId:H}),H===V$())' +
+  'WA().currentSessionAgentColor=$;c("tengu_agent_color_set",{})}';
+
 const makeCLIState = () =>
   'effortValue:oR(w.effort),' +
   'activeOverlays:new Set,fastMode:cP8(N5),' +
@@ -19,6 +24,8 @@ const makeBoth = () =>
 
 const makeFullFile = () => makeBoth() + makeSaveAgentColor();
 
+const makeFullFileAsync = () => makeBoth() + makeAsyncSaveAgentColor();
+
 describe('sessionColor', () => {
   describe('writeSessionColor', () => {
     it('should inject into CLI initialState and patch saveAgentColor', () => {
@@ -27,6 +34,14 @@ describe('sessionColor', () => {
       expect(result).toContain('TWEAKCC_SESSION_COLOR');
       expect(result).toContain('{name:"",color:__c}');
       expect(result).toContain('__tweakccSaveAgentColor');
+    });
+
+    it('should inject and patch async saveAgentColor', () => {
+      const result = writeSessionColor(makeFullFileAsync());
+      expect(result).not.toBeNull();
+      expect(result).toContain('TWEAKCC_SESSION_COLOR');
+      expect(result).toContain('__tweakccSaveAgentColor');
+      expect(result).toContain('if(await Hv(K,');
     });
 
     it('should inject into default app state', () => {
@@ -80,6 +95,13 @@ describe('sessionColor', () => {
       const result = patchSaveAgentColor(makeSaveAgentColor());
       expect(result).not.toBeNull();
       expect(result).toContain('globalThis.__tweakccSaveAgentColor');
+    });
+
+    it('should patch async saveAgentColor with awaited write', () => {
+      const result = patchSaveAgentColor(makeAsyncSaveAgentColor());
+      expect(result).not.toBeNull();
+      expect(result).toContain('globalThis.__tweakccSaveAgentColor');
+      expect(result).toContain('if(await Hv(K,');
     });
 
     it('should return null when pattern not found', () => {

--- a/src/patches/sessionColor.ts
+++ b/src/patches/sessionColor.ts
@@ -81,7 +81,7 @@ export const patchSaveAgentColor = (oldFile: string): string | null => {
       '(async function ([$\\w]+)' +
       '\\(([$\\w]+),([$\\w]+),([$\\w]+)\\)' +
       '\\{let [$\\w]+=\\6\\?\\?[$\\w]+\\(\\4\\);' +
-      'if\\([$\\w]+\\([$\\w]+,' +
+      'if\\((?:await )?[$\\w]+\\([$\\w]+,' +
       '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}\\),' +
       '\\4===([$\\w]+)\\(\\)\\))'
   );


### PR DESCRIPTION
## Problem

On Claude Code 2.1.201 the `session-color` patch fails with pattern-not-found, so setting the prompt bar color via `TWEAKCC_SESSION_COLOR` no longer works.

## Cause

CC 2.1.201 made the agent-settings write asynchronous. The `saveAgentColor` body changed from:

```
if(KV(r,{type:"agent-color",...}),r===...)
```

to:

```
if(await KV(r,{type:"agent-color",...}),r===...)
```

`patchSaveAgentColor` matched `if\([$\w]+\(` and did not account for the `await ` keyword, so the whole patch bailed out via its null-return path.

## Fix

Make the `await ` prefix optional in the regex:

```
if\((?:await )?[$\w]+\([$\w]+,
```

This matches both the pre-2.1.201 synchronous form and the new asynchronous form, so the patch keeps working on older versions too. Added tests for the awaited variant (`patchSaveAgentColor` and the full `writeSessionColor` path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session color handling so patches work correctly when the color update runs asynchronously.
  * Expanded matching to cover both standard and delayed update flows, reducing missed updates in supported sessions.

* **Tests**
  * Added coverage for the asynchronous session color flow to verify the updated behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->