### PR TITLE
Update `node-lief` to v1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "globby": "^14.1.0",
     "gray-matter": "^4.0.3",
     "ink": "^6.1.0",
-    "node-lief": "^1.3.0",
+    "node-lief": "^1.3.2",
     "oxfmt": "^0.28.0",
     "react": "^19.1.1",
     "terminal-link": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0(@types/react@19.2.17)(react@19.1.1)
       node-lief:
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.2
+        version: 1.3.2
       oxfmt:
         specifier: ^0.28.0
         version: 0.28.0
@@ -1575,16 +1575,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-addon-api@8.5.0:
-    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
-    engines: {node: ^18 || ^20 || >= 21}
-
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
-
-  node-lief@1.3.0:
-    resolution: {integrity: sha512-HlZw0jG/kDaPngass2QA79iW5QmSKZuSdKfrI35MiwV0GDDiB+qghhkuOhub/dW2QxFqMZw3OBulI32JqHn0Wg==}
+  node-lief@1.3.2:
+    resolution: {integrity: sha512-Hpko9foMqv7BnUDMJIFF4juDxMSVXxo957R5IQgYq1amt1z9Bwc51axXTlOt3vyyIDDdWMKv/2J4+vyfTuTqig==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3751,14 +3743,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-addon-api@8.5.0: {}
-
-  node-gyp-build@4.8.4: {}
-
-  node-lief@1.3.0:
-    dependencies:
-      node-addon-api: 8.5.0
-      node-gyp-build: 4.8.4
+  node-lief@1.3.2: {}
 
   object-assign@4.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   esbuild: true
   node-lief: false
+minimumReleaseAgeExclude:
+  - node-lief@1.3.2


### PR DESCRIPTION
@coderabbitai ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `node-lief` dependency to version 1.3.2.
  * Adjusted package release-age settings to allow the updated dependency immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->