### PR TITLE
Guard system-prompt --apply against injecting an undefined identifier from a stale prompt file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Skip a system prompt instead of corrupting `cli.js` when a stale prompt file would inject an identifier the current bundle does not define; an interpolation identifier renamed upstream without a per-prompt version bump left the old human-name unmapped, so `--apply` wrote an undefined variable that `node --check` could not catch and that crashed Claude Code on the first turn (#TBD) - @StreamDemon
 - Clarify that `--apply --patches` restores from backup then applies only the listed patch IDs (not additive); prefer `tweakcc --apply` with no filter (#699)
 
 ## [v4.3.2](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.2) - 2026-07-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Skip a system prompt instead of corrupting `cli.js` when a stale prompt file would inject an identifier the current bundle does not define; an interpolation identifier renamed upstream without a per-prompt version bump left the old human-name unmapped, so `--apply` wrote an undefined variable that `node --check` could not catch and that crashed Claude Code on the first turn (#TBD) - @StreamDemon
+- Skip a system prompt instead of corrupting `cli.js` when a stale prompt file would inject an identifier the current bundle does not define; an interpolation identifier renamed upstream without a per-prompt version bump left the old human-name unmapped, so `--apply` wrote an undefined variable that `node --check` could not catch and that crashed Claude Code on the first turn (#901) - @StreamDemon
 - Clarify that `--apply --patches` restores from backup then applies only the listed patch IDs (not additive); prefer `tweakcc --apply` with no filter (#699)
 
 ## [v4.3.2](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.2) - 2026-07-20

--- a/src/patches/systemPrompts.test.ts
+++ b/src/patches/systemPrompts.test.ts
@@ -308,6 +308,162 @@ describe('systemPrompts.ts', () => {
       spy.mockRestore();
     });
 
+    it('should skip a prompt whose replacement injects an identifier absent from the bundle (stale .md drift, #900)', async () => {
+      // A stale .md (whose interpolation identifier was renamed upstream without a
+      // per-prompt version bump) leaves an old human-name unmapped, so the
+      // interpolated content references an identifier the bundle never defines.
+      // Injecting it would throw ReferenceError at runtime (node --check cannot
+      // catch it). The apply must refuse the injection rather than corrupt cli.js.
+      const mockPromptData = buildMockPromptData({
+        promptId: 'stale-memory-instructions',
+        prompt: { content: 'Memory ${HAS_UPKEEP_FN} tail' },
+        regex: 'Memory \\$\\{([\\w$]+)\\} tail',
+        // Q1 is the real captured bundle var; STALE_UPKEEP_FLAG is a leftover
+        // human-name that applyIdentifierMapping could not map.
+        getInterpolatedContent: () => 'Memory ${Q1} ${STALE_UPKEEP_FLAG} tail',
+        pieces: ['Memory ${', '} tail'],
+        identifiers: [1],
+        identifierMap: { '1': 'HAS_UPKEEP_FN' },
+      });
+
+      setupMocks(mockPromptData);
+
+      // Bundle template literal: Q1 is defined, STALE_UPKEEP_FLAG is not.
+      const cliContent = 'desc:`Memory ${Q1} tail`';
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe(cliContent); // bundle left untouched
+      expect(result.newContent).not.toContain('STALE_UPKEEP_FLAG');
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].applied).toBe(false);
+      expect(result.results[0].details).toMatch(/stale identifier/i);
+      expect(result.results[0].details).toContain('STALE_UPKEEP_FLAG');
+    });
+
+    it('should flag a single-word (no-underscore) stale identifier in a backtick interpolation (#900)', async () => {
+      // Human identifier names are often single-word (PREAMBLE, INTERVAL, TOOLS).
+      // The guard must catch these too, not just multi-segment UPPER_SNAKE names.
+      const mockPromptData = buildMockPromptData({
+        promptId: 'stale-single-word',
+        regex: 'Cron \\$\\{([\\w$]+)\\} run',
+        getInterpolatedContent: () => 'Cron ${INTERVAL} run',
+        pieces: ['Cron ${', '} run'],
+        identifiers: [1],
+        identifierMap: { '1': 'x' },
+      });
+
+      setupMocks(mockPromptData);
+      const cliContent = 'desc:`Cron ${x} run`'; // x captured; INTERVAL absent
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe(cliContent);
+      expect(result.results[0].applied).toBe(false);
+      expect(result.results[0].details).toContain('INTERVAL');
+    });
+
+    it('should reproduce the real drift shape ${Q1}${HAS_X()...} where a bare name survives the _FN mapping (#900)', async () => {
+      const mockPromptData = buildMockPromptData({
+        promptId: 'stale-has-x',
+        regex: 'Mode \\$\\{([\\w$]+)\\} end',
+        // HAS_X_FN maps to Q1; the adjacent bare HAS_X() survives unmapped.
+        getInterpolatedContent: () => 'Mode ${Q1}${HAS_X()?" yes":" no"} end',
+        pieces: ['Mode ${', '} end'],
+        identifiers: [1],
+        identifierMap: { '1': 'HAS_X_FN' },
+      });
+
+      setupMocks(mockPromptData);
+      const cliContent = 'desc:`Mode ${Q1} end`';
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe(cliContent);
+      expect(result.results[0].applied).toBe(false);
+      expect(result.results[0].details).toContain('HAS_X');
+    });
+
+    it('should flag a drifted interpolation identifier even when the same name also appears in the match prose (#900)', async () => {
+      // The guard compares interpolation-token sets, not the whole match text, so
+      // a `## TOOLS` heading in prose must not mask a genuinely drifted ${TOOLS}.
+      const mockPromptData = buildMockPromptData({
+        promptId: 'drift-name-in-prose',
+        regex: '## TOOLS\\n\\$\\{([\\w$]+)\\} x',
+        getInterpolatedContent: () => '## TOOLS\n${TOOLS} x',
+        pieces: ['## TOOLS\n${', '} x'],
+        identifiers: [1],
+        identifierMap: { '1': 'q' },
+      });
+
+      setupMocks(mockPromptData);
+      const cliContent = 'desc:`## TOOLS\n${q} x`'; // q is live; TOOLS only in prose
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe(cliContent);
+      expect(result.results[0].applied).toBe(false);
+      expect(result.results[0].details).toContain('TOOLS');
+    });
+
+    it('should apply normally when an ALL-CAPS interpolation identifier is present in the bundle match (no false positive)', async () => {
+      // Negative control: a genuine ALL-CAPS bundle reference must NOT be flagged.
+      const mockPromptData = buildMockPromptData({
+        promptId: 'legit-caps-present',
+        regex: 'Limit \\$\\{MAX_TOKENS\\} (\\w+)',
+        getInterpolatedContent: () => 'Limit ${MAX_TOKENS} refreshed',
+        pieces: ['Limit ${MAX_TOKENS} ', ''],
+        identifiers: [],
+        identifierMap: {},
+      });
+
+      setupMocks(mockPromptData);
+      const cliContent = 'desc:`Limit ${MAX_TOKENS} stale`';
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe('desc:`Limit ${MAX_TOKENS} refreshed`');
+      expect(result.results[0].applied).toBe(true);
+    });
+
+    it('should not flag an ALL-CAPS token that appears only in prose, not inside ${...}', async () => {
+      const mockPromptData = buildMockPromptData({
+        promptId: 'prose-caps-token',
+        regex: 'Doc \\$\\{([\\w$]+)\\} (\\w+)',
+        getInterpolatedContent: () => 'Doc ${x} see CLAUDE_LOCAL_MD',
+        pieces: ['Doc ${', '} '],
+        identifiers: [1],
+        identifierMap: { '1': 'x' },
+      });
+
+      setupMocks(mockPromptData);
+      const cliContent = 'desc:`Doc ${x} old`';
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.results[0].applied).toBe(true);
+      expect(result.newContent).toContain('CLAUDE_LOCAL_MD');
+    });
+
+    it('should not guard quoted/JSON prompts where ${...} is inert text (delimiter is not a backtick)', async () => {
+      const mockPromptData = buildMockPromptData({
+        promptId: 'quoted-inert',
+        regex: 'Cfg \\$\\{INERT_TOKEN\\} (\\w+)',
+        getInterpolatedContent: () => 'Cfg ${INERT_TOKEN} refreshed',
+        pieces: ['Cfg ${INERT_TOKEN} ', ''],
+        identifiers: [],
+        identifierMap: {},
+      });
+
+      setupMocks(mockPromptData);
+      const cliContent = 'desc:"Cfg ${INERT_TOKEN} stale"'; // double-quoted -> inert
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.results[0].applied).toBe(true);
+      expect(result.newContent).toContain('INERT_TOKEN');
+    });
+
     it('should auto-escape multiple backticks in template literal context', async () => {
       const mockPromptData = buildMockPromptData({
         content: 'Use `foo` and `bar` for config',

--- a/src/patches/systemPrompts.ts
+++ b/src/patches/systemPrompts.ts
@@ -39,13 +39,73 @@ const extractBuildTime = (content: string): string | undefined => {
 };
 
 /**
- * Apply system prompt customizations to cli.js content
- * @param content - The current content of cli.js
- * @param version - The Claude Code version
- * @param escapeNonAscii - Whether to escape non-ASCII characters (auto-detected if not specified)
- * @param patchFilter - Optional list of patch/prompt IDs to apply (if provided, only matching prompts are applied)
- * @returns SystemPromptsResult with modified content and per-prompt results
+ * Collects the ALL-CAPS identifier tokens used inside `${...}` interpolations of
+ * a string. Escaped interpolations (`\${...}`) are inert (even in a backtick
+ * literal) and skipped; only ALL-CAPS tokens are collected because Claude Code's
+ * minified variables are lowercase while its prompt identifiers are ALL-CAPS, so
+ * ordinary lowercase code and method names inside an interpolation are ignored.
  */
+const capsTokensInInterpolations = (s: string): Set<string> => {
+  const found = new Set<string>();
+  const capsToken = /\b[A-Z][A-Z0-9_]*\b/g;
+
+  for (let i = 0; i < s.length - 1; i++) {
+    if (s[i] === '$' && s[i + 1] === '{') {
+      // Skip escaped interpolations (\${...}); inert even in a backtick literal.
+      let backslashes = 0;
+      let k = i - 1;
+      while (k >= 0 && s[k] === '\\') {
+        backslashes++;
+        k--;
+      }
+      if (backslashes % 2 === 1) continue;
+
+      // Walk to the matching close brace, tracking nested braces.
+      let depth = 1;
+      let j = i + 2;
+      const start = j;
+      while (j < s.length && depth > 0) {
+        if (s[j] === '{') depth++;
+        else if (s[j] === '}') depth--;
+        j++;
+      }
+      for (const m of s.slice(start, j - 1).matchAll(capsToken))
+        found.add(m[0]);
+      i = j - 1;
+    }
+  }
+
+  return found;
+};
+
+/**
+ * Detects identifiers a prompt's interpolated replacement would introduce into a
+ * live `${...}` interpolation that the original matched bundle text never
+ * defined.
+ *
+ * This catches a stale prompt .md whose interpolation identifier was renamed
+ * upstream without a per-prompt version bump (#899): applyIdentifierMapping
+ * leaves the old human-name unmapped, so the replacement references a variable
+ * that does not exist. That is a runtime ReferenceError which `node --check`
+ * cannot catch (it parses fine) and which crashes Claude Code on the first turn
+ * (#900).
+ *
+ * Callers must invoke this only for backtick-delimited prompts, where `${...}`
+ * is real interpolation; in quoted/JSON string literals `${...}` is inert text.
+ * Interpolation-identifier sets are compared like-for-like, so a name that also
+ * appears in the prompt's ALL-CAPS prose (e.g. a "## TOOLS" heading) does not
+ * mask a genuinely drifted `${TOOLS}` interpolation.
+ */
+const findIntroducedInterpolationIdentifiers = (
+  replacement: string,
+  originalMatch: string
+): string[] => {
+  const inMatch = capsTokensInInterpolations(originalMatch);
+  return [...capsTokensInInterpolations(replacement)].filter(
+    tok => !inMatch.has(tok)
+  );
+};
+
 const escapeUnescapedChar = (str: string, char: string): string => {
   let result = '';
   for (let i = 0; i < str.length; i++) {
@@ -68,6 +128,14 @@ const escapeUnescapedChar = (str: string, char: string): string => {
   return result;
 };
 
+/**
+ * Apply system prompt customizations to cli.js content
+ * @param content - The current content of cli.js
+ * @param version - The Claude Code version
+ * @param escapeNonAscii - Whether to escape non-ASCII characters (auto-detected if not specified)
+ * @param patchFilter - Optional list of patch/prompt IDs to apply (if provided, only matching prompts are applied)
+ * @returns SystemPromptsResult with modified content and per-prompt results
+ */
 export const applySystemPrompts = async (
   content: string,
   version: string,
@@ -156,6 +224,37 @@ export const applySystemPrompts = async (
       // Check the delimiter character before the match to determine string type
       const matchIndex = match.index;
       const delimiter = matchIndex > 0 ? content[matchIndex - 1] : '';
+
+      // For backtick-delimited prompts, `${...}` is live interpolation. A stale
+      // .md (identifier renamed upstream without a version bump, #899) leaves an
+      // old human-name unmapped in applyIdentifierMapping, so the replacement
+      // references a variable the bundle never defines; writing it would throw
+      // ReferenceError at runtime, which node --check cannot catch (#900). Skip
+      // the prompt rather than corrupt cli.js. Quoted/JSON prompts are inert
+      // here and are left to the escaping paths below.
+      if (delimiter === '`') {
+        const introduced = findIntroducedInterpolationIdentifiers(
+          interpolatedContent,
+          match[0]
+        );
+        if (introduced.length > 0) {
+          console.log(
+            chalk.yellow(
+              `Skipped "${prompt.name}": replacement references ${introduced.join(
+                ', '
+              )} not found in cli.js (stale prompt file — re-sync it, e.g. delete the prompt's .md in your system-prompts directory and re-run --apply)`
+            )
+          );
+          results.push({
+            id: promptId,
+            name: prompt.name,
+            group: PatchGroup.SYSTEM_PROMPTS,
+            applied: false,
+            details: `stale identifier: ${introduced.join(', ')}`,
+          });
+          continue;
+        }
+      }
 
       // Calculate character counts for this prompt (both with human-readable placeholders)
       // Note: trim() to match how markdown files are parsed and how whitespace is applied


### PR DESCRIPTION
Fixes #900.

## The bug

After `--apply`, Claude Code parses fine (`node --check` passes) and boots, but crashes on the first turn:

```
{"subtype":"error_during_execution","is_error":true,"num_turns":0,
 "errors":["HAS_PROJECT_SKILL_UPKEEP_INSTRUCTIONS is not defined"]}
```

A prompt `.md` generated from an older snapshot can carry an interpolation identifier that was later renamed upstream without a per-prompt `version` bump (see #899). `applyIdentifierMapping` maps only the *current* identifier names, so the old human-name survives unmapped and is written into `cli.js` as an undefined variable.

## The invariant this leans on

A `${...}` `ReferenceError` is only reachable inside a **live backtick template literal**. In a quoted or JSON string literal, `${...}` is inert text, so a made-up identifier there is harmless. That is what makes the guard both safe (quoted/JSON "Data:" docs are never touched) and complete (a real crash implies a backtick).

## The fix

In `applySystemPrompts`, for backtick-delimited prompts only, compare the ALL-CAPS interpolation-identifier sets of the replacement and the original bundle match. If the replacement uses an identifier inside a `${...}` that never appears in one of the match's `${...}` interpolations, skip the prompt with a warning instead of writing the corrupt content.

- Sets are compared like-for-like (interpolations vs interpolations), so an ALL-CAPS name that also appears in prose (e.g. a `## TOOLS` heading) does not mask a genuinely drifted `${TOOLS}`.
- Escaped `\${...}` is inert even inside a backtick literal and is skipped.
- Single-word identifiers (`INTERVAL`, `TOOLS`) are covered, not just multi-segment `UPPER_SNAKE`.

## Verification

- 8 unit tests: the crash repro, the real `${Q1}${HAS_X()...}` drift shape, single-word drift, prose-masking, plus negative controls (a legit ALL-CAPS bundle reference still applies; ALL-CAPS prose is ignored; quoted `${...}` is not guarded).
- Built the fix and applied it to a copy of a real Claude Code 2.1.216 native binary against a healthy 598-prompt config: 0 spurious skips, `node --check` passes, it boots, and a live `-p` round-trips.

A companion issue (#899) covers the sync side (detecting the drift so the `.md` heals instead of being skipped); this PR is the apply-time safety net.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale system-prompt replacements from corrupting the CLI and causing crashes on the first turn.
  * Invalid prompt interpolations are now safely skipped with a warning instead of being applied.
  * Preserved valid interpolations and ensured quoted prompts are handled correctly.

* **Documentation**
  * Added an entry documenting this fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->