### PR TITLE
Fix Claude Code 2.1.209+ patch regressions: --apply startup crash and dead React-dependent patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Fix over-escaping of backslashes in backtick-delimited system prompts that produced invalid JS and crashed Claude Code at startup (#870) - @StreamDemon
-- Fix thinking-block-visibility patch for Claude Code 2.1.209 and later (the early return is now `if(...){return null}`, so an unbounded `.+?` spanned ~7.6KB into an unrelated function and the replacement deleted it, crashing Claude Code at startup) (#TBD) - @StreamDemon
+- Fix thinking-block-visibility patch for Claude Code 2.1.209 and later (the early return is now `if(...){return null}`, so an unbounded `.+?` spanned ~7.6KB into an unrelated function and the replacement deleted it, crashing Claude Code at startup) (#882) - @StreamDemon
+- Fix React variable resolution for Claude Code 2.1.209 and later, restoring the patches-applied indication, conversation-title, and toolsets patches (modules are now wrapped in function expressions rather than arrow functions) (#882) - @StreamDemon
 
 ## [v4.3.1](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.1) - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Fix over-escaping of backslashes in backtick-delimited system prompts that produced invalid JS and crashed Claude Code at startup (#870) - @StreamDemon
+- Fix thinking-block-visibility patch for Claude Code 2.1.209 and later (the early return is now `if(...){return null}`, so an unbounded `.+?` spanned ~7.6KB into an unrelated function and the replacement deleted it, crashing Claude Code at startup) (#TBD) - @StreamDemon
 
 ## [v4.3.1](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.1) - 2026-07-06
 

--- a/src/patches/helpers.test.ts
+++ b/src/patches/helpers.test.ts
@@ -1,6 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { escapeNonAscii, findBoxComponent } from './helpers';
+import {
+  clearReactVarCache,
+  escapeNonAscii,
+  findBoxComponent,
+  getReactModuleFunctionBun,
+  getReactModuleNameNonBun,
+  getReactVar,
+} from './helpers';
+
+const LOADER = 'var Zq=1,H=(e,t,r)=>{r=e!=null?Xq(Zq(e)):{};return r};';
+
+const ARROW_BUNDLE =
+  LOADER +
+  'var n7L=X((yg)=>{var s2i=Symbol.for("react.element");yg.version="19.2.0"});' +
+  'var fH=X((pBE,N8c)=>{N8c.exports=n7L()});' +
+  'var qwd=H(fH(),1),up=H(ne(),1);';
+
+const FN_EXPR_BUNDLE =
+  LOADER +
+  'var $8c=X(function(yg){var s2i=Symbol.for("react.transitional.element");yg.version="19.2.0"});' +
+  'var tt=X(function(pBE,N8c){N8c.exports=$8c()});' +
+  'var G8c=H(tt(),1),W8c=G8c.createContext({stdin:process.stdin});';
 
 describe('escapeNonAscii', () => {
   it('escapes non-ASCII code points as \\uXXXX and leaves ASCII untouched', () => {
@@ -18,6 +39,46 @@ describe('escapeNonAscii', () => {
     // 🎉 (U+1F389) is a surrogate pair; both halves become \uXXXX and still
     // reconstruct the emoji when the JS source is parsed.
     expect(escapeNonAscii('🎉')).toBe('\\ud83c\\udf89');
+  });
+});
+
+describe('React module resolution', () => {
+  beforeEach(() => {
+    clearReactVarCache();
+  });
+
+  describe('getReactModuleNameNonBun', () => {
+    it('finds the React module wrapped in an arrow function', () => {
+      expect(getReactModuleNameNonBun(ARROW_BUNDLE)).toBe('n7L');
+    });
+
+    it('finds the React module wrapped in a function expression (CC 2.1.209)', () => {
+      expect(getReactModuleNameNonBun(FN_EXPR_BUNDLE)).toBe('$8c');
+    });
+  });
+
+  describe('getReactModuleFunctionBun', () => {
+    it('finds the re-exporting module wrapped in an arrow function', () => {
+      expect(getReactModuleFunctionBun(ARROW_BUNDLE)).toBe('fH');
+    });
+
+    it('finds the re-exporting module wrapped in a function expression (CC 2.1.209)', () => {
+      expect(getReactModuleFunctionBun(FN_EXPR_BUNDLE)).toBe('tt');
+    });
+  });
+
+  describe('getReactVar', () => {
+    it('resolves the React variable on arrow-wrapped bundles', () => {
+      expect(getReactVar(ARROW_BUNDLE)).toBe('qwd');
+    });
+
+    it('resolves the React variable on function-expression bundles (CC 2.1.209)', () => {
+      expect(getReactVar(FN_EXPR_BUNDLE)).toBe('G8c');
+    });
+
+    it('returns undefined when React is absent', () => {
+      expect(getReactVar(LOADER + 'var a=1;')).toBeUndefined();
+    });
   });
 });
 

--- a/src/patches/helpers.ts
+++ b/src/patches/helpers.ts
@@ -86,7 +86,7 @@ export const getReactModuleNameNonBun = (
 ): string | undefined => {
   // Pattern: var X=Y((Z)=>{var W=Symbol.for("react.element") or "react.transitional.element"
   const pattern =
-    /var ([$\w]+)=[$\w]+\(\([$\w]+\)=>\{var [$\w]+=Symbol\.for\("react\.(transitional\.)?element"\)/;
+    /var ([$\w]+)=[$\w]+\((?:\([$\w]+\)=>|function\([$\w]+\))\{var [$\w]+=Symbol\.for\("react\.(transitional\.)?element"\)/;
   const match = fileContents.match(pattern);
   if (!match) {
     console.log(
@@ -126,7 +126,7 @@ export const getReactModuleFunctionBun = (
 
   // Pattern: var X=Y((Z,W)=>{W.exports=reactModuleNameNonBun()
   const pattern = new RegExp(
-    `var ([$\\w]+)=[$\\w]+\\(\\([$\\w]+,[$\\w]+\\)=>\\{[$\\w]+\\.exports=${escapeIdent(reactModuleNameNonBun)}\\(\\)`
+    `var ([$\\w]+)=[$\\w]+\\((?:\\([$\\w]+,[$\\w]+\\)=>|function\\([$\\w]+,[$\\w]+\\))\\{[$\\w]+\\.exports=${escapeIdent(reactModuleNameNonBun)}\\(\\)`
   );
   const match = fileContents.match(pattern);
   if (!match) {

--- a/src/patches/thinkingVisibility.test.ts
+++ b/src/patches/thinkingVisibility.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { writeThinkingVisibility } from './thinkingVisibility';
+
+const cc209 =
+  'function Vwd(WM,dq,Ilt,fJ,nLt,up,xir){switch(WM.type){' +
+  'case"thinking":{if(!Ilt&&!fJ){return null}' +
+  'let I4;if(nLt[32]!==dq||nLt[35]!==fJ)I4=up.jsx(xir,{addMargin:dq,param:WM,' +
+  'isTranscriptMode:Ilt,verbose:fJ}),nLt[32]=dq,nLt[36]=I4;else I4=nLt[36];return I4}' +
+  'default:{return null}}}' +
+  'function oTd(e,t){let r=[];if(r.length===0)return null;' +
+  'return Ea.jsx(Ea.Fragment,{children:r})}' +
+  'function Llt(e,{tools:t,verbose:r,inProgressToolCallCount:o,isTranscriptMode:i=!1}){' +
+  'if(!e.length)return Ea.jsx(fr,{height:1,children:null});return i}';
+
+const cc205 =
+  'function R(A,B,V,I){switch(A.type){' +
+  'case"thinking":if(!V&&!I)return null;' +
+  'return w3.createElement(Q$Q,{addMargin:B,param:A,isTranscriptMode:V,verbose:I});' +
+  'default:return null}}';
+
+const bracedSemicolon =
+  'function R(A,B,V,I){switch(A.type){' +
+  'case"thinking":{if(!V&&!I){return null;}' +
+  'let k;k=w3.createElement(Q$Q,{addMargin:B,param:A,isTranscriptMode:V,verbose:I});return k}' +
+  'default:{return null}}}';
+
+const unrecognisedEarlyReturn =
+  'function Vwd(WM,dq,Ilt,fJ,up,xir){switch(WM.type){' +
+  'case"thinking":{if(!Ilt&&!fJ){return void 0}' +
+  'let I4;I4=up.jsx(xir,{addMargin:dq,isTranscriptMode:Ilt,verbose:fJ});return I4}' +
+  'default:{return null}}}' +
+  'function oTd(e,q,z){let r=[];if(r.length===0)return null;' +
+  'return Ea.jsx(F,{children:r,isTranscriptMode:q,verbose:z})}';
+
+describe('thinkingVisibility', () => {
+  describe('writeThinkingVisibility', () => {
+    it('should not produce a syntax error on the CC 2.1.209 braces shape', () => {
+      const result = writeThinkingVisibility(cc209);
+
+      expect(result).not.toBeNull();
+      expect(() => new Function(result as string)).not.toThrow();
+    });
+
+    it('should force isTranscriptMode true and drop the early return on 2.1.209', () => {
+      const result = writeThinkingVisibility(cc209) as string;
+
+      expect(result).toContain('isTranscriptMode:true,verbose:fJ');
+      expect(result).not.toContain('if(!Ilt&&!fJ){return null}');
+    });
+
+    it('should not delete unrelated code that follows the thinking case on 2.1.209', () => {
+      const result = writeThinkingVisibility(cc209) as string;
+
+      expect(result).toContain('function oTd(e,t)');
+      expect(result).toContain('if(r.length===0)return null;');
+      expect(result).toContain('isTranscriptMode:i=!1');
+      expect(result).toContain('I4=up.jsx(xir,{addMargin:dq,param:WM,');
+    });
+
+    it('should still patch the CC 2.0.50 semicolon shape', () => {
+      const result = writeThinkingVisibility(cc205);
+
+      expect(result).not.toBeNull();
+      expect(result as string).toContain('isTranscriptMode:true,verbose:I');
+      expect(result as string).not.toContain('if(!V&&!I)return null;');
+      expect(() => new Function(result as string)).not.toThrow();
+    });
+
+    it('should keep braces balanced when the early return is `{return null;}`', () => {
+      const result = writeThinkingVisibility(bracedSemicolon);
+
+      expect(result).not.toBeNull();
+      const out = result as string;
+      expect(out).not.toContain('case"thinking":{}');
+      expect((out.match(/\{/g) ?? []).length).toBe(
+        (out.match(/\}/g) ?? []).length
+      );
+      expect(() => new Function(out)).not.toThrow();
+    });
+
+    it('should decline to patch an unrecognised early-return shape rather than match a distant one', () => {
+      expect(writeThinkingVisibility(unrecognisedEarlyReturn)).toBeNull();
+    });
+
+    it('should return null when the thinking case is absent', () => {
+      expect(writeThinkingVisibility('function f(){return 1}')).toBeNull();
+    });
+  });
+});

--- a/src/patches/thinkingVisibility.ts
+++ b/src/patches/thinkingVisibility.ts
@@ -42,7 +42,7 @@ export const writeThinkingVisibility = (oldFile: string): string | null => {
   // - Group 3: Everything from `{` or return up to `isTranscriptMode:`
   // - Then the variable name followed by comma (replaced with `true,`)
   const pattern =
-    /(case"thinking":\{?)(if\(.+?\)return null;)(.{0,400}isTranscriptMode:).+?,/;
+    /(case"thinking":\{?)(if\(.{0,80}?\)\s*(?:\{\s*return null\s*;?\s*\}|return null\s*;?))(.{0,400}?isTranscriptMode:)([$\w]+)\s*,/;
 
   const match = oldFile.match(pattern);
 


### PR DESCRIPTION
Two independent anchor regressions broke tweakcc for Claude Code 2.1.209 through 2.1.211. Both are fixed here, as two commits touching different files.

Fixes #880 (startup crash) and fixes #881 (dead React-dependent patches).

## 1. Thinking-visibility deletes 7.6KB and Claude Code will not start (commit 1)

After `--apply`, Claude Code 2.1.211 does not start:

```
SyntaxError: Cannot use the keyword 'true' as a parameter name.
Bun v1.4.0 (Linux x64 baseline)
```

Since 2.1.209 the thinking case reads `case"thinking":{if(!Pdt&&!YJ){return null}` (braces, no semicolon), so the pattern's group 2 `if\(.+?\)return null;` no longer matches there. It does not fail there: cli.js is minified onto single lines, so `.+?` runs to the next `)return null;` thousands of characters away, crosses a function boundary, and the replacement (`match[1] + match[3] + 'true,'`) drops group 2 and deletes everything spanned. `isTranscriptMode:i=!1` becomes the literal `true` in a destructuring parameter list.

Group 2 now accepts `)return null;` and `){return null}` as one balanced alternation, so the closing brace cannot be orphaned into group 3. The spans are bounded and lazy, so an unrecognised early-return shape declines to patch instead of matching one 7KB away, and the tail `([$\w]+)\s*,` can only bind an identifier followed by a comma.

| Claude Code | old pattern deletes | new pattern delta |
|---|---|---|
| 2.1.209 | 7,312 → bundle fails | -25 → parses |
| 2.1.210 | 7,645 → bundle fails | -25 → parses |
| 2.1.211 | 7,645 → bundle fails | -25 → parses |

## 2. React resolution: version banner and three patches silently die (commit 2)

`--apply` prints `getReactModuleNameNonBun` / `getReactVar` / `patchesAppliedIndication` failures. One root cause: since 2.1.209 the module wrapper is a function expression, not an arrow:

```js
var Bou=Y(function(Lg){var tqi=Symbol.for("react.transitional.element")
var tt=Y(function(pBE,N8c){N8c.exports=Bou()});
```

`getReactModuleNameNonBun` and `getReactModuleFunctionBun` matched only the arrow form, so `getReactVar` returned undefined and took `patchesAppliedIndication`, `conversationTitle`, and `toolsets` with it. Both patterns now accept either wrapper form via a non-capturing alternation, leaving the existing capture groups intact. This is not a blanket arrow-to-function migration: the bundles still contain `H=(e,t,r)=>{` and `v(()=>{...})`, so only the module-wrapper patterns move.

The module lookup finds nothing on 2.1.209, 2.1.210, and 2.1.211; the fix resolves the chain on all three (reactVar `G8c` / `uYc` / `Gou`).

## Why one PR

The two fixes are independent and each is individually correct, but 2.1.211 needs both to be usable after `--apply`. Without commit 1 the binary will not start; without commit 2 the version banner and three patches silently do nothing. Shipping one alone leaves 2.1.211 broken, so they are submitted together.

## Verification

Built from this branch and applied to a real, unpacked Claude Code 2.1.211 native binary:

- combined `--apply` reports both patches applied
- the full ~19.8MB patched bundle parses (`node --check`)
- the binary boots: `2.1.211 (Claude Code)`, then `4.3.1 (tweakcc)`, then a live prompt round-trip
- the React fix without the thinking-visibility fix still crashes at startup (the unfixed thinking-visibility bug corrupts the binary), which is why both are required

Each fix also verified individually against unpacked 2.1.209, 2.1.210, and 2.1.211 bundles. Full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Claude Code 2.1.209+ by restoring React variable/module resolution so the expected patch status and related UI updates work correctly.
  * Fixed a startup crash in the thinking-block visibility patch caused by overly broad pattern matching.
  * Enhanced thinking-block visibility patching to more reliably handle alternate compiled “thinking” code shapes while leaving unrelated code untouched.
* **Tests**
  * Added new tests for thinking-block visibility patching and expanded coverage for React module/variable resolution across multiple bundle fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->