### PR TITLE
fix: match try/catch agent-color write in session-color patch

### DIFF
--- a/src/patches/sessionColor.test.ts
+++ b/src/patches/sessionColor.test.ts
@@ -11,6 +11,12 @@ const makeAsyncSaveAgentColor = () =>
   'if(await Hv(K,{type:"agent-color",agentColor:$,sessionId:H}),H===V$())' +
   'WA().currentSessionAgentColor=$;c("tengu_agent_color_set",{})}';
 
+const makeTryCatchSaveAgentColor = () =>
+  ';async function Mr$(H,$,q){let K=q??sT(H);' +
+  'try{await Hv(K,{type:"agent-color",agentColor:$,sessionId:H})}' +
+  'catch(z){if(Qd(z))w(`saveAgentColor failed (${Yt(z)}): ${ne(z)}`,{level:"error"});else throw z}' +
+  'if(H===V$())WA().currentSessionAgentColor=$;c("tengu_agent_color_set",{})}';
+
 const makeCLIState = () =>
   'effortValue:oR(w.effort),' +
   'activeOverlays:new Set,fastMode:cP8(N5),' +
@@ -102,6 +108,14 @@ describe('sessionColor', () => {
       expect(result).not.toBeNull();
       expect(result).toContain('globalThis.__tweakccSaveAgentColor');
       expect(result).toContain('if(await Hv(K,');
+    });
+
+    it('should patch saveAgentColor with try/catch awaited write', () => {
+      const result = patchSaveAgentColor(makeTryCatchSaveAgentColor());
+      expect(result).not.toBeNull();
+      expect(result).toContain('globalThis.__tweakccSaveAgentColor');
+      expect(result).toContain('try{await Hv(K,');
+      expect(result).toContain('(c)=>Mr$(V$(),c)');
     });
 
     it('should return null when pattern not found', () => {

--- a/src/patches/sessionColor.ts
+++ b/src/patches/sessionColor.ts
@@ -76,21 +76,21 @@ export const writeSessionColor = (oldFile: string): string | null => {
 };
 
 export const patchSaveAgentColor = (oldFile: string): string | null => {
+  const prefix =
+    '([,;{}])' +
+    '(async function ([$\\w]+)' +
+    '\\(([$\\w]+),([$\\w]+),([$\\w]+)\\)' +
+    '\\{let [$\\w]+=\\6\\?\\?[$\\w]+\\(\\4\\);';
+
   const patterns = [
     new RegExp(
-      '([,;{}])' +
-        '(async function ([$\\w]+)' +
-        '\\(([$\\w]+),([$\\w]+),([$\\w]+)\\)' +
-        '\\{let [$\\w]+=\\6\\?\\?[$\\w]+\\(\\4\\);' +
+      prefix +
         'if\\((?:await )?[$\\w]+\\([$\\w]+,' +
         '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}\\),' +
         '\\4===([$\\w]+)\\(\\)\\))'
     ),
     new RegExp(
-      '([,;{}])' +
-        '(async function ([$\\w]+)' +
-        '\\(([$\\w]+),([$\\w]+),([$\\w]+)\\)' +
-        '\\{let [$\\w]+=\\6\\?\\?[$\\w]+\\(\\4\\);' +
+      prefix +
         'try\\{await [$\\w]+\\([$\\w]+,' +
         '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}\\)\\}' +
         'catch\\([$\\w]+\\)\\{[\\s\\S]*?\\}' +

--- a/src/patches/sessionColor.ts
+++ b/src/patches/sessionColor.ts
@@ -76,16 +76,34 @@ export const writeSessionColor = (oldFile: string): string | null => {
 };
 
 export const patchSaveAgentColor = (oldFile: string): string | null => {
-  const pattern = new RegExp(
-    '([,;{}])' +
-      '(async function ([$\\w]+)' +
-      '\\(([$\\w]+),([$\\w]+),([$\\w]+)\\)' +
-      '\\{let [$\\w]+=\\6\\?\\?[$\\w]+\\(\\4\\);' +
-      'if\\((?:await )?[$\\w]+\\([$\\w]+,' +
-      '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}\\),' +
-      '\\4===([$\\w]+)\\(\\)\\))'
-  );
-  const match = oldFile.match(pattern);
+  const patterns = [
+    new RegExp(
+      '([,;{}])' +
+        '(async function ([$\\w]+)' +
+        '\\(([$\\w]+),([$\\w]+),([$\\w]+)\\)' +
+        '\\{let [$\\w]+=\\6\\?\\?[$\\w]+\\(\\4\\);' +
+        'if\\((?:await )?[$\\w]+\\([$\\w]+,' +
+        '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}\\),' +
+        '\\4===([$\\w]+)\\(\\)\\))'
+    ),
+    new RegExp(
+      '([,;{}])' +
+        '(async function ([$\\w]+)' +
+        '\\(([$\\w]+),([$\\w]+),([$\\w]+)\\)' +
+        '\\{let [$\\w]+=\\6\\?\\?[$\\w]+\\(\\4\\);' +
+        'try\\{await [$\\w]+\\([$\\w]+,' +
+        '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}\\)\\}' +
+        'catch\\([$\\w]+\\)\\{[\\s\\S]*?\\}' +
+        'if\\(\\4===([$\\w]+)\\(\\)\\))'
+    ),
+  ];
+
+  let match: RegExpMatchArray | null = null;
+  for (const pattern of patterns) {
+    match = oldFile.match(pattern);
+    if (match && match.index !== undefined) break;
+    match = null;
+  }
   if (!match || match.index === undefined) {
     return null;
   }


### PR DESCRIPTION
Claude Code 2.1.204 rewrote `saveAgentColor` to wrap the transcript write in `try/catch` and moved the session-id check into a separate `if`, so the `patchSaveAgentColor` pattern (which expected `if(await Z(...),A===W())`) no longer matched and the whole session-color patch returned `null`.

This adds the new try/catch shape as an alternative pattern while keeping the previous if-based pattern for older Claude Code versions. Both shapes expose the same capture groups, so extraction is unchanged.

A test covering the 2.1.204 try/catch structure (with a template-literal + object literal inside the catch body) is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color-save patching to handle an async implementation that wraps the write in a `try/catch`, improving compatibility across app variations.
  * Kept the injected save hook and callback behavior consistent so the expected patched flow is preserved.
* **Tests**
  * Added unit coverage for the `try/catch`-based async save scenario to confirm the patch is applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->