### PR TITLE
Support Bun code-split standalone binaries (Claude Code 2.1.243)

### DIFF
--- a/src/nativeInstallation.test.ts
+++ b/src/nativeInstallation.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildModuleReplacements,
   computeBunSectionPlacement,
+  isChunkModule,
+  MODULE_BOUNDARY,
   replaceTailBunSection,
+  splitModulePayload,
 } from './nativeInstallation';
 
 // Real Claude Code 2.1.218 native (ELF) numbers, read via readelf:
@@ -233,5 +237,167 @@ describe('computeBunSectionPlacement', () => {
     expect(p.compact).toBe(false);
     expect(p.newVaddr % REAL_218.pageSize).toBe(0n);
     expect(p.newVaddr).toBe(0x20001000n); // align(0x20000800, page)
+  });
+});
+
+describe('isChunkModule', () => {
+  it('recognizes the code-split chunks emitted by Bun', () => {
+    expect(isChunkModule('/$bunfs/root/chunk-zrs5zyqa.js')).toBe(true);
+    expect(isChunkModule('B:/~BUN/root/chunk-b08jpphw.js')).toBe(true);
+    expect(isChunkModule('chunk-abc123.js')).toBe(true);
+  });
+
+  it('does not claim the entrypoint or ordinary modules', () => {
+    expect(isChunkModule('/$bunfs/root/cli')).toBe(false);
+    expect(isChunkModule('/$bunfs/root/claude')).toBe(false);
+    expect(isChunkModule('/$bunfs/root/chart.umd.min.js')).toBe(false);
+    expect(isChunkModule('/$bunfs/root/image-processor.node')).toBe(false);
+    // A directory named like a chunk must not drag its children in.
+    expect(isChunkModule('/$bunfs/root/chunk-abc.js/nested.js')).toBe(false);
+  });
+});
+
+describe('splitModulePayload', () => {
+  const join = (parts: Array<[string, string]>) =>
+    parts.map(([n, b]) => `${MODULE_BOUNDARY}${n}\n${b}`).join('');
+
+  it('returns null for a single-module payload so legacy binaries are untouched', () => {
+    expect(splitModulePayload('var a=1;')).toBeNull();
+    expect(splitModulePayload('')).toBeNull();
+  });
+
+  it('round-trips names and bodies exactly', () => {
+    const parts: Array<[string, string]> = [
+      ['/$bunfs/root/cli', 'var a=1;'],
+      ['/$bunfs/root/chunk-a.js', 'var b=2;\nvar c=3;'],
+      ['/$bunfs/root/chunk-b.js', ''],
+    ];
+    expect(splitModulePayload(join(parts))).toEqual(parts);
+  });
+
+  it('preserves bodies that contain blank lines and comment-like text', () => {
+    const parts: Array<[string, string]> = [
+      ['/$bunfs/root/cli', '\n\n// not a boundary\n'],
+      ['/$bunfs/root/chunk-a.js', '//#__tweakcc_module__ without colon'],
+    ];
+    expect(splitModulePayload(join(parts))).toEqual(parts);
+  });
+
+  it('survives a patch that changes a body length', () => {
+    const parts: Array<[string, string]> = [
+      ['/$bunfs/root/chunk-a.js', 'var x=200000;'],
+      ['/$bunfs/root/chunk-b.js', 'var y=1;'],
+    ];
+    const patched = join(parts).replace(
+      'var x=200000;',
+      'var x=(+process.env.CLAUDE_CODE_CONTEXT_LIMIT||200000);'
+    );
+    expect(splitModulePayload(patched)).toEqual([
+      [
+        '/$bunfs/root/chunk-a.js',
+        'var x=(+process.env.CLAUDE_CODE_CONTEXT_LIMIT||200000);',
+      ],
+      ['/$bunfs/root/chunk-b.js', 'var y=1;'],
+    ]);
+  });
+
+  it('throws rather than mis-split a malformed boundary', () => {
+    expect(() =>
+      splitModulePayload(`${MODULE_BOUNDARY}no-newline-after-name`)
+    ).toThrow(/Malformed tweakcc module boundary/);
+  });
+});
+
+describe('buildModuleReplacements', () => {
+  // The names a code-split binary would hand to the payload.
+  const BINARY = [
+    '/$bunfs/root/cli',
+    '/$bunfs/root/chunk-a.js',
+    '/$bunfs/root/chunk-b.js',
+  ];
+  const payload = (parts: Array<[string, string]>) =>
+    parts.map(([n, b]) => `${MODULE_BOUNDARY}${n}\n${b}`).join('');
+  const split = (parts: Array<[string, string]>) =>
+    splitModulePayload(payload(parts))!;
+
+  it("accepts a payload naming exactly the binary's modules", () => {
+    const parts: Array<[string, string]> = [
+      ['/$bunfs/root/cli', 'var a=1;'],
+      ['/$bunfs/root/chunk-a.js', 'var b=2;'],
+      ['/$bunfs/root/chunk-b.js', 'var c=3;'],
+    ];
+    const out = buildModuleReplacements(split(parts), BINARY);
+    expect([...out.keys()].sort()).toEqual([...BINARY].sort());
+    expect(out.get('/$bunfs/root/chunk-a.js')?.toString('utf8')).toBe(
+      'var b=2;'
+    );
+  });
+
+  it('accepts modules in a different order than the binary lists them', () => {
+    const parts: Array<[string, string]> = [
+      ['/$bunfs/root/chunk-b.js', 'var c=3;'],
+      ['/$bunfs/root/cli', 'var a=1;'],
+      ['/$bunfs/root/chunk-a.js', 'var b=2;'],
+    ];
+    expect(() => buildModuleReplacements(split(parts), BINARY)).not.toThrow();
+  });
+
+  // A patch that clobbers a boundary line drops that module from the payload.
+  // Writing on would silently keep the module's ORIGINAL contents.
+  it("rejects a payload missing one of the binary's modules", () => {
+    const parts: Array<[string, string]> = [
+      ['/$bunfs/root/cli', 'var a=1;'],
+      ['/$bunfs/root/chunk-a.js', 'var b=2;'],
+    ];
+    expect(() => buildModuleReplacements(split(parts), BINARY)).toThrow(
+      /missing 1 module\(s\).*chunk-b\.js/s
+    );
+  });
+
+  // Map construction keeps the LAST value, so a repeated name would silently
+  // discard the edits made to the earlier copy.
+  it('rejects a payload naming the same module twice', () => {
+    const parts: Array<[string, string]> = [
+      ['/$bunfs/root/cli', 'var a=1;'],
+      ['/$bunfs/root/chunk-a.js', 'var b=2;'],
+      ['/$bunfs/root/chunk-b.js', 'var c=3;'],
+      ['/$bunfs/root/chunk-a.js', 'var b=999;'],
+    ];
+    expect(() => buildModuleReplacements(split(parts), BINARY)).toThrow(
+      /more than once.*chunk-a\.js/s
+    );
+  });
+
+  // rebuildBunData looks replacements up by name, so a name the binary does
+  // not have is never consulted and its edits vanish without a trace.
+  it('rejects a payload naming a module the binary does not have', () => {
+    const parts: Array<[string, string]> = [
+      ['/$bunfs/root/cli', 'var a=1;'],
+      ['/$bunfs/root/chunk-a.js', 'var b=2;'],
+      ['/$bunfs/root/chunk-b.js', 'var c=3;'],
+      ['/$bunfs/root/chunk-typo.js', 'var d=4;'],
+    ];
+    expect(() => buildModuleReplacements(split(parts), BINARY)).toThrow(
+      /absent from the binary.*chunk-typo\.js/s
+    );
+  });
+
+  it('reports a mangled boundary name as both unknown and missing', () => {
+    // Corrupting one name is simultaneously an unknown entry and an absent one;
+    // whichever fires, it must not be accepted.
+    const parts: Array<[string, string]> = [
+      ['/$bunfs/root/cli', 'var a=1;'],
+      ['/$bunfs/root/chunk-a.js', 'var b=2;'],
+      ['/$bunfs/root/chunk-B.js', 'var c=3;'], // was chunk-b.js
+    ];
+    expect(() => buildModuleReplacements(split(parts), BINARY)).toThrow();
+  });
+
+  it('caps the reported names so a wholesale mismatch stays readable', () => {
+    const many = Array.from(
+      { length: 30 },
+      (_, i) => `/$bunfs/root/chunk-${i}.js`
+    );
+    expect(() => buildModuleReplacements([], many)).toThrow(/\(30 total\)/);
   });
 });

--- a/src/nativeInstallation.ts
+++ b/src/nativeInstallation.ts
@@ -236,6 +236,59 @@ function isClaudeModule(moduleName: string): boolean {
 }
 
 /**
+ * True if the module is one of the code-split chunks emitted alongside the
+ * entrypoint.
+ *
+ * Claude Code >= 2.1.243 is built with Bun's code splitting enabled: the entry
+ * module is a ~20 KB loader that `import`s ~1400 sibling `chunk-<hash>.js`
+ * modules, and essentially all of the application source lives in those chunks
+ * rather than in the entrypoint.
+ */
+export function isChunkModule(moduleName: string): boolean {
+  return /(^|\/)chunk-[^/]+\.js$/.test(moduleName);
+}
+
+/**
+ * Boundary marker used to present a code-split binary as a single string.
+ *
+ * `readContent()` hands callers one string so that a patch can be written as a
+ * plain search-and-replace, but a code-split binary has no single module to
+ * hand back. Concatenating the JS modules with a boundary that names each one
+ * keeps that contract: `writeContent()` splits on the same marker and routes
+ * every part back to the module it came from.
+ *
+ * The marker starts with a newline and is a `//` comment so that the assembled
+ * string stays valid, readable JavaScript.
+ */
+export const MODULE_BOUNDARY = '\n//#__tweakcc_module__:';
+
+/**
+ * Splits a concatenated multi-module payload back into [name, contents] pairs.
+ * Returns null if the payload is not in multi-module form.
+ */
+export function splitModulePayload(
+  content: string
+): Array<[string, string]> | null {
+  if (!content.startsWith(MODULE_BOUNDARY)) {
+    return null;
+  }
+
+  return content
+    .split(MODULE_BOUNDARY)
+    .slice(1) // leading '' before the first boundary
+    .map(segment => {
+      const nameEnd = segment.indexOf('\n');
+      if (nameEnd === -1) {
+        throw new Error('Malformed tweakcc module boundary: missing newline');
+      }
+      return [segment.slice(0, nameEnd), segment.slice(nameEnd + 1)] as [
+        string,
+        string,
+      ];
+    });
+}
+
+/**
  * Detects the module struct size from the modules list byte length.
  * Returns SIZEOF_MODULE_NEW (52) or SIZEOF_MODULE_OLD (36).
  */
@@ -697,6 +750,103 @@ function getBunData(
 }
 
 /**
+ * Collects every module holding application JavaScript, in module-table order.
+ * A binary that is not code-split yields exactly one (the entrypoint); a
+ * code-split one yields the entrypoint plus its chunks.
+ *
+ * Extraction and repacking have to agree exactly on this set -- a payload is
+ * written back by module name, so both sides share this one definition rather
+ * than repeating the predicate and risking drift.
+ */
+function collectJsModules(
+  bunData: Buffer,
+  bunOffsets: BunOffsets,
+  moduleStructSize: number
+): Array<[string, Buffer]> {
+  const jsModules: Array<[string, Buffer]> = [];
+
+  mapModules(
+    bunData,
+    bunOffsets,
+    moduleStructSize,
+    (module, moduleName, index) => {
+      debug(`collectJsModules: Module ${index}: ${moduleName}`);
+
+      // Module name is typically:
+      // - Unix/macOS: /$bunfs/root/claude
+      // - Windows:    B:/~BUN/root/claude.exe
+      if (!isClaudeModule(moduleName) && !isChunkModule(moduleName)) {
+        return undefined;
+      }
+
+      const moduleContents = getStringPointerContent(bunData, module.contents);
+      if (moduleContents.length > 0) {
+        jsModules.push([moduleName, moduleContents]);
+      }
+
+      return undefined; // visit every module
+    }
+  );
+
+  return jsModules;
+}
+
+/** Caps a name list so a wholesale mismatch cannot produce an unreadable error. */
+function summarizeNames(names: string[]): string {
+  const shown = names.slice(0, 5).join(', ');
+  return names.length > 5 ? `${shown}, ... (${names.length} total)` : shown;
+}
+
+/**
+ * Turns a split payload into per-module replacements, rejecting any payload
+ * that does not name exactly the modules it was assembled from.
+ *
+ * rebuildBunData() applies replacements by module name, so an unknown or
+ * repeated name is silently dropped and an absent one silently keeps the
+ * original contents. Each of those writes a binary that looks patched but is
+ * not, so validate the whole payload up front and fail loudly instead.
+ */
+export function buildModuleReplacements(
+  parts: Array<[string, string]>,
+  expectedNames: string[]
+): Map<string, Buffer> {
+  const replacements = new Map<string, Buffer>();
+  const duplicates: string[] = [];
+
+  for (const [moduleName, body] of parts) {
+    if (replacements.has(moduleName)) {
+      duplicates.push(moduleName);
+    }
+    replacements.set(moduleName, Buffer.from(body, 'utf8'));
+  }
+
+  if (duplicates.length > 0) {
+    throw new Error(
+      `Module payload names a module more than once: ${summarizeNames(duplicates)}`
+    );
+  }
+
+  const expected = new Set(expectedNames);
+  const unknown = [...replacements.keys()].filter(name => !expected.has(name));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Module payload names ${unknown.length} module(s) absent from the binary: ` +
+        summarizeNames(unknown)
+    );
+  }
+
+  const missing = expectedNames.filter(name => !replacements.has(name));
+  if (missing.length > 0) {
+    throw new Error(
+      `Module payload is missing ${missing.length} module(s) present in the binary: ` +
+        summarizeNames(missing)
+    );
+  }
+
+  return replacements;
+}
+
+/**
  * Extracts claude.js from a native installation binary.
  * Returns the contents as a Buffer, or null if not found.
  *
@@ -717,35 +867,42 @@ export function extractClaudeJsFromNativeInstallation(
       `extractClaudeJsFromNativeInstallation: Got bunData, size=${bunData.length} bytes, moduleStructSize=${moduleStructSize}`
     );
 
-    const result = mapModules(
-      bunData,
-      bunOffsets,
-      moduleStructSize,
-      (module, moduleName, index) => {
-        debug(
-          `extractClaudeJsFromNativeInstallation: Module ${index}: ${moduleName}`
-        );
+    const jsModules = collectJsModules(bunData, bunOffsets, moduleStructSize);
 
-        // Module name is typically:
-        // - Unix/macOS: /$bunfs/root/claude
-        // - Windows:    B:/~BUN/root/claude.exe
-        if (!isClaudeModule(moduleName)) return undefined;
-
-        const moduleContents = getStringPointerContent(
-          bunData,
-          module.contents
-        );
-
-        debug(
-          `extractClaudeJsFromNativeInstallation: Found claude module, contents length=${moduleContents.length}`
-        );
-
-        return moduleContents.length > 0 ? moduleContents : undefined;
-      }
+    debug(
+      `extractClaudeJsFromNativeInstallation: Found ${jsModules.length} JS module(s)`
     );
 
-    if (result) {
-      return result;
+    // Not code-split: hand back the entrypoint verbatim, exactly as before.
+    if (jsModules.length === 1) {
+      return jsModules[0][1];
+    }
+
+    if (jsModules.length > 1) {
+      // The boundary must not occur inside the source it delimits, or the
+      // round-trip through writeContent() would mis-split. Bail out rather than
+      // risk writing a corrupted binary.
+      for (const [moduleName, contents] of jsModules) {
+        if (contents.includes(MODULE_BOUNDARY)) {
+          throw new Error(
+            `Module ${moduleName} already contains the tweakcc boundary marker`
+          );
+        }
+      }
+
+      debug(
+        `extractClaudeJsFromNativeInstallation: Code-split binary, joining ${jsModules.length} modules`
+      );
+
+      return Buffer.from(
+        jsModules
+          .map(
+            ([moduleName, contents]) =>
+              `${MODULE_BOUNDARY}${moduleName}\n${contents.toString('utf8')}`
+          )
+          .join(''),
+        'utf8'
+      );
     }
 
     debug(
@@ -766,7 +923,11 @@ export function extractClaudeJsFromNativeInstallation(
 function rebuildBunData(
   bunData: Buffer,
   bunOffsets: BunOffsets,
-  modifiedClaudeJs: Buffer | null,
+  /**
+   * A Buffer replaces the entrypoint module's contents; a Map replaces the
+   * contents of each named module (used for code-split binaries).
+   */
+  modifiedClaudeJs: Buffer | Map<string, Buffer> | null,
   moduleStructSize: number
 ): Buffer {
   // Phase 1: Collect all string data
@@ -788,9 +949,13 @@ function rebuildBunData(
   mapModules(bunData, bunOffsets, moduleStructSize, (module, moduleName) => {
     const nameBytes = getStringPointerContent(bunData, module.name);
 
-    // Check if this is claude.js and we have modified contents
+    // Check if this module has modified contents
     let contentsBytes: Buffer;
-    if (modifiedClaudeJs && isClaudeModule(moduleName)) {
+    if (modifiedClaudeJs instanceof Map) {
+      contentsBytes =
+        modifiedClaudeJs.get(moduleName) ??
+        getStringPointerContent(bunData, module.contents);
+    } else if (modifiedClaudeJs && isClaudeModule(moduleName)) {
       contentsBytes = modifiedClaudeJs;
     } else {
       contentsBytes = getStringPointerContent(bunData, module.contents);
@@ -1706,10 +1871,32 @@ export function repackNativeInstallation(
   // Extract Bun data and rebuild with modified claude.js
   const { bunOffsets, bunData, sectionHeaderSize, moduleStructSize } =
     getBunData(binary);
+
+  // A payload produced from a code-split binary carries every module it was
+  // assembled from; split it back apart so each lands in its own module.
+  const parts = splitModulePayload(modifiedClaudeJs.toString('utf8'));
+  let replacement: Buffer | Map<string, Buffer>;
+
+  if (parts) {
+    // Only a payload naming exactly the modules it came from may be written;
+    // anything else would leave some module silently unpatched.
+    replacement = buildModuleReplacements(
+      parts,
+      collectJsModules(bunData, bunOffsets, moduleStructSize).map(
+        ([moduleName]) => moduleName
+      )
+    );
+    debug(
+      `repackNativeInstallation: Code-split payload, writing ${parts.length} modules`
+    );
+  } else {
+    replacement = modifiedClaudeJs;
+  }
+
   const newBuffer = rebuildBunData(
     bunData,
     bunOffsets,
-    modifiedClaudeJs,
+    replacement,
     moduleStructSize
   );
 


### PR DESCRIPTION
## The problem

Claude Code 2.1.243 is built with Bun's code splitting enabled. The entrypoint module (`/$bunfs/root/cli`) is now a ~20 KB loader that `import`s ~1400 sibling `chunk-<hash>.js` modules, and essentially all of the application source lives in those chunks.

`extractClaudeJsFromNativeInstallation()` returns only the module matched by `isClaudeModule()`, so on such a binary it hands back the loader stub. Every patch that searches the returned text then fails to find its anchor:

| Claude Code | modules | what `readContent()` returns |
|---|---:|---|
| 2.1.241 | 15 | 28,252,504 chars — the whole application |
| 2.1.243 | 1391 | **19,949 chars** — the loader stub only |

The application source is still there (35.9 MB across 1376 JS modules), just no longer in one module.

## The change

Represent a code-split binary as all of its JS modules concatenated, each introduced by a boundary comment naming the module, so callers can keep treating the application as one string and patches stay plain search-and-replace. `repackNativeInstallation()` splits on the same boundary and routes each part back to the module it came from, which required letting `rebuildBunData()` take per-module replacements as well as a single entrypoint buffer.

Deliberately conservative:

- **A binary that is not code-split is unaffected.** It still yields exactly the entrypoint module's bytes, with no boundary markers, so nothing changes for Claude Code <= 2.1.241.
- **Only the entrypoint and `chunk-*.js` modules are collected.** Native `.node` modules must never make the round trip through UTF-8 — all five in 2.1.243 are corrupted by it — so they are excluded and pass through untouched.
- **Extraction fails loudly** if a module already contains the boundary marker, rather than risk a mis-split on the way back in.

## Verification

Against real Claude Code 2.1.243 on macOS arm64, patching the two context-limit constants:

- 3 of 1391 modules change contents; module count, order, names, `entryPointId`, flags and struct size are preserved
- every bytecode blob, sourcemap and flag byte is unchanged
- all 5 native `.node` modules are byte-identical
- the byte delta reconciles exactly with the char delta once UTF-8 multi-byte characters are accounted for
- the repacked binary runs, and the patched value is honoured at runtime (unset -> 200000, `1000000` -> 1000000, `777777` -> 777777)

Regression checks on 2.1.241 (non-code-split): `readContent()` returns the identical 28,252,504 chars with zero boundary markers, and a read/write round trip with no edits changes **zero** modules.

Worth noting for anyone patching these binaries: every module in 2.1.243 carries bytecode, but Bun validates its bytecode cache against the module source, so patching `contents` correctly invalidates it — confirmed by injecting a `console.error` and observing it fire.

7 new unit tests cover `isChunkModule` and the payload split/round-trip, including the malformed-boundary failure. Full suite: 530 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for code-split Bun installations, including entrypoint and chunk modules.
  * Improved extraction and repackaging of multi-module application source content.
  * Preserved individual module contents during native installation updates.

* **Bug Fixes**
  * Improved compatibility with newer Bun-based application builds.
  * Added validation for malformed module boundaries and payloads.
  * Prevented invalid, missing, duplicate, or unrecognized modules from being repackaged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->