### PR TITLE
Fix system-prompt sync crash on prompts whose content starts with an HTML comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix over-escaping of backslashes in backtick-delimited system prompts that produced invalid JS and crashed Claude Code at startup (#870) - @StreamDemon
 - Fix thinking-block-visibility patch for Claude Code 2.1.209 and later (the early return is now `if(...){return null}`, so an unbounded `.+?` spanned ~7.6KB into an unrelated function and the replacement deleted it, crashing Claude Code at startup) (#882) - @StreamDemon
 - Fix React variable resolution for Claude Code 2.1.209 and later, restoring the patches-applied indication, conversation-title, and toolsets patches (modules are now wrapped in function expressions rather than arrow functions) (#882) - @StreamDemon
+- Fix system-prompt sync crashing on prompts whose content begins with an HTML comment (`<!--`), which collided with the `<!--`/`-->` front-matter delimiters so `matter.stringify` re-parsed the body as YAML; the throw aborted the whole sync and left every later prompt's markdown file uncreated, surfacing as `ENOENT` "Failed to read markdown file" errors on `--apply` (#TBD) - @StreamDemon
 
 ## [v4.3.1](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.1) - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix over-escaping of backslashes in backtick-delimited system prompts that produced invalid JS and crashed Claude Code at startup (#870) - @StreamDemon
 - Fix thinking-block-visibility patch for Claude Code 2.1.209 and later (the early return is now `if(...){return null}`, so an unbounded `.+?` spanned ~7.6KB into an unrelated function and the replacement deleted it, crashing Claude Code at startup) (#882) - @StreamDemon
 - Fix React variable resolution for Claude Code 2.1.209 and later, restoring the patches-applied indication, conversation-title, and toolsets patches (modules are now wrapped in function expressions rather than arrow functions) (#882) - @StreamDemon
-- Fix system-prompt sync crashing on prompts whose content begins with an HTML comment (`<!--`), which collided with the `<!--`/`-->` front-matter delimiters so `matter.stringify` re-parsed the body as YAML; the throw aborted the whole sync and left every later prompt's markdown file uncreated, surfacing as `ENOENT` "Failed to read markdown file" errors on `--apply` (#TBD) - @StreamDemon
+- Fix system-prompt sync crashing on prompts whose content begins with an HTML comment (`<!--`), which collided with the `<!--`/`-->` front-matter delimiters so `matter.stringify` re-parsed the body as YAML; the throw aborted the whole sync and left every later prompt's markdown file uncreated, surfacing as `ENOENT` "Failed to read markdown file" errors on `--apply` (#889) - @StreamDemon
 
 ## [v4.3.1](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.1) - 2026-07-06
 

--- a/src/systemPromptSync.ts
+++ b/src/systemPromptSync.ts
@@ -137,7 +137,12 @@ export const generateMarkdownFromPrompt = (
     frontmatterData.variables = variables;
   }
 
-  return matter.stringify(content, frontmatterData, {
+  // Pass the content as a file object rather than a raw string. matter.stringify
+  // re-parses a string argument as front matter first, so content that itself
+  // begins with "<!--" (e.g. an HTML template) collides with the "<!--"/"-->"
+  // delimiters and is mis-parsed as YAML — either throwing or corrupting the
+  // body. A file object skips that re-parse and stringifies the content verbatim.
+  return matter.stringify({ content }, frontmatterData, {
     delimiters: ['<!--', '-->'],
   });
 };
@@ -363,9 +368,15 @@ export const updateVariables = async (
     updatedData.variables = variables;
   }
 
-  const updatedMarkdown = matter.stringify(parsed.content, updatedData, {
-    delimiters: ['<!--', '-->'],
-  });
+  // Wrap in a file object so matter.stringify does not re-parse content that
+  // begins with "<!--" as front matter (see generateMarkdownFromPrompt).
+  const updatedMarkdown = matter.stringify(
+    { content: parsed.content },
+    updatedData,
+    {
+      delimiters: ['<!--', '-->'],
+    }
+  );
   await writePromptFile(promptId, updatedMarkdown);
 };
 

--- a/src/tests/systemPromptSync.test.ts
+++ b/src/tests/systemPromptSync.test.ts
@@ -237,6 +237,37 @@ Content only.`;
       const matches = result.match(/^ {2}- SETTINGS$/gm);
       expect(matches?.length).toBe(1); // Should only appear once in variables list
     });
+
+    it('should not crash when content itself starts with an HTML comment', () => {
+      // Regression: a prompt whose content is an HTML document that begins with
+      // "<!--" collides with the "<!--"/"-->" frontmatter delimiters. Passing the
+      // content as a string made matter.stringify re-parse the body as YAML and
+      // throw "bad indentation of a mapping entry" (this is exactly what
+      // data-plan-artifact-html-template did, aborting the whole prompt sync).
+      // The content below reproduces that YAML shape: a folded value followed by
+      // an indented colon-bearing prose line.
+      const prompt: StringsPrompt = {
+        id: 'html-template',
+        name: 'HTML Template',
+        description: 'Template whose content starts with a comment',
+        version: '2.1.212',
+        pieces: [
+          '<!--\nstyle: tokens come from the vanilla export, embedded verbatim\n  Dark mode keys off both theme axes: prefers-color-scheme, and the\n  data-theme attribute set by the theme toggle\n-->\n<html><body>hi</body></html>',
+        ],
+        identifiers: [],
+        identifierMap: {},
+      };
+
+      const result = promptSync.generateMarkdownFromPrompt(prompt);
+
+      // The tweakcc metadata is the frontmatter; the HTML comment stays in content
+      expect(result).toContain('name: HTML Template');
+      const parsed = promptSync.parseMarkdownPrompt(result);
+      expect(parsed.content).toContain(
+        'Dark mode keys off both theme axes: prefers-color-scheme'
+      );
+      expect(parsed.content.trimStart().startsWith('<!--')).toBe(true);
+    });
   });
 
   describe('buildRegexFromPieces', () => {
@@ -601,6 +632,36 @@ Content`;
       expect(writtenContent).not.toContain('variables:');
       expect(writtenContent).not.toContain('OLD_VAR');
     });
+
+    it('should not crash when prompt content starts with an HTML comment', async () => {
+      // Regression: updateVariables re-stringifies parsed.content. When that
+      // content begins with "<!--" (an HTML template body), matter.stringify
+      // re-parsed it as YAML and threw, aborting the whole prompt sync.
+      const mockContent = `<!--
+name: Test
+description: Test
+ccVersion: 1.0.0
+-->
+<!--
+theme notes:
+    Dark mode keys off both theme axes: prefers-color-scheme, and the data-theme attribute.
+-->
+<html></html>`;
+
+      vi.spyOn(fs, 'readFile').mockResolvedValue(mockContent);
+      const writeFileSpy = vi
+        .spyOn(fs, 'writeFile')
+        .mockResolvedValue(undefined);
+
+      await promptSync.updateVariables('test-prompt', { '1': 'SETTINGS' });
+
+      expect(writeFileSpy).toHaveBeenCalled();
+      const writtenContent = writeFileSpy.mock.calls[0][1] as string;
+      expect(writtenContent).toContain('SETTINGS');
+      expect(writtenContent).toContain(
+        'Dark mode keys off both theme axes: prefers-color-scheme'
+      );
+    });
   });
 
   describe('generateDiffHtml', () => {
@@ -816,6 +877,70 @@ Greet user as \${SETTINGS.preferredName}!`;
       expect(result.results).toHaveLength(2);
       expect(result.results[0].action).toBe('created');
       expect(result.results[1].action).toBe('created');
+    });
+
+    it('should not let one HTML-comment prompt abort the whole sync', async () => {
+      // Symptom regression: the sync loop rethrows on any prompt failure, so a
+      // single prompt whose content begins with "<!--" (and crashed the markdown
+      // generator) aborted the entire sync — every prompt ordered AFTER it never
+      // got its .md file written, surfacing later as ENOENT on --apply. With the
+      // generator fixed, the middle prompt no longer throws and the prompts after
+      // it are still created.
+      const mockStringsFile: StringsFile = {
+        version: '2.0.0',
+        prompts: [
+          {
+            id: 'prompt-before',
+            name: 'Before',
+            description: 'Ordered before the HTML-comment prompt',
+            version: '2.0.0',
+            pieces: ['Content before'],
+            identifiers: [],
+            identifierMap: {},
+          },
+          {
+            id: 'html-template',
+            name: 'HTML Template',
+            description: 'Content begins with an HTML comment (used to crash)',
+            version: '2.0.0',
+            pieces: [
+              '<!--\nstyle: tokens come from the vanilla export, embedded verbatim\n  Dark mode keys off both theme axes: prefers-color-scheme, and the\n  data-theme attribute set by the theme toggle\n-->\n<html></html>',
+            ],
+            identifiers: [],
+            identifierMap: {},
+          },
+          {
+            id: 'prompt-after',
+            name: 'After',
+            description: 'Ordered after the HTML-comment prompt',
+            version: '2.0.0',
+            pieces: ['Content after'],
+            identifiers: [],
+            identifierMap: {},
+          },
+        ],
+      };
+
+      const { downloadStringsFile } = await import('../systemPromptDownload');
+      const hashIndexModule = await import('../systemPromptHashIndex');
+
+      vi.mocked(downloadStringsFile).mockResolvedValue(
+        mockStringsFile as StringsFile
+      );
+      vi.spyOn(hashIndexModule, 'storeHashes').mockResolvedValue(0);
+      vi.spyOn(fs, 'mkdir').mockResolvedValue(undefined);
+      vi.spyOn(fs, 'access').mockRejectedValue(createEnoent());
+      const writeFileSpy = vi
+        .spyOn(fs, 'writeFile')
+        .mockResolvedValue(undefined);
+
+      const result = await promptSync.syncSystemPrompts('2.0.0');
+
+      // All three prompts synced — crucially the one ordered AFTER the template
+      expect(result.results).toHaveLength(3);
+      expect(result.results.every(r => r.action === 'created')).toBe(true);
+      const writtenPaths = writeFileSpy.mock.calls.map(c => String(c[0]));
+      expect(writtenPaths.some(p => p.includes('prompt-after'))).toBe(true);
     });
 
     it('should throw error for failed prompt syncs', async () => {


### PR DESCRIPTION
Fixes #888

## Problem

`--apply` prints `Failed to read markdown file ... ENOENT` for a batch of system prompts (14 on Claude Code 2.1.212). The prompts are skipped, so those system prompts are never applied.

## Root cause

`generateMarkdownFromPrompt` and `updateVariables` call `matter.stringify(content, data, { delimiters: ['<!--', '-->'] })` with `content` as a **string**. gray-matter re-parses a string argument as front matter before stringifying:

```js
if (typeof file === 'string') file = matter(file, options);
```

Because tweakcc uses `<!--`/`-->` as delimiters, a prompt whose content itself begins with `<!--` (e.g. `data-plan-artifact-html-template`, an HTML template, on Claude Code 2.1.208+) is mis-parsed as YAML and throws `bad indentation of a mapping entry` (or silently corrupts the body when the YAML is coincidentally valid).

`syncSystemPrompts` rethrows on any prompt failure, so the single throw aborts the entire sync. Every prompt ordered after the offending one never gets its `.md` written, which surfaces later as the ENOENT batch.

## Fix

Pass the content as a file object (`{ content }`) at both call sites so gray-matter skips the string re-parse and stringifies the body verbatim. `{ content: string }` is gray-matter's documented input shape. Output is byte-identical for content that does not begin with `<!--` (verified across the full 2.1.212 prompt set: 580/580 unchanged, the 581st being the previously-crashing template, which now generates and round-trips correctly).

## Tests

- `generateMarkdownFromPrompt`: content starting with `<!--` no longer throws and round-trips through `parseMarkdownPrompt`
- `updateVariables`: same, covering the silent-corruption path
- `syncSystemPrompts`: a bad HTML-comment prompt in the middle no longer aborts the sync, so prompts ordered after it are still written

All three fail if the fix is reverted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed system-prompt synchronization crashes when a prompt body starts with an HTML comment (`<!--`), preventing sync runs from aborting.
  - Improved markdown generation and variable updates so frontmatter parsing stays correct and the HTML-comment content is preserved.
- **Tests**
  - Added regression tests covering generation, variable updates, and syncing for prompts whose content begins with HTML-comment delimiters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->