### PR TITLE
fix: match semicolon-separated chevron init in input-chevron-color patch

### DIFF
--- a/src/patches/inputChevronColor.test.ts
+++ b/src/patches/inputChevronColor.test.ts
@@ -43,6 +43,19 @@ describe('writeInputChevronColor', () => {
     expect(result).not.toContain('color:i,dimColor:n');
   });
 
+  it('handles the CC 2.1.204 shape (semicolon after void 0 + const/let between init and guard)', () => {
+    const input =
+      'var z=1,{isLoading:QFp,isScreenReader:MOC,themeColor:$OC}=POC,' +
+      'ZFp=$OC??void 0;const e2p=MOC?"$":Oe.pointer;let w9_;' +
+      'if(OOC[0]!==ZFp||OOC[1]!==QFp||OOC[2]!==e2p)' +
+      'w9_=I_e.jsxs(h,{color:ZFp,dimColor:QFp,children:[e2p,"\\xA0"]}),OOC[0]=ZFp';
+    const result = writeInputChevronColor(input, 'red');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('color:QFp?ZFp:"red",dimColor:!1');
+    expect(result).not.toContain('color:ZFp,dimColor:QFp');
+  });
+
   it('works with different identifier names', () => {
     const input =
       'var a=1,{isLoading:X$,themeColor:Y$}=Z$,W$=Y$??void 0,V$;' +

--- a/src/patches/inputChevronColor.ts
+++ b/src/patches/inputChevronColor.ts
@@ -6,7 +6,7 @@ export const writeInputChevronColor = (
   resolvedColor: string
 ): string | null => {
   const pattern =
-    /,\{isLoading:([$\w]+),(?:[$\w]+:[$\w]+,)*themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0,[^;]*;if\([^)]*\[0\]!==\3[^)]*\|\|[^)]*\[1\]!==\1[^)]*\)[$\w]+=[$\w]+\.jsxs\([$\w]+,\{color:\3,dimColor:\1,children:/;
+    /,\{isLoading:([$\w]+),(?:[$\w]+:[$\w]+,)*themeColor:([$\w]+)\}=[$\w]+,([$\w]+)=\2\?\?void 0[,;][^{}]*?if\([^)]*\[0\]!==\3[^)]*\|\|[^)]*\[1\]!==\1[^)]*\)[$\w]+=[$\w]+\.jsxs\([$\w]+,\{color:\3,dimColor:\1,children:/;
 
   const match = file.match(pattern);
 


### PR DESCRIPTION
Claude Code 2.1.204 changed the input chevron component so the resolved-color init now ends with a semicolon (`??void 0;`) followed by `const`/`let` statements before the memo guard, instead of `??void 0,` directly before it. The old pattern expected `??void 0,[^;]*;if(`, so it no longer matched.

This relaxes the pattern to accept either separator after `void 0` (`[,;]`) and to skip intermediate statements up to the guard, staying compatible with older Claude Code versions.

A test covering the 2.1.204 shape is added alongside the existing 2.1.199 test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for input chevron color handling in more app builds, so the color update now applies more reliably.
  * Fixed a case where some inputs could miss the intended loading-state styling and fallback color behavior.

* **Tests**
  * Added coverage for a newer input shape to help prevent regressions in this color behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->