### PR TITLE
Update docs: clarify --patches restore-then-apply behavior (#699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Clarify that `--apply --patches` restores from backup then applies only the listed patch IDs (not additive); prefer `tweakcc --apply` with no filter (#699)
+
 ## [v4.3.2](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.2) - 2026-07-20
 
 - fix: match try/catch agent-color write in session-color patch (#864) - @VitalyOstanin

--- a/README.md
+++ b/README.md
@@ -182,6 +182,19 @@ Your local config will **not** be overwritten; the remote config will be copied 
 In addition to the interactive TUI (`npx tweakcc`) and the `--apply` flag, tweakcc provides three subcommands for advanced use: `unpack`, `repack`, and `adhoc-patch`.
 
 <details>
+<summary><code>--apply</code> and <code>--patches</code></summary>
+
+`npx tweakcc --apply` reads your saved customizations from `config.json` and patches Claude Code. Before applying, tweakcc **restores Claude Code from its backup** so patching always starts from a clean slate (see [Troubleshooting](#troubleshooting)).
+
+Use `tweakcc --apply` with **no filter** as the default way to apply all enabled patches from your config.
+
+`--patches <ids>` limits which patches are applied, but it is **not additive**: tweakcc still restores from backup first, then applies **only** the listed patch IDs. Any previously applied patches that are not in the list are removed from the binary. For example, if you have both `themes` and `user-message-display` enabled and run `tweakcc --apply --patches themes`, only the themes patch remains in Claude Code.
+
+List available patch IDs with `tweakcc --list-patches` (or `tweakcc --list-system-prompts [version]` for system prompt IDs).
+
+</details>
+
+<details>
 <summary><code>unpack</code></summary>
 
 Extract the embedded JavaScript from a native Claude Code binary and write it to a file. This is useful for inspecting Claude Code's source, writing custom patches, or making manual edits before repacking. Note that `unpack` only works with native/binary installations; it will error if pointed at an npm-based installation (`cli.js`), because it can already be read directly from disk. `unpack` takes the path to the JS file to write to, and an optional path to a native binary, which if omitted will default to the current installation.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -180,7 +180,7 @@ const main = async () => {
     )
     .option(
       '--patches <ids>',
-      'comma-separated list of patch IDs to apply (use with --apply)'
+      'restore from backup, then apply only these patch IDs (not additive; use with --apply). Prefer tweakcc --apply with no filter.'
     )
     .option('--list-patches', 'list all available patches with their IDs')
     .option(
@@ -609,11 +609,16 @@ function handleListPatches(): void {
 
   console.log(
     chalk.gray(
-      'Use --patches <ids> with --apply to apply specific patches, e.g.:'
+      'Use --patches <ids> with --apply to restore from backup and apply only the listed patches (not additive), e.g.:'
     )
   );
   console.log();
   console.log(chalk.gray('  tweakcc --apply --patches "themes,toolsets"'));
+  console.log(
+    chalk.gray(
+      '  Prefer tweakcc --apply with no filter to apply all enabled patches.'
+    )
+  );
   console.log();
   console.log(chalk.blue.bold('Available patches'));
   console.log();
@@ -721,11 +726,16 @@ async function handleListSystemPrompts(
 
   console.log(
     chalk.gray(
-      'Use --patches <ids> with --apply to apply specific prompts, e.g.:'
+      'Use --patches <ids> with --apply to restore from backup and apply only the listed prompts (not additive), e.g.:'
     )
   );
   console.log();
   console.log(chalk.gray('  tweakcc --apply --patches "identity,environment"'));
+  console.log(
+    chalk.gray(
+      '  Prefer tweakcc --apply with no filter to apply all enabled patches.'
+    )
+  );
   console.log();
   console.log(chalk.blue.bold(`System prompts for CC ${version}`));
   console.log();


### PR DESCRIPTION
## Summary

- Clarify that `tweakcc --apply --patches <ids>` restores Claude Code from backup first, then applies only the listed patch IDs (not additive on top of existing binary patches)
- Recommend `tweakcc --apply` with no filter as the default way to apply all enabled patches

## Changes

- Update `--patches` CLI help text in `src/index.tsx`
- Clarify restore-then-apply behavior in `--list-patches` and `--list-system-prompts` output
- Add a README section documenting `--apply` and `--patches`
- Add an Unreleased changelog entry

## Testing

- [x] All existing tests pass (`pnpm run test`)
- [x] Lint passes (`pnpm lint`)
- [x] Manual review of help text and README wording

## Related Issues

Closes #699

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `--apply` restores from backup before applying patches.
  * Documented that `--patches <ids>` applies only the specified patches and removes other enabled patches.
  * Updated CLI guidance to recommend using `--apply` without a filter to apply all enabled patches.
  * Added clearer references for available patch IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->