### PR TITLE
Recognize the extension-less 'cli' entry module of Claude Code 2.1.229+

### DIFF
--- a/src/nativeInstallation.ts
+++ b/src/nativeInstallation.ts
@@ -227,7 +227,11 @@ function isClaudeModule(moduleName: string): boolean {
     moduleName.endsWith('/claude.exe') ||
     moduleName === 'claude.exe' ||
     moduleName.endsWith('/src/entrypoints/cli.js') ||
-    moduleName === 'src/entrypoints/cli.js'
+    moduleName === 'src/entrypoints/cli.js' ||
+    // Claude Code >= 2.1.229 names the entry module `cli` with no extension
+    // (`/$bunfs/root/cli` on POSIX, `B:/~BUN/root/cli` on Windows).
+    moduleName.endsWith('/cli') ||
+    moduleName === 'cli'
   );
 }
 


### PR DESCRIPTION
🤖 Generated by [Claude Code](https://claude.com/claude-code)

Closes #945

Claude Code 2.1.229 renamed the Bun compile entry module from `src/entrypoints/cli.js` to extension-less `cli` — `/$bunfs/root/cli` on POSIX, `B:/~BUN/root/cli` on Windows. `isClaudeModule()` no longer matches it, so both `unpack` and `repack` fail on 2.1.229 native binaries with `Error: Could not extract JS from native binary`. Same failure mode as #584 when 2.1.69 last renamed the module.

The rename looks deliberate and permanent: the Claude Agent SDK's `extractFromBunfs.js` extracts the embedded CLI to a temp file named after the module's basename, and comments that a native binary must not come out named `cli.js` because `ProcessTransport.isNativeBinary()` picks the spawn strategy by extension.

## Testing

- `unpack` on the published 2.1.229 binaries for darwin-arm64, linux-x64, and win32-x64 (from the `@anthropic-ai/claude-code-*` npm packages): all extract successfully (~25.4 MB of JS each); all fail without this change.
- `unpack` on 2.1.228 darwin-arm64 still works (old `src/entrypoints/cli.js` name, no regression).
- Round-trip: `repack` of the extracted JS into a copy of the 2.1.229 darwin-arm64 binary succeeds and the repacked binary runs (`--version` → `2.1.229 (Claude Code)`).
- `npm run lint` and the vitest suite (510 tests) pass. Pre-commit hook steps were run manually — the hook invokes pnpm, which this machine doesn't have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of Claude Code command-line modules, including modules named `cli` or ending in `/cli`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->