### PR TITLE
Fix over-escaping of backslashes in backtick-delimited system prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix over-escaping of backslashes in backtick-delimited system prompts that produced invalid JS and crashed Claude Code at startup (#870) - @StreamDemon
+
 ## [v4.3.1](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.1) - 2026-07-06
 
 - Preserve literal backslashes when applying system prompts to JavaScript string literals (#664) - @mike1858

--- a/src/patches/systemPrompts.test.ts
+++ b/src/patches/systemPrompts.test.ts
@@ -273,7 +273,7 @@ describe('systemPrompts.ts', () => {
       );
     });
 
-    it('should escape backslashes before backticks to preserve literal backslash-backticks (#660)', async () => {
+    it('should preserve already-escaped backticks in template literals (round-trips to vanilla)', async () => {
       const mockPromptData = buildMockPromptData({
         content: 'Use \\`foo\\` for config',
         regex: 'Use \\\\`foo\\\\` for config',
@@ -287,7 +287,7 @@ describe('systemPrompts.ts', () => {
 
       const result = await applySystemPrompts(cliContent, '1.0.0', false);
 
-      expect(result.newContent).toBe('desc:`Use \\\\\\`foo\\\\\\` for config`');
+      expect(result.newContent).toBe('desc:`Use \\`foo\\` for config`');
     });
 
     it('should auto-escape backticks adjacent to template expressions', async () => {
@@ -321,17 +321,17 @@ describe('systemPrompts.ts', () => {
 
       const result = await applySystemPrompts(cliContent, '1.0.0', false);
 
-      expect(result.newContent).toBe('desc:`Use \\\\\\${name} literally`');
+      expect(result.newContent).toBe('desc:`Use \\${name} literally`');
       expect(
         new Function(
           'const name = "expanded"; return { ' + result.newContent + ' };'
         )()
       ).toEqual({
-        desc: 'Use \\${name} literally',
+        desc: 'Use ${name} literally',
       });
     });
 
-    it('should escape backslashes in already-escaped backticks and also escape bare backticks (#660)', async () => {
+    it('should preserve already-escaped backticks and auto-escape bare backticks in template literals', async () => {
       const mockPromptData = buildMockPromptData({
         content: 'Use \\`foo\\` and `bar` for config',
         regex: 'Use \\\\`foo\\\\` and `bar` for config',
@@ -346,7 +346,7 @@ describe('systemPrompts.ts', () => {
       const result = await applySystemPrompts(cliContent, '1.0.0', false);
 
       expect(result.newContent).toBe(
-        'desc:`Use \\\\\\`foo\\\\\\` and \\`bar\\` for config`'
+        'desc:`Use \\`foo\\` and \\`bar\\` for config`'
       );
     });
 
@@ -553,6 +553,141 @@ describe('systemPrompts.ts', () => {
       expect(result.results[0].details).toContain('too complex');
       expect(result.results[1].id).toBe('good-prompt');
       expect(result.results[1].applied).toBe(true);
+    });
+  });
+
+  describe('backtick round-trip byte-identity (#869)', () => {
+    const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    const applyBacktick = async (source: string) => {
+      setupMocks(
+        buildMockPromptData({
+          content: source,
+          regex: escapeRegex(source),
+          getInterpolatedContent: () => source,
+          pieces: [source],
+        })
+      );
+      const cliContent = 'x:`' + source + '`';
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+      expect(result.results[0].details ?? '').not.toContain('incomplete');
+      return { newContent: result.newContent, cliContent };
+    };
+
+    it('preserves an escaped backtick inside a ${...} interpolation (the fatal case)', async () => {
+      const { newContent, cliContent } = await applyBacktick(
+        '${l?`\\`${y}\\``:y}'
+      );
+      expect(newContent).toBe(cliContent);
+    });
+
+    it('preserves an escaped backtick at depth 0 (the cosmetic case)', async () => {
+      const { newContent, cliContent } = await applyBacktick('\\`${MC}\\`');
+      expect(newContent).toBe(cliContent);
+    });
+
+    it('preserves nested template literals inside an interpolation', async () => {
+      const { newContent, cliContent } = await applyBacktick(
+        '${a?`${b?`deep`:`also`}`:`flat`}'
+      );
+      expect(newContent).toBe(cliContent);
+    });
+
+    it('preserves an escaped interpolation marker', async () => {
+      const { newContent, cliContent } = await applyBacktick(
+        'Use \\${name} literally'
+      );
+      expect(newContent).toBe(cliContent);
+    });
+
+    it('preserves an escaped non-ASCII sequence without doubling its backslash', async () => {
+      const { newContent, cliContent } = await applyBacktick(
+        'em dash \\u2014 here'
+      );
+      expect(newContent).toBe(cliContent);
+    });
+
+    it('still auto-escapes a genuinely raw backtick in prose', async () => {
+      const { newContent } = await applyBacktick('Use `foo`');
+      expect(newContent).toBe('x:`Use \\`foo\\``');
+    });
+
+    it('still doubles backslashes for single-quoted (#660) prompts', async () => {
+      setupMocks(
+        buildMockPromptData({
+          content: "It\\'s working",
+          regex: "It\\\\'s working",
+          getInterpolatedContent: () => "It\\'s working",
+          pieces: ["It\\'s working"],
+        })
+      );
+      const result = await applySystemPrompts(
+        "msg:'It\\'s working'",
+        '1.0.0',
+        false
+      );
+      expect(result.newContent).toBe("msg:'It\\\\\\'s working'");
+    });
+
+    it('emits a template literal that evaluates back to the intended prompt text', async () => {
+      const { newContent: n1 } = await applyBacktick('${l?`\\`${y}\\``:y}');
+      expect(
+        new Function('const l = true, y = "IDX"; return { ' + n1 + ' };')()
+      ).toEqual({ x: '`IDX`' });
+
+      const { newContent: n2 } = await applyBacktick('\\`${MC}\\`');
+      expect(new Function('const MC = "F"; return { ' + n2 + ' };')()).toEqual({
+        x: '`F`',
+      });
+
+      const { newContent: n3 } = await applyBacktick('Use \\${name} literally');
+      expect(
+        new Function('const name = "X"; return { ' + n3 + ' };')()
+      ).toEqual({ x: 'Use ${name} literally' });
+    });
+
+    it('escapeDepthZeroBackticks is byte-identity on template-literal prompts in the recent snapshots', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const dir = 'data/prompts';
+      const files = fs
+        .readdirSync(dir)
+        .filter(f => /^prompts-\d+\.\d+\.\d+\.json$/.test(f))
+        .sort((a, b) => {
+          const pa = a
+            .match(/(\d+)\.(\d+)\.(\d+)/)!
+            .slice(1)
+            .map(Number);
+          const pb = b
+            .match(/(\d+)\.(\d+)\.(\d+)/)!
+            .slice(1)
+            .map(Number);
+          return pb[0] - pa[0] || pb[1] - pa[1] || pb[2] - pa[2];
+        })
+        .slice(0, 15);
+      const failures: string[] = [];
+      let checked = 0;
+      for (const file of files) {
+        const parsed = JSON.parse(
+          fs.readFileSync(path.join(dir, file), 'utf8')
+        );
+        for (const p of parsed.prompts ?? []) {
+          const recon = promptSync.reconstructContentFromPieces(
+            p.pieces,
+            p.identifiers,
+            p.identifierMap
+          );
+          if (!recon.includes('\\`')) continue;
+          checked++;
+          const { content, incomplete } =
+            promptSync.escapeDepthZeroBackticks(recon);
+          if (content !== recon || incomplete) {
+            failures.push(`${parsed.version}:${p.id}`);
+          }
+        }
+      }
+      expect(checked).toBeGreaterThan(0);
+      expect(failures).toEqual([]);
     });
   });
 });

--- a/src/patches/systemPrompts.ts
+++ b/src/patches/systemPrompts.ts
@@ -172,15 +172,8 @@ export const applySystemPrompts = async (
 
       let replacementContent = interpolatedContent;
 
-      if (delimiter === '"' || delimiter === "'" || delimiter === '`') {
+      if (delimiter === '"' || delimiter === "'") {
         replacementContent = replacementContent.replace(/\\/g, '\\\\');
-      }
-
-      if (delimiter === '`') {
-        replacementContent = replacementContent.replace(
-          /\\\\\$\{/g,
-          '\\\\\\${'
-        );
       }
 
       if (delimiter === '"') {


### PR DESCRIPTION
`tweakcc --apply` writes a `cli.js` that Claude Code refuses to load:

```
SyntaxError: Unexpected identifier '$'. Expected ':' in ternary operator.
```

The cause is one line. `src/patches/systemPrompts.ts:176` (added by #664) doubles every backslash in the injected content for the `"`, `'`, and backtick delimiters. Backtick-delimited prompt content is template-literal source that already carries valid escapes, including `\`` inside live `${...}` interpolations. Doubling `\`` gives `\\`` (escaped backslash, then an unescaped backtick), which closes a nested template early. On `System Prompt: Team memory index pointer instructions`:

```
vanilla:  ${l?`\`${y}\``:y}
patched:  ${l?`\\`${y}\\``:y}
```

`${y}` now sits where the ternary's `:` belongs. That is the crash. This prompt is not one tweakcc modifies, so every `--apply` on an affected version produces the broken bundle (the prompt ships since 2.1.173). Two more memory-pointer prompts hit a depth-0 variant that stays valid JS but silently gains stray backslashes in the rendered text.

## The change

Restrict the backslash-doubling to the `"` and `'` delimiters, and drop the backtick-only `\\${` fixup that existed only to patch up the doubling. `escapeDepthZeroBackticks` already escapes genuine depth-0 backticks and leaves interpolation interiors verbatim, so the backtick path needs nothing more.

This reverts only the backtick-delimiter change #664 made. The `"`/`'` path is byte-for-byte unchanged from `main`, so #660 (literal `\'` in quote-delimited prompts, which is what #664 actually closed) is untouched. It restores the backtick path to its pre-#664, #576-era behavior.

## Evidence

- Reconstruct-then-embed round-trips byte-identical to vanilla for every backtick-delimited prompt in the recent snapshots: 2,788 checks, 0 diffs.
- Applied against the real native 2.1.207 and published 2.1.206 bundles: `node --check` was failing at the team-memory site, now clean, and the patched region matches vanilla byte-for-byte.
- The escaped-non-ASCII path is fixed by the same change: the old doubling also turned `—` into `\\u2014` on native installs.

## Tests

Three template-literal tests asserted the corrupted output; they now assert the round-trip form. The `"`/`'` #660 tests are unchanged. A new byte-identity suite covers the fatal interpolation case, the depth-0 case, nested templates, an escaped `\${`, raw-backtick auto-escape, and the `'`-quoted #660 case, with a `new Function` check that the emitted template evaluates back to the intended text, plus a corpus scan over the snapshots.

## One limitation

Backtick-delimited prompts no longer auto-escape a hand-typed literal backslash in prose, so a customized prompt must write `C:\\path` rather than `C:\path`. This is the pre-#664 behavior, and it cannot be restored without re-corrupting the vanilla `\`` / `\uXXXX` sequences above. A post-apply parse check on the generated `cli.js` is the general guard for that class and is worth a follow-up.

Closes #869


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed over-escaping in backtick-delimited system prompts that could generate invalid JavaScript and prevent Claude Code from starting.
  * Preserved escaped backticks, interpolation markers, nested templates, and non-ASCII escape sequences during prompt processing.
  * Improved round-trip consistency for prompt content, including raw backticks and escaped characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->