### PR TITLE
Replace the existing `.bun` payload for ELF binaries instead of appending a new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Replace the existing `.bun` payload for ELF binaries instead of appending a new one (#952) - @signadou
+
 ## [v4.3.3](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.3) - 2026-08-13
 
 - Clarify that `--apply --patches` restores from backup before applying the listed patch IDs (#699)

--- a/src/nativeInstallation.test.ts
+++ b/src/nativeInstallation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeBunSectionPlacement } from './nativeInstallation';
+import {
+  computeBunSectionPlacement,
+  replaceTailBunSection,
+} from './nativeInstallation';
 
 // Real Claude Code 2.1.218 native (ELF) numbers, read via readelf:
 //   RW PT_LOAD: vaddr 0x524f1a0, fileoff 0x504f1a0, filesz/memsz 0xb42ae60
@@ -17,6 +20,126 @@ const REAL_218 = {
   newContentSize: 0xb231a61n,
   pageSize: 0x1000n,
 };
+
+function makeReplaceableElf(): Buffer {
+  const file = Buffer.alloc(0x6000);
+  file.set([0x7f, 0x45, 0x4c, 0x46, 2, 1]);
+  file.writeBigUInt64LE(0x40n, 32); // e_phoff
+  file.writeBigUInt64LE(0x5000n, 40); // e_shoff
+  file.writeUInt16LE(56, 54); // e_phentsize
+  file.writeUInt16LE(1, 56); // e_phnum
+  file.writeUInt16LE(64, 58); // e_shentsize
+  file.writeUInt16LE(2, 60); // e_shnum
+
+  // Sole PT_LOAD: RW, file [0x1000, 0x4000), vaddr [0x500000, 0x503000)
+  file.writeUInt32LE(1, 0x40);
+  file.writeUInt32LE(6, 0x44);
+  file.writeBigUInt64LE(0x1000n, 0x48);
+  file.writeBigUInt64LE(0x500000n, 0x50);
+  file.writeBigUInt64LE(0x3000n, 0x60);
+  file.writeBigUInt64LE(0x3000n, 0x68);
+
+  // .bun section: final page of the RW LOAD, old logical size 0x900.
+  const bunHeader = 0x5000 + 64;
+  file.writeUInt32LE(1, bunHeader);
+  file.writeBigUInt64LE(0x502000n, bunHeader + 16);
+  file.writeBigUInt64LE(0x3000n, bunHeader + 24);
+  file.writeBigUInt64LE(0x900n, bunHeader + 32);
+
+  // File-only tail section that must move with the section table.
+  file.writeUInt32LE(1, 0x5000);
+  file.writeBigUInt64LE(0x4200n, 0x5000 + 24);
+  file.writeBigUInt64LE(0x100n, 0x5000 + 32);
+  file.fill(0xab, 0x4200, 0x4300);
+  return file;
+}
+
+describe('replaceTailBunSection', () => {
+  it('replaces a tail .bun allocation and shifts file-only metadata by the aligned delta', () => {
+    const result = replaceTailBunSection({
+      file: makeReplaceableElf(),
+      bunFileOffset: 0x3000n,
+      bunVirtualAddress: 0x502000n,
+      bunSize: 0x900n,
+      rwFileOffset: 0x1000n,
+      rwVirtualAddress: 0x500000n,
+      rwFileSize: 0x3000n,
+      rwVirtualSize: 0x3000n,
+      pageSize: 0x1000n,
+      newSectionData: Buffer.alloc(0x1800, 0xcd),
+    });
+
+    expect(result).not.toBeNull();
+    const output = result!;
+    expect(output.length).toBe(0x7000);
+    expect(output.subarray(0x3000, 0x4800)).toEqual(Buffer.alloc(0x1800, 0xcd));
+    expect(output.readBigUInt64LE(40)).toBe(0x6000n);
+    expect(output.readBigUInt64LE(0x40 + 32)).toBe(0x4000n);
+    expect(output.readBigUInt64LE(0x40 + 40)).toBe(0x4000n);
+    expect(output.readBigUInt64LE(0x6000 + 24)).toBe(0x5200n);
+    expect(output.readBigUInt64LE(0x6000 + 64 + 32)).toBe(0x1800n);
+    expect(output.subarray(0x5200, 0x5300)).toEqual(Buffer.alloc(0x100, 0xab));
+  });
+
+  it('reuses the existing allocation without growing the binary when the rebuilt .bun fits in its page', () => {
+    const result = replaceTailBunSection({
+      file: makeReplaceableElf(),
+      bunFileOffset: 0x3000n,
+      bunVirtualAddress: 0x502000n,
+      bunSize: 0x900n,
+      rwFileOffset: 0x1000n,
+      rwVirtualAddress: 0x500000n,
+      rwFileSize: 0x3000n,
+      rwVirtualSize: 0x3000n,
+      pageSize: 0x1000n,
+      newSectionData: Buffer.alloc(0x800, 0xef),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(0x6000);
+    expect(result!.readBigUInt64LE(0x5000 + 64 + 32)).toBe(0x800n);
+  });
+
+  it('declines a `.bun` whose allocation does not reach the writable segment end', () => {
+    const result = replaceTailBunSection({
+      file: makeReplaceableElf(),
+      bunFileOffset: 0x3000n,
+      bunVirtualAddress: 0x502000n,
+      bunSize: 0x900n,
+      rwFileOffset: 0x1000n,
+      rwVirtualAddress: 0x500000n,
+      rwFileSize: 0x3000n,
+      rwVirtualSize: 0x4000n,
+      pageSize: 0x1000n,
+      newSectionData: Buffer.alloc(0x1800),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('declines layouts where another loadable segment reaches into the moved tail', () => {
+    const file = makeReplaceableElf();
+    file.writeUInt16LE(2, 56);
+    file.writeUInt32LE(1, 0x40 + 56);
+    file.writeBigUInt64LE(0x3f00n, 0x40 + 56 + 8);
+    file.writeBigUInt64LE(0x600000n, 0x40 + 56 + 16);
+    file.writeBigUInt64LE(0x200n, 0x40 + 56 + 32);
+    const result = replaceTailBunSection({
+      file,
+      bunFileOffset: 0x3000n,
+      bunVirtualAddress: 0x502000n,
+      bunSize: 0x900n,
+      rwFileOffset: 0x1000n,
+      rwVirtualAddress: 0x500000n,
+      rwFileSize: 0x3000n,
+      rwVirtualSize: 0x3000n,
+      pageSize: 0x1000n,
+      newSectionData: Buffer.alloc(0x1800),
+    });
+
+    expect(result).toBeNull();
+  });
+});
 
 describe('computeBunSectionPlacement', () => {
   it('places the new .bun right after the writable segment when it is topmost (no zero-padding gap)', () => {

--- a/src/nativeInstallation.ts
+++ b/src/nativeInstallation.ts
@@ -995,15 +995,12 @@ function rebuildBunData(
  * @param outputPath - Target file path
  * @param originalPath - Original file to copy permissions from
  */
-function atomicWriteBinary(
-  binary: LIEF.ELF.Binary | LIEF.PE.Binary | LIEF.MachO.Binary,
+function atomicReplaceFile(
+  tempPath: string,
   outputPath: string,
   originalPath: string,
-  copyPermissions: boolean = true
+  copyPermissions: boolean
 ): void {
-  const tempPath = outputPath + '.tmp';
-  binary.write(tempPath);
-
   if (copyPermissions) {
     const origStat = fs.statSync(originalPath);
     fs.chmodSync(tempPath, origStat.mode);
@@ -1037,6 +1034,28 @@ function atomicWriteBinary(
 
     throw error;
   }
+}
+
+function atomicWriteBinary(
+  binary: LIEF.ELF.Binary | LIEF.PE.Binary | LIEF.MachO.Binary,
+  outputPath: string,
+  originalPath: string,
+  copyPermissions: boolean = true
+): void {
+  const tempPath = outputPath + '.tmp';
+  binary.write(tempPath);
+  atomicReplaceFile(tempPath, outputPath, originalPath, copyPermissions);
+}
+
+/** Atomically write a raw binary buffer while retaining the original mode. */
+function atomicWriteBuffer(
+  content: Buffer,
+  outputPath: string,
+  originalPath: string
+): void {
+  const tempPath = outputPath + '.tmp';
+  fs.writeFileSync(tempPath, content);
+  atomicReplaceFile(tempPath, outputPath, originalPath, true);
 }
 
 /**
@@ -1222,6 +1241,205 @@ export interface BunSectionPlacement {
   compact: boolean;
 }
 
+const ELF64_EHDR_SIZE = 64;
+const ELF64_PHDR_SIZE = 56;
+const ELF64_SHDR_SIZE = 64;
+const ELF64_SHT_NOBITS = 8;
+
+function bigintToSafeNumber(value: bigint, label: string): number {
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`${label} is outside JavaScript's safe buffer range`);
+  }
+  return Number(value);
+}
+
+/**
+ * Rebuild an ELF file around the current tail `.bun` payload instead of appending
+ * another copy. This is valid only when `.bun` occupies the end of its writable
+ * PT_LOAD: data after that boundary is file-only metadata, whose offsets can be
+ * shifted without moving any mapped virtual address.
+ *
+ * Returns null for layouts that do not meet those invariants; callers must fall
+ * back to relocation rather than risk changing mapped ELF content.
+ */
+export function replaceTailBunSection(params: {
+  file: Buffer;
+  bunFileOffset: bigint;
+  bunVirtualAddress: bigint;
+  bunSize: bigint;
+  rwFileOffset: bigint;
+  rwVirtualAddress: bigint;
+  rwFileSize: bigint;
+  rwVirtualSize: bigint;
+  pageSize: bigint;
+  newSectionData: Buffer;
+}): Buffer | null {
+  const {
+    file,
+    bunFileOffset,
+    bunVirtualAddress,
+    bunSize,
+    rwFileOffset,
+    rwVirtualAddress,
+    rwFileSize,
+    rwVirtualSize,
+    pageSize,
+    newSectionData,
+  } = params;
+
+  if (
+    file.length < ELF64_EHDR_SIZE ||
+    !file.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46])) ||
+    file[4] !== 2 ||
+    file[5] !== 1 ||
+    pageSize <= 0n
+  ) {
+    return null;
+  }
+
+  const rwFileEnd = rwFileOffset + rwFileSize;
+  const oldAllocatedSize = alignBigInt(bunSize, pageSize);
+  if (
+    bunFileOffset + oldAllocatedSize !== rwFileEnd ||
+    bunVirtualAddress + oldAllocatedSize !== rwVirtualAddress + rwVirtualSize ||
+    rwFileEnd > BigInt(file.length)
+  ) {
+    return null;
+  }
+
+  const ePhoff = file.readBigUInt64LE(32);
+  const eShoff = file.readBigUInt64LE(40);
+  const ePhentsize = file.readUInt16LE(54);
+  const ePhnum = file.readUInt16LE(56);
+  const eShentsize = file.readUInt16LE(58);
+  const eShnum = file.readUInt16LE(60);
+  if (ePhentsize !== ELF64_PHDR_SIZE || eShentsize !== ELF64_SHDR_SIZE) {
+    return null;
+  }
+
+  const phTableEnd = ePhoff + BigInt(ePhentsize * ePhnum);
+  const shTableEnd = eShoff + BigInt(eShentsize * eShnum);
+  if (
+    phTableEnd > BigInt(file.length) ||
+    eShoff < rwFileEnd ||
+    shTableEnd > BigInt(file.length)
+  ) {
+    return null;
+  }
+
+  // Everything after the writable file end must be file-only. Moving another
+  // PT_LOAD would require changing its file offset and virtual-address mapping.
+  for (let index = 0; index < ePhnum; index++) {
+    const headerOffset = bigintToSafeNumber(
+      ePhoff + BigInt(index * ELF64_PHDR_SIZE),
+      'ELF program header offset'
+    );
+    if (file.readUInt32LE(headerOffset) !== 1) {
+      continue;
+    }
+    const offset = file.readBigUInt64LE(headerOffset + 8);
+    const fileSize = file.readBigUInt64LE(headerOffset + 32);
+    if (offset !== rwFileOffset && offset + fileSize > rwFileEnd) {
+      return null;
+    }
+  }
+
+  // A section may not straddle the replacement boundary. Such a section would
+  // have mapped bytes before the boundary and moved bytes after it.
+  for (let index = 0; index < eShnum; index++) {
+    const headerOffset = bigintToSafeNumber(
+      eShoff + BigInt(index * ELF64_SHDR_SIZE),
+      'ELF section header offset'
+    );
+    const type = file.readUInt32LE(headerOffset + 4);
+    const offset = file.readBigUInt64LE(headerOffset + 24);
+    const size = file.readBigUInt64LE(headerOffset + 32);
+    if (
+      type !== ELF64_SHT_NOBITS &&
+      offset < rwFileEnd &&
+      offset + size > rwFileEnd
+    ) {
+      return null;
+    }
+  }
+
+  const newAllocatedSize = alignBigInt(BigInt(newSectionData.length), pageSize);
+  const sizeDelta = newAllocatedSize - oldAllocatedSize;
+  const oldTailOffset = bigintToSafeNumber(
+    rwFileEnd,
+    'ELF writable segment end'
+  );
+  const newTailOffset = bigintToSafeNumber(
+    rwFileEnd + sizeDelta,
+    'ELF replacement tail offset'
+  );
+  if (newTailOffset < 0) {
+    return null;
+  }
+
+  const result = Buffer.alloc(
+    bigintToSafeNumber(BigInt(file.length) + sizeDelta, 'ELF replacement size')
+  );
+  const bunOffset = bigintToSafeNumber(bunFileOffset, '.bun file offset');
+  file.copy(result, 0, 0, bunOffset);
+  newSectionData.copy(result, bunOffset);
+  file.copy(result, newTailOffset, oldTailOffset);
+
+  // The section table lies in the moved file-only tail. Repoint it first, then
+  // update each section whose bytes moved. SHT_NOBITS has no file bytes.
+  const newShoff = eShoff + sizeDelta;
+  result.writeBigUInt64LE(newShoff, 40);
+  let bunSectionFound = false;
+  for (let index = 0; index < eShnum; index++) {
+    const headerOffset = bigintToSafeNumber(
+      newShoff + BigInt(index * ELF64_SHDR_SIZE),
+      'ELF section header offset'
+    );
+    const sectionType = result.readUInt32LE(headerOffset + 4);
+    const sectionAddress = result.readBigUInt64LE(headerOffset + 16);
+    const sectionOffset = result.readBigUInt64LE(headerOffset + 24);
+    const sectionSize = result.readBigUInt64LE(headerOffset + 32);
+
+    if (
+      sectionOffset === bunFileOffset &&
+      sectionAddress === bunVirtualAddress &&
+      sectionSize === bunSize
+    ) {
+      result.writeBigUInt64LE(BigInt(newSectionData.length), headerOffset + 32);
+      bunSectionFound = true;
+    } else if (sectionType !== ELF64_SHT_NOBITS && sectionOffset >= rwFileEnd) {
+      result.writeBigUInt64LE(sectionOffset + sizeDelta, headerOffset + 24);
+    }
+  }
+  if (!bunSectionFound) {
+    return null;
+  }
+
+  // Locate the exact writable PT_LOAD and resize only its file/memory extent.
+  let rwProgramHeaderFound = false;
+  for (let index = 0; index < ePhnum; index++) {
+    const headerOffset = bigintToSafeNumber(
+      ePhoff + BigInt(index * ELF64_PHDR_SIZE),
+      'ELF program header offset'
+    );
+    const type = result.readUInt32LE(headerOffset);
+    const offset = result.readBigUInt64LE(headerOffset + 8);
+    const virtualAddress = result.readBigUInt64LE(headerOffset + 16);
+    if (
+      type === 1 &&
+      offset === rwFileOffset &&
+      virtualAddress === rwVirtualAddress
+    ) {
+      result.writeBigUInt64LE(rwFileSize + sizeDelta, headerOffset + 32);
+      result.writeBigUInt64LE(rwVirtualSize + sizeDelta, headerOffset + 40);
+      rwProgramHeaderFound = true;
+      break;
+    }
+  }
+
+  return rwProgramHeaderFound ? result : null;
+}
+
 /**
  * Compute where to place the rebuilt `.bun` section inside the writable PT_LOAD.
  *
@@ -1292,14 +1510,50 @@ function repackELFSection(
       throw new Error('.bun section not found');
     }
 
-    const rwSegment = elfBinary
-      .segments()
-      .find(s => s.type === 'LOAD' && (s.flags & 2) !== 0);
+    // Match the writable PT_LOAD that actually contains `.bun`; choosing the
+    // first writable segment is unsafe on binaries with an additional RW LOAD.
+    const rwSegment = elfBinary.segments().find(s => {
+      const segmentEnd = s.virtualAddress + BigInt(s.virtualSize);
+      return (
+        s.type === 'LOAD' &&
+        (s.flags & 2) !== 0 &&
+        s.virtualAddress <= bunSection.virtualAddress &&
+        bunSection.virtualAddress < segmentEnd
+      );
+    });
     if (!rwSegment) {
-      throw new Error('No writable ELF PT_LOAD segment found');
+      throw new Error('No writable ELF PT_LOAD contains .bun');
     }
 
     const newSectionData = buildSectionData(newBunBuffer, sectionHeaderSize);
+
+    // Current Bun appends the active `.bun` at the end of this PT_LOAD, with
+    // only file-only metadata after it. Replace that allocation in place and
+    // shift the metadata tail, avoiding an orphaned previous module graph.
+    const compactedFile = replaceTailBunSection({
+      file: fs.readFileSync(binPath),
+      bunFileOffset: bunSection.fileOffset,
+      bunVirtualAddress: bunSection.virtualAddress,
+      bunSize: bunSection.size,
+      rwFileOffset: rwSegment.fileOffset,
+      rwVirtualAddress: rwSegment.virtualAddress,
+      rwFileSize: rwSegment.fileSize,
+      rwVirtualSize: BigInt(rwSegment.virtualSize),
+      pageSize: elfBinary.pageSize(),
+      newSectionData,
+    });
+    if (compactedFile) {
+      debug(
+        `repackELFSection: replaced tail .bun in place at offset=0x${bunSection.fileOffset.toString(16)}, size=0x${newSectionData.length.toString(16)}`
+      );
+      atomicWriteBuffer(compactedFile, outputPath, binPath);
+      debug('repackELFSection: In-place replacement completed successfully');
+      return;
+    }
+
+    debug(
+      'repackELFSection: .bun is not a replaceable tail allocation; falling back to relocation'
+    );
     const oldBunSectionVaddr = bunSection.virtualAddress;
     const vaddrBytes = Buffer.alloc(8);
     vaddrBytes.writeBigUInt64LE(oldBunSectionVaddr);


### PR DESCRIPTION
This reduces the size for patched ELF binaries by **40.7%**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing embedded Bun payloads are now replaced instead of unnecessarily appended, reducing file growth.
  * Updates preserve file permissions and handle busy files more reliably.
  * Replacements now reuse available space when possible and safely adjust file metadata when additional space is required.
  * Unsupported or invalid executable layouts are rejected safely rather than producing an invalid result.

* **Tests**
  * Added coverage for payload replacement, file growth, metadata updates, in-place reuse, and invalid layouts.

* **Documentation**
  * Added an unreleased changelog entry describing the payload replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->