### PR TITLE
fix(tableFormat): match hoisted rows-array inter-row separator (Claude Code >= 2.1.212)

### DIFF
--- a/src/patches/tableFormat.ts
+++ b/src/patches/tableFormat.ts
@@ -70,17 +70,20 @@ const TABLE_BORDERS_PATTERN_SPACED =
 // Pattern for inter-row separator logic
 // The minified code looks like:
 //   A.rows.forEach((S,g)=>{if(R.push(...N(S,!1)),g<A.rows.length-1)R.push(T("middle"))})
+// Since Claude Code 2.1.212 the rows array is hoisted into a local first, so
+// the guard loses the `.rows` member access:
+//   a.forEach((R,G)=>{if(N.push(...D(R,!1)),G<a.length-1)N.push(M("middle"))})
 // The formatted code looks like:
 //   if ((R.push(...N(S, !1)), g < A.rows.length - 1)) R.push(T("middle"));
 // We need to remove the condition and the push of T("middle") to remove inter-row separators
 
-// Minified pattern (no extra parens, no spaces)
+// Minified pattern (no extra parens, no spaces; `.rows` optional for hoisted-array form)
 const INTER_ROW_SEP_PATTERN_MINIFIED =
-  /if\(([$\w]+)\.push\(\.\.\.([$\w]+)\(([$\w]+),!1\)\),([$\w]+)<([$\w]+)\.rows\.length-1\)([$\w]+)\.push\(([$\w]+)\("middle"\)\)/g;
+  /if\(([$\w]+)\.push\(\.\.\.([$\w]+)\(([$\w]+),!1\)\),([$\w]+)<([$\w]+)(?:\.rows)?\.length-1\)([$\w]+)\.push\(([$\w]+)\("middle"\)\)/g;
 
-// Formatted pattern (extra parens, spaces, optional semicolon)
+// Formatted pattern (extra parens, spaces, optional semicolon; `.rows` optional for hoisted-array form)
 const INTER_ROW_SEP_PATTERN_FORMATTED =
-  /if\s*\(\s*\(\s*([$\w]+)\.push\(\.\.\.([$\w]+)\(([$\w]+)\s*,\s*!1\)\)\s*,\s*([$\w]+)\s*<\s*([$\w]+)\.rows\.length\s*-\s*1\s*\)\s*\)\s*([$\w]+)\.push\(([$\w]+)\("middle"\)\)\s*;?/g;
+  /if\s*\(\s*\(\s*([$\w]+)\.push\(\.\.\.([$\w]+)\(([$\w]+)\s*,\s*!1\)\)\s*,\s*([$\w]+)\s*<\s*([$\w]+)(?:\.rows)?\.length\s*-\s*1\s*\)\s*\)\s*([$\w]+)\.push\(([$\w]+)\("middle"\)\)\s*;?/g;
 
 // Patterns to remove T("top") and T("bottom") pushes for clean format
 // Minified: R.push(T("top")),R.push(...  ->  R.push(...


### PR DESCRIPTION
## Problem

On Claude Code **2.1.212**, every table format that routes through `removeInterRowSeparators()` (`ascii`, `clean`, `clean-top-bottom`) fails to patch — `--apply` reports **"✗ Table format"** / *Customizations applied with some failures*.

## Root cause

2.1.212 refactored the table renderer: the rows array is hoisted into a local before the `forEach`, so the inter-row separator guard lost its `.rows` member access.

Pre-2.1.212 (the form documented in `tableFormat.ts`'s header):

```js
A.rows.forEach((S,g)=>{if(R.push(...N(S,!1)),g<A.rows.length-1)R.push(T("middle"))})
```

2.1.212 (extracted from the real native binary via `tweakcc unpack`):

```js
a.forEach((R,G)=>{if(N.push(...D(R,!1)),G<a.length-1)N.push(M("middle"))})
```

`INTER_ROW_SEP_PATTERN_MINIFIED` / `_FORMATTED` require the literal `\.rows\.length-1`, so they no longer match.

## Fix

Make `.rows` optional via a **non-capturing** group in both patterns:

```diff
- ...,([$\w]+)<([$\w]+)\.rows\.length-1\)...
+ ...,([$\w]+)<([$\w]+)(?:\.rows)?\.length-1\)...
```

Group numbering is unchanged, so the `$1.push(...$2($3,!1))` replacement strings are untouched.

## Verification

Ran the exact regex literals from the edited source against all four shapes:

| Input | Result |
|---|---|
| pre-2.1.212 minified (`.rows` form, file-header example) | MATCH |
| 2.1.212 minified (hoisted form, real bundle) | MATCH |
| formatted `.rows` form (file-header example) | MATCH |
| formatted hoisted form | MATCH |

Against the full unpacked 2.1.212 bundle (~20 MB): **exactly 1 match**, replacement output `N.push(...D(R,!1))` — i.e. `clean-top-bottom` renders with top/bottom borders + header separator and no inter-row separators, as designed.

Backward compatibility: both patterns still match the pre-2.1.212 `.rows` forms, so older installs are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table rendering compatibility with newer Claude Code CLI output.
  * Inter-row separators are now consistently removed in both formatted and minified table layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->