### PR TITLE
Fix parse gate rejecting ESM native bundles (CC 2.1.245+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replace the existing `.bun` payload for ELF binaries instead of appending a new one (#952) - @signadou
 - Preserve prompt identity across formatting-only interpolation source changes and correct the Claude Code 2.1.235 prompt archive (#958) - @mike1858
+- Fix the parse gate rejecting ESM native bundles on Claude Code 2.1.245+ (#978) - @aegntic
 
 ## [v4.3.3](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.3) - 2026-08-13
 

--- a/src/patches/parseGate.test.ts
+++ b/src/patches/parseGate.test.ts
@@ -70,6 +70,37 @@ describe('assertPatchedBundleParses', () => {
     expect(() => assertPatchedBundleParses(keywordsInStrings)).not.toThrow();
   });
 
+  it('does not throw on a valid ESM multi-chunk entry bundle', () => {
+    // Newer CC native builds (observed on 2.1.245) extract an ESM entry chunk
+    // that begins with cross-chunk import statements. Under the CommonJS goal
+    // such a bundle always fails, so the gate must retry under the ESM goal
+    // before declaring it broken.
+    const esm =
+      'import{x}from"/$bunfs/root/chunk-abc123.js";\n' +
+      'if(x)console.log(x);\n';
+    expect(() => assertPatchedBundleParses(esm)).not.toThrow();
+  });
+
+  it('throws on a broken ESM bundle with the real break, not the module-goal diagnostic', () => {
+    // When the bundle is ESM and genuinely broken, the CommonJS failure is the
+    // goal mismatch at the healthy import statement; the thrown message must
+    // carry the ESM-goal diagnostic that points at the actual break.
+    const brokenEsm =
+      'import{x}from"/$bunfs/root/chunk-abc123.js";\n' + 'let b=;\n';
+    let caught: unknown;
+    try {
+      assertPatchedBundleParses(brokenEsm);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(PatchedBundleParseError);
+    const message = (caught as Error).message;
+    expect(message).toContain('SyntaxError');
+    expect(message).not.toContain(
+      'Cannot use import statement outside a module'
+    );
+  });
+
   it('surfaces a bounded SyntaxError even when the break is on a very long line', () => {
     // Prompt-injection sites live on long minified lines. node --check writes
     // its diagnostic to stderr then exits; a piped stderr truncates before the

--- a/src/patches/parseGate.test.ts
+++ b/src/patches/parseGate.test.ts
@@ -101,6 +101,24 @@ describe('assertPatchedBundleParses', () => {
     );
   });
 
+  it('throws with the ESM break when top-level await precedes it', () => {
+    // An ESM chunk whose first offending construct under the CommonJS goal is
+    // a top-level `await` rather than an `import`. CommonJS parsing stops at
+    // the healthy await, so that diagnostic must also be recognized as a goal
+    // mismatch; otherwise the gate reports the await instead of the real break.
+    const brokenEsm = 'const x = await Promise.resolve(1);\n' + 'let b=;\n';
+    let caught: unknown;
+    try {
+      assertPatchedBundleParses(brokenEsm);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(PatchedBundleParseError);
+    const message = (caught as Error).message;
+    expect(message).toContain('Unexpected token');
+    expect(message).not.toContain('await is only valid in async function');
+  });
+
   it('surfaces a bounded SyntaxError even when the break is on a very long line', () => {
     // Prompt-injection sites live on long minified lines. node --check writes
     // its diagnostic to stderr then exits; a piped stderr truncates before the

--- a/src/patches/parseGate.ts
+++ b/src/patches/parseGate.ts
@@ -84,17 +84,37 @@ export const isParseFailureExit = (err: unknown): boolean =>
   err != null && typeof (err as { status?: unknown }).status === 'number';
 
 /**
+ * `node --check` diagnostics that indicate the wrong module goal rather than a
+ * broken bundle. Older CC native builds bundle as CommonJS (`@bun-cjs`), but
+ * newer multi-chunk builds (observed on 2.1.245) extract an ESM entry chunk
+ * that begins with cross-chunk `import` statements. Parsed as CommonJS, such a
+ * bundle always fails with one of these diagnostics — unpatched or not — so
+ * they signal "retry under the ESM goal", never "the bundle is broken".
+ */
+const ESM_GOAL_DIAGNOSTICS = [
+  'Cannot use import statement outside a module',
+  "Unexpected token 'export'",
+  "Cannot use 'import.meta' outside a module",
+] as const;
+
+/**
  * Parses the fully-patched bundle with `node --check` and throws
- * PatchedBundleParseError if it does not parse. The bundle is CommonJS
- * (`@bun-cjs`), so the temp file uses a `.cjs` extension to pin CommonJS parsing
- * regardless of any ambient package.json "type". A real parser is used rather
- * than `new Function` / `vm.compileFunction`, which impose a bare function-body
- * context that diverges from module parsing. `node --check` writes its
- * diagnostic to stderr and then exits, which truncates a piped stderr on long
- * lines, so stderr is captured to a file. The check is bounded by a timeout.
- * Only a genuine non-zero exit is treated as a parse failure; a timeout, signal,
- * spawn failure, or an unwritable temp file warns and skips the check, so an
- * operational problem never blocks an otherwise-valid apply.
+ * PatchedBundleParseError if it does not parse. The bundle may be CommonJS
+ * (older `@bun-cjs` native builds) or ESM (newer multi-chunk builds), so the
+ * temp file uses an explicit extension to pin the module goal regardless of any
+ * ambient package.json "type": the check runs under CommonJS first and, only
+ * when that fails to parse, retries under the ESM goal. A bundle that parses
+ * under either goal passes; only failing both is a parse failure, and the
+ * reported diagnostic comes from the goal the bundle actually targets (a
+ * CommonJS goal-mismatch message would point at a healthy `import` statement).
+ * A real parser is used rather than `new Function` / `vm.compileFunction`,
+ * which impose a bare function-body context that diverges from module parsing.
+ * `node --check` writes its diagnostic to stderr and then exits, which
+ * truncates a piped stderr on long lines, so stderr is captured to a file. The
+ * check is bounded by a timeout. Only a genuine non-zero exit is treated as a
+ * parse failure; a timeout, signal, spawn failure, or an unwritable temp file
+ * warns and skips the check, so an operational problem never blocks an
+ * otherwise-valid apply.
  */
 export const assertPatchedBundleParses = (content: string): void => {
   let dir: string;
@@ -109,66 +129,83 @@ export const assertPatchedBundleParses = (content: string): void => {
     return;
   }
 
-  const tmpFile = path.join(dir, 'bundle.cjs');
-  const errFile = path.join(dir, 'stderr.txt');
   try {
-    try {
-      fsSync.writeFileSync(tmpFile, content, 'utf8');
-    } catch (err) {
-      console.warn(
-        chalk.yellow(
-          `Warning: could not write the patched bundle for verification (${String(err)}); skipping the parse check.`
-        )
-      );
-      return;
-    }
-
-    let errFd: number;
-    try {
-      errFd = fsSync.openSync(errFile, 'w');
-    } catch (err) {
-      console.warn(
-        chalk.yellow(
-          `Warning: could not open a temp file to verify the patched bundle (${String(err)}); skipping the parse check.`
-        )
-      );
-      return;
-    }
-    let parseFailed = false;
-    let operationalFailure: string | null = null;
-    try {
-      execFileSync(process.execPath, ['--check', tmpFile], {
-        stdio: ['ignore', 'ignore', errFd],
-        timeout: PARSE_CHECK_TIMEOUT_MS,
-      });
-    } catch (err) {
-      if (isParseFailureExit(err)) {
-        parseFailed = true;
-      } else {
-        operationalFailure = String(err);
+    const check = (ext: 'cjs' | 'mjs') => {
+      const tmpFile = path.join(dir, `bundle.${ext}`);
+      const errFile = path.join(dir, `stderr-${ext}.txt`);
+      let errFd: number;
+      try {
+        fsSync.writeFileSync(tmpFile, content, 'utf8');
+        errFd = fsSync.openSync(errFile, 'w');
+      } catch (err) {
+        return {
+          tmpFile,
+          parseFailed: false,
+          operationalFailure: String(err),
+          stderr: '',
+        };
       }
-    } finally {
-      fsSync.closeSync(errFd);
-    }
-
-    if (operationalFailure !== null) {
-      console.warn(
-        chalk.yellow(
-          `Warning: the parse check could not run to completion (${operationalFailure}); skipping it.`
-        )
-      );
-      return;
-    }
-
-    if (parseFailed) {
+      let parseFailed = false;
+      let operationalFailure: string | null = null;
+      try {
+        execFileSync(process.execPath, ['--check', tmpFile], {
+          stdio: ['ignore', 'ignore', errFd],
+          timeout: PARSE_CHECK_TIMEOUT_MS,
+        });
+      } catch (err) {
+        if (isParseFailureExit(err)) {
+          parseFailed = true;
+        } else {
+          operationalFailure = String(err);
+        }
+      } finally {
+        fsSync.closeSync(errFd);
+      }
       let stderr = '';
       try {
         stderr = fsSync.readFileSync(errFile, 'utf8');
       } catch {
         // The sanitizer synthesizes a message when stderr is unavailable.
       }
-      throw new PatchedBundleParseError(sanitizeParseError(stderr, tmpFile));
+      return { tmpFile, parseFailed, operationalFailure, stderr };
+    };
+
+    const warnOperational = (description: string): void => {
+      console.warn(
+        chalk.yellow(
+          `Warning: the parse check could not run to completion (${description}); skipping it.`
+        )
+      );
+    };
+
+    const asCjs = check('cjs');
+    if (asCjs.operationalFailure !== null) {
+      warnOperational(asCjs.operationalFailure);
+      return;
     }
+    if (!asCjs.parseFailed) {
+      return;
+    }
+
+    // CommonJS parsing failed. If the bundle targets the ESM goal, that is the
+    // expected outcome rather than a patching regression, so retry under the
+    // ESM goal before declaring the bundle broken.
+    const asMjs = check('mjs');
+    if (asMjs.operationalFailure !== null) {
+      warnOperational(asMjs.operationalFailure);
+      return;
+    }
+    if (!asMjs.parseFailed) {
+      return;
+    }
+
+    const goalMismatch = ESM_GOAL_DIAGNOSTICS.some(diagnostic =>
+      asCjs.stderr.includes(diagnostic)
+    );
+    const failure = goalMismatch ? asMjs : asCjs;
+    throw new PatchedBundleParseError(
+      sanitizeParseError(failure.stderr, failure.tmpFile)
+    );
   } finally {
     try {
       fsSync.rmSync(dir, { recursive: true, force: true });

--- a/src/patches/parseGate.ts
+++ b/src/patches/parseGate.ts
@@ -90,12 +90,27 @@ export const isParseFailureExit = (err: unknown): boolean =>
  * that begins with cross-chunk `import` statements. Parsed as CommonJS, such a
  * bundle always fails with one of these diagnostics — unpatched or not — so
  * they signal "retry under the ESM goal", never "the bundle is broken".
+ *
+ * The top-level `await` entry is a prefix match so it covers both the current
+ * wording ("… async functions and the top level bodies of modules") and the
+ * older, shorter one. It matters because CommonJS parsing reports the first
+ * offending construct: an ESM chunk whose top-level `await` precedes a genuine
+ * syntax error would otherwise be diagnosed at the healthy `await`.
  */
 const ESM_GOAL_DIAGNOSTICS = [
   'Cannot use import statement outside a module',
   "Unexpected token 'export'",
   "Cannot use 'import.meta' outside a module",
+  'await is only valid in async function',
 ] as const;
+
+/** Outcome of one `node --check` run under a single module goal. */
+interface ParseCheckResult {
+  tmpFile: string;
+  parseFailed: boolean;
+  operationalFailure: string | null;
+  stderr: string;
+}
 
 /**
  * Parses the fully-patched bundle with `node --check` and throws
@@ -130,7 +145,7 @@ export const assertPatchedBundleParses = (content: string): void => {
   }
 
   try {
-    const check = (ext: 'cjs' | 'mjs') => {
+    const check = (ext: 'cjs' | 'mjs'): ParseCheckResult => {
       const tmpFile = path.join(dir, `bundle.${ext}`);
       const errFile = path.join(dir, `stderr-${ext}.txt`);
       let errFd: number;


### PR DESCRIPTION
## Summary

Newer Claude Code native builds (observed on **2.1.245**, Linux x64 native install) extract an **ESM entry chunk** that begins with cross-chunk imports:

```js
import{G5c as ct}from"/$bunfs/root/chunk-fngvchpn.js";
import{H5c as ot,I5c as rt}from"/$bunfs/root/chunk-16xens49.js";
```

The parse gate was written for the CommonJS `@bun-cjs` bundle and pins the temp file to `.cjs`. `node --check` therefore parses the ESM chunk as CommonJS and **always** fails with:

```
SyntaxError: Cannot use import statement outside a module
```

— for the unpatched bundle, so **every apply on such installs rolls back** with a `PatchedBundleParseError` before any patch result is reported. Confirmed on the pristine entry chunk (no patches applied):

```
$ tweakcc unpack /tmp/cc-bundle.js            # 19,952 chars, untouched
$ cp cc-bundle.js b.cjs && node --check b.cjs  # ✗ SyntaxError: Cannot use import statement…
$ cp cc-bundle.js b.mjs && node --check b.mjs  # ✓ parses
```

## Changes

- `assertPatchedBundleParses` now runs the CommonJS check first (unchanged fast path for `@bun-cjs` builds) and, only when that fails to parse, retries the same content under the ESM goal (`bundle.mjs`). A bundle that parses under either goal passes.
- When both goals fail, the thrown diagnostic comes from the goal the bundle actually targets (detected via the three `node` module-goal diagnostics), so a broken ESM bundle reports its real break instead of the goal mismatch at a healthy `import` statement.
- The per-goal check is factored into a local `check(ext)` helper returning `{ tmpFile, parseFailed, operationalFailure, stderr }`; warn-and-skip semantics for operational failures are preserved.
- No keyword sniffing of bundle content: keywords inside string/template literals (see the existing test) cannot cause a false retry, because retry is only triggered by a real CommonJS parse failure.

## Testing

- [x] Tests added/updated — two regression tests in `src/patches/parseGate.test.ts`: a valid ESM multi-chunk bundle must pass, and a broken ESM bundle must throw with the ESM diagnostic (not the module-goal one)
- [x] Manual testing completed — patched `dist/config-*.mjs` (`bundle.cjs` → `.mjs` retry) in the installed 4.3.3 and re-ran `tweakcc --apply -y` against CC 2.1.245: the parse gate now passes and apply proceeds to report real per-patch results
- [x] All existing tests pass — `pnpm test`: 45 files, **525 passed**, 5 skipped; `pnpm lint` (tsc + eslint) and `prettier --check` clean

## Related Issues

Same install/version family as #942 and #957 (pattern drift on 2.1.2xx), but distinct: those patches fail to *locate*; this one blocks *all* applies at the parse gate regardless of patch matching. Note the parse gate fix exposes a separate repack problem on 2.1.245 — will file separately with evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of patched JavaScript bundles using ESM imports and top-level `await`.
  * Valid ESM bundles now pass validation, including multi-chunk bundles.
  * Reports the underlying ESM syntax error instead of a misleading CommonJS diagnostic.
  * Avoids duplicate warnings when bundle validation cannot be completed.

* **Tests**
  * Added coverage for valid multi-chunk ESM bundles and invalid ESM syntax scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->