### PR TITLE
Match saveAgentColor with its new options argument on Claude Code 2.1.233

### DIFF
--- a/src/patches/sessionColor.test.ts
+++ b/src/patches/sessionColor.test.ts
@@ -17,6 +17,12 @@ const makeTryCatchSaveAgentColor = () =>
   'catch(z){if(Qd(z))w(`saveAgentColor failed (${Yt(z)}): ${ne(z)}`,{level:"error"});else throw z}' +
   'if(H===V$())WA().currentSessionAgentColor=$;c("tengu_agent_color_set",{})}';
 
+const makeOptionsArgSaveAgentColor = () =>
+  ';async function Mr$(H,$,q,z){let K=q??sT(H);' +
+  'try{await Hv(K,{type:"agent-color",agentColor:$,sessionId:H},z)}' +
+  'catch(J){if(Qd(J))w(`saveAgentColor failed (${Yt(J)}): ${ne(J)}`,{level:"error"});else throw J}' +
+  'if(H===V$())WA().currentSessionAgentColor=$;c("tengu_agent_color_set",{})}';
+
 const makeCLIState = () =>
   'effortValue:oR(w.effort),' +
   'activeOverlays:new Set,fastMode:cP8(N5),' +
@@ -115,6 +121,15 @@ describe('sessionColor', () => {
       expect(result).not.toBeNull();
       expect(result).toContain('globalThis.__tweakccSaveAgentColor');
       expect(result).toContain('try{await Hv(K,');
+      expect(result).toContain('(c)=>Mr$(V$(),c)');
+    });
+
+    it('should patch saveAgentColor that takes an options argument', () => {
+      const result = patchSaveAgentColor(makeOptionsArgSaveAgentColor());
+      expect(result).not.toBeNull();
+      expect(result).toContain('globalThis.__tweakccSaveAgentColor');
+      expect(result).toContain('try{await Hv(K,');
+      expect(result).toContain('sessionId:H},z)');
       expect(result).toContain('(c)=>Mr$(V$(),c)');
     });
 

--- a/src/patches/sessionColor.ts
+++ b/src/patches/sessionColor.ts
@@ -79,20 +79,20 @@ export const patchSaveAgentColor = (oldFile: string): string | null => {
   const prefix =
     '([,;{}])' +
     '(async function ([$\\w]+)' +
-    '\\(([$\\w]+),([$\\w]+),([$\\w]+)\\)' +
+    '\\(([$\\w]+),([$\\w]+),([$\\w]+)(?:,[$\\w]+)?\\)' +
     '\\{let [$\\w]+=\\6\\?\\?[$\\w]+\\(\\4\\);';
 
   const patterns = [
     new RegExp(
       prefix +
         'if\\((?:await )?[$\\w]+\\([$\\w]+,' +
-        '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}\\),' +
+        '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}(?:,[$\\w]+)?\\),' +
         '\\4===([$\\w]+)\\(\\)\\))'
     ),
     new RegExp(
       prefix +
         'try\\{await [$\\w]+\\([$\\w]+,' +
-        '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}\\)\\}' +
+        '\\{type:"agent-color",agentColor:\\5,sessionId:\\4\\}(?:,[$\\w]+)?\\)\\}' +
         'catch\\([$\\w]+\\)\\{[\\s\\S]*?\\}' +
         'if\\(\\4===([$\\w]+)\\(\\)\\))'
     ),


### PR DESCRIPTION
## Problem

On Claude Code 2.1.233 the whole `session-color` patch bails out:

```
patch: sessionColor: failed to patch saveAgentColor
```

`saveAgentColor` grew a fourth parameter, which it forwards to the transcript append call:

```js
async function o2n(e,t,r,n){
  let o=r??yj(e);
  try{await Kie(o,{type:"agent-color",agentColor:t,sessionId:e},n)}
  catch(i){/* … */}
  if(e===qt())Cu().currentSessionAgentColor=t;
  O("tengu_agent_color_set",{})
}
```

The pattern pinned the signature to exactly three parameters and the append call to exactly two arguments, so neither of the two alternatives matched, and `writeSessionColor` returned `null` even though its app-state injections were fine.

## Fix

Make the extra parameter and the extra argument optional. Capture-group numbering is untouched (both additions are non-capturing), so the extraction of the function name and the session-id getter is unchanged.

## Verification

Ran the old and the new implementation over every extracted bundle I have (2.1.88, 2.1.89, 2.1.92, 2.1.98, 2.1.113, 2.1.126, 2.1.144, 2.1.183, 2.1.195, 2.1.201, 2.1.204, 2.1.214, 2.1.219, 2.1.233):

- On all 13 pre-2.1.233 bundles the new patterns produce a **byte-identical** result.
- On 2.1.233 the old patterns produce `null`; the new ones inject `globalThis.__tweakccSaveAgentColor=(c)=>o2n(qt(),c);`, which matches the `if(e===qt())` check inside that function.
- **Exactly one** match per bundle, so the looser patterns cannot latch onto a different function.
- Cost per bundle: 5–27 ms.

Applied to a real 2.1.233 native binary: the patch reports success, `TWEAKCC_SESSION_COLOR` and `__tweakccSaveAgentColor` are present in the patched bundle, and the binary runs (`2.1.233 (Claude Code)`).

A regression test covers the new shape; the existing tests for the three earlier shapes still pass. Full suite, `tsc`, ESLint and Prettier are clean.