### PR TITLE
Add targeted replacement of native Bun modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace the existing `.bun` payload for ELF binaries instead of appending a new one (#952) - @signadou
 - Preserve prompt identity across formatting-only interpolation source changes and correct the Claude Code 2.1.235 prompt archive (#958) - @mike1858
 
+- Add identity-validated native JavaScript module replacement for split Bun bundles (#408) - @mike1858
+
 ## [v4.3.3](https://github.com/Piebald-AI/tweakcc/releases/tag/v4.3.3) - 2026-08-13
 
 - Clarify that `--apply --patches` restores from backup before applying the listed patch IDs (#699)

--- a/src/nativeInstallation.ts
+++ b/src/nativeInstallation.ts
@@ -3,6 +3,8 @@
  */
 
 import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+import { isUtf8 } from 'node:buffer';
 import { execSync } from 'node:child_process';
 import LIEF from 'node-lief';
 import { isDebug, debug } from './utils';
@@ -197,6 +199,46 @@ interface BunData {
   moduleStructSize: number;
 }
 
+/** An embedded module's stable table identity and unmodified source bytes. */
+export interface ExtractedBunModule {
+  index: number;
+  name: string;
+  contents: Buffer;
+  loader: number;
+  moduleFormat: number;
+  encoding: number;
+  side: number;
+  isEntrypoint: boolean;
+  isJavaScript: boolean;
+}
+
+/** Read-only module view; retain the source digest when preparing replacements. */
+export interface ExtractedBunCorpus {
+  sourceSha256: string;
+  moduleStructSize: 36 | 52;
+  entryPointId: number;
+  modules: ExtractedBunModule[];
+}
+
+/**
+ * One explicit source replacement. Both index and full embedded name must match;
+ * basenames are not unique in a compiled graph. Contents must be UTF-8 JavaScript.
+ */
+export interface BunModuleReplacement {
+  index: number;
+  name: string;
+  contents: Buffer;
+}
+
+/**
+ * Replacements prepared against one exact executable. The digest rejects stale
+ * work if the installation updated between extraction and repacking.
+ */
+export interface BunModuleReplacements {
+  sourceSha256: string;
+  modules: readonly BunModuleReplacement[];
+}
+
 /**
  * Read a StringPointer slice from given buffer.
  */
@@ -204,10 +246,23 @@ function getStringPointerContent(
   buffer: Buffer,
   stringPointer: StringPointer
 ): Buffer {
-  return buffer.subarray(
-    stringPointer.offset,
-    stringPointer.offset + stringPointer.length
-  );
+  const { offset, length } = stringPointer;
+  const end = offset + length;
+  // Buffer.subarray silently truncates invalid pointers. A repacker must reject
+  // corruption rather than rebuild a seemingly valid graph from truncated data.
+  if (
+    !Number.isSafeInteger(offset) ||
+    !Number.isSafeInteger(length) ||
+    offset < 0 ||
+    length < 0 ||
+    end < offset ||
+    end > buffer.length
+  ) {
+    throw new Error(
+      `Bun string pointer is out of bounds: offset=${offset}, length=${length}, buffer=${buffer.length}`
+    );
+  }
+  return buffer.subarray(offset, end);
 }
 
 function parseStringPointer(buffer: Buffer, offset: number): StringPointer {
@@ -236,28 +291,44 @@ function isClaudeModule(moduleName: string): boolean {
 }
 
 /**
- * Detects the module struct size from the modules list byte length.
- * Returns SIZEOF_MODULE_NEW (52) or SIZEOF_MODULE_OLD (36).
+ * Detects 36- or 52-byte records from a bounded module table. Throws if neither
+ * layout is structurally valid or both are valid; never guesses for a writer.
  */
-function detectModuleStructSize(modulesListLength: number): number {
-  const fitsNew = modulesListLength % SIZEOF_MODULE_NEW === 0;
-  const fitsOld = modulesListLength % SIZEOF_MODULE_OLD === 0;
-
-  if (fitsNew && !fitsOld) return SIZEOF_MODULE_NEW;
-  if (fitsOld && !fitsNew) return SIZEOF_MODULE_OLD;
-  if (fitsNew && fitsOld) {
-    // Ambiguous — prefer new format (more likely with recent Bun versions)
-    debug(
-      `detectModuleStructSize: Ambiguous module list length ${modulesListLength}, assuming new format`
+export function detectModuleStructSize(
+  bunData: Buffer,
+  modulesPtr: StringPointer
+): 36 | 52 {
+  const records = getStringPointerContent(bunData, modulesPtr);
+  // 468 bytes fits both widths. Validate names and every payload pointer so a
+  // legacy table cannot be mistaken for the newer format merely by its length.
+  const candidates = [SIZEOF_MODULE_NEW, SIZEOF_MODULE_OLD].filter(size => {
+    if (!records.length || records.length % size !== 0) return false;
+    try {
+      for (let offset = 0; offset < records.length; offset += size) {
+        const module = parseCompiledModuleGraphFile(records, offset, size);
+        const name = getStringPointerContent(bunData, module.name);
+        if (!name.length || name.includes(0) || !isUtf8(name)) return false;
+        for (const pointer of [
+          module.contents,
+          module.sourcemap,
+          module.bytecode,
+          module.moduleInfo,
+          module.bytecodeOriginPath,
+        ]) {
+          getStringPointerContent(bunData, pointer);
+        }
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Invalid or ambiguous Bun module record layout: ${records.length} bytes, ${candidates.length} valid layouts`
     );
-    return SIZEOF_MODULE_NEW;
   }
-
-  // Neither fits cleanly — try new format as default
-  debug(
-    `detectModuleStructSize: Module list length ${modulesListLength} doesn't cleanly divide by either struct size, assuming new format`
-  );
-  return SIZEOF_MODULE_NEW;
+  return candidates[0] as 36 | 52;
 }
 
 /**
@@ -400,7 +471,10 @@ function parseBunDataBlob(bunDataContent: Buffer): {
     offsetsStart + SIZEOF_OFFSETS
   );
   const bunOffsets = parseOffsets(offsetsBytes);
-  const moduleStructSize = detectModuleStructSize(bunOffsets.modulesPtr.length);
+  const moduleStructSize = detectModuleStructSize(
+    bunDataContent,
+    bunOffsets.modulesPtr
+  );
 
   return {
     bunOffsets,
@@ -622,7 +696,10 @@ function extractBunDataFromELFOverlay(elfBinary: LIEF.ELF.Binary): BunData {
 
   // Reconstruct full blob [data][offsets][trailer] to match other formats
   const bunDataBlob = Buffer.concat([dataRegion, offsetsBytes, trailerBytes]);
-  const moduleStructSize = detectModuleStructSize(bunOffsets.modulesPtr.length);
+  const moduleStructSize = detectModuleStructSize(
+    bunDataBlob,
+    bunOffsets.modulesPtr
+  );
 
   return {
     bunOffsets,
@@ -696,6 +773,61 @@ function getBunData(
   }
 }
 
+/** Hashes the exact input executable, not just the source module being edited. */
+function binaryDigest(binaryPath: string): string {
+  return createHash('sha256').update(fs.readFileSync(binaryPath)).digest('hex');
+}
+
+/**
+ * Extracts every embedded module without decoding binary payloads as text.
+ * Returns null on unsupported/corrupt input or missing modules. The path must
+ * already resolve any Nix wrapper. No files are modified.
+ */
+export function extractClaudeJsModulesFromNativeInstallation(
+  nativeInstallationPath: string
+): ExtractedBunCorpus | null {
+  try {
+    LIEF.logging.disable();
+    const sourceSha256 = binaryDigest(nativeInstallationPath);
+    const binary = LIEF.parse(nativeInstallationPath);
+    const { bunOffsets, bunData, moduleStructSize } = getBunData(binary);
+    const modules: ExtractedBunModule[] = [];
+    mapModules(bunData, bunOffsets, moduleStructSize, (module, name, index) => {
+      modules.push({
+        index,
+        name,
+        contents: getStringPointerContent(bunData, module.contents),
+        loader: module.loader,
+        moduleFormat: module.moduleFormat,
+        encoding: module.encoding,
+        side: module.side,
+        isEntrypoint: index === bunOffsets.entryPointId,
+        // Loader 5 assets can have .js or cli names while containing binary
+        // payloads. Names never override the loader in the module-aware API.
+        isJavaScript: module.loader === 1,
+      });
+      return undefined;
+    });
+    if (!modules.some(module => module.isEntrypoint)) {
+      throw new Error('Bun entrypoint is outside the module table');
+    }
+    // An auto-update during extraction must not pair one graph with another
+    // executable's identity. The digest accompanies subsequent write requests.
+    if (binaryDigest(nativeInstallationPath) !== sourceSha256) {
+      throw new Error('Native binary changed during extraction');
+    }
+    return {
+      sourceSha256,
+      moduleStructSize: moduleStructSize as 36 | 52,
+      entryPointId: bunOffsets.entryPointId,
+      modules,
+    };
+  } catch (error) {
+    debug('extractClaudeJsModulesFromNativeInstallation:', error);
+    return null;
+  }
+}
+
 /**
  * Extracts claude.js from a native installation binary.
  * Returns the contents as a Buffer, or null if not found.
@@ -761,6 +893,125 @@ export function extractClaudeJsFromNativeInstallation(
 
     return null;
   }
+}
+
+/**
+ * Replaces explicitly identified JavaScript sources in a normalized Bun blob.
+ * Returns the original buffer for byte-identical edits. Throws before allocating
+ * output for duplicate/missing targets, invalid UTF-8, or unsupported records.
+ *
+ * Existing payloads stay at their original offsets: bytecode contains aligned
+ * opaque data that cannot safely be relocated as ordinary strings. Replacement
+ * source is appended before the offsets/trailer; only selected records change.
+ */
+export function replaceBunModuleSources(
+  bunData: Buffer,
+  replacements: readonly BunModuleReplacement[]
+): Buffer {
+  const { bunOffsets, moduleStructSize } = parseBunDataBlob(bunData);
+  const targets = new Map<number, BunModuleReplacement>();
+  for (const replacement of replacements) {
+    if (!Number.isSafeInteger(replacement.index) || replacement.index < 0) {
+      throw new Error('Invalid Bun replacement index');
+    }
+    if (targets.has(replacement.index)) {
+      throw new Error(`Duplicate Bun replacement index: ${replacement.index}`);
+    }
+    if (!isUtf8(replacement.contents) || replacement.contents.includes(0)) {
+      throw new Error(
+        'Bun replacement must contain UTF-8 JavaScript without NUL bytes'
+      );
+    }
+    targets.set(replacement.index, replacement);
+  }
+  const changed: BunModuleReplacement[] = [];
+  mapModules(bunData, bunOffsets, moduleStructSize, (module, name, index) => {
+    const replacement = targets.get(index);
+    if (!replacement) return undefined;
+    if (replacement.name !== name) {
+      throw new Error(`Bun replacement name mismatch at index ${index}`);
+    }
+    if (module.loader !== 1) {
+      throw new Error(`Cannot replace non-JavaScript Bun module: ${name}`);
+    }
+    if (![0, 1, 2].includes(module.encoding)) {
+      throw new Error(`Unsupported Bun source encoding: ${module.encoding}`);
+    }
+    if (
+      !getStringPointerContent(bunData, module.contents).equals(
+        replacement.contents
+      )
+    ) {
+      changed.push(replacement);
+    }
+    targets.delete(index);
+    return undefined;
+  });
+  if (targets.size)
+    throw new Error('Bun replacement index is outside the module table');
+  if (!changed.length) return bunData;
+
+  const offsetsStart = bunData.length - SIZEOF_OFFSETS - BUN_TRAILER.length;
+  const addedLength = changed.reduce(
+    (sum, item) => sum + item.contents.length + 1,
+    0
+  );
+  const newOffsetsStart = offsetsStart + addedLength;
+  // Every serialized pointer is u32, even though byteCount is u64. Reject an
+  // oversized result instead of wrapping a pointer into another module's data.
+  if (newOffsetsStart > 0xffffffff)
+    throw new Error('Bun replacement exceeds u32 offsets');
+  if (
+    bunOffsets.modulesPtr.offset + bunOffsets.modulesPtr.length >
+    offsetsStart
+  ) {
+    throw new Error('Bun module table overlaps its trailer');
+  }
+  const output = Buffer.alloc(bunData.length + addedLength);
+  bunData.copy(output, 0, 0, offsetsStart);
+  bunData.copy(output, newOffsetsStart, offsetsStart);
+  let cursor = offsetsStart;
+  for (const replacement of changed) {
+    const record =
+      bunOffsets.modulesPtr.offset + replacement.index * moduleStructSize;
+    replacement.contents.copy(output, cursor);
+    output.writeUInt32LE(cursor, record + 8);
+    output.writeUInt32LE(replacement.contents.length, record + 12);
+    cursor += replacement.contents.length + 1;
+
+    // Bun's ModuleLoader loads moduleInfo independently of bytecode; JSC can
+    // skip source analysis using stale imports/exports even after a cache miss.
+    // Invalidate both caches and the origin override, plus the obsolete map.
+    // Source: oven-sh/bun@0d9b296, ModuleLoader.zig:1189 and
+    // src/jsc/bindings/ZigSourceProvider.cpp:73. Unchanged modules retain caches.
+    output.fill(0, record + 16, record + (moduleStructSize === 52 ? 48 : 32));
+    // Bun 1.4.1 reuses the formerly unused tag 2 for UTF-16. Tag 0 takes
+    // cloneUTF8 in both old and new runtimes, so replacement bytes have an
+    // unambiguous interpretation without guessing the compiler version.
+    // oven-sh/bun@4661e494, StandaloneModuleGraph.rs:411,703.
+    output.writeUInt8(0, record + moduleStructSize - 4);
+    if (bunOffsets.flags & (1 << 5)) {
+      // Modern graphs store cached source hashes immediately after the module
+      // table. Zero means recompute: keeping the old hash can produce stale
+      // cache keys even after this module's own bytecode has been removed.
+      const hash =
+        bunOffsets.modulesPtr.offset +
+        bunOffsets.modulesPtr.length +
+        replacement.index * 4;
+      if (hash + 4 > offsetsStart)
+        throw new Error('Bun source hash table is out of bounds');
+      output.writeUInt32LE(0, hash);
+    }
+  }
+  output.writeBigUInt64LE(BigInt(newOffsetsStart), newOffsetsStart);
+  // Appending source breaks the compiler's contiguous-source-run invariant.
+  // Clear only this flag; retaining it could let Bun discard pages containing
+  // unrelated caches between the original source run and the appended source.
+  output.writeUInt32LE(
+    (bunOffsets.flags & ~(1 << 4)) >>> 0,
+    newOffsetsStart + 28
+  );
+  return output;
 }
 
 function rebuildBunData(
@@ -1502,7 +1753,8 @@ function repackELFSection(
   binPath: string,
   newBunBuffer: Buffer,
   outputPath: string,
-  sectionHeaderSize: number
+  sectionHeaderSize: number,
+  sourceSnapshot?: Buffer
 ): void {
   try {
     const bunSection = elfBinary.getSection('.bun');
@@ -1531,7 +1783,9 @@ function repackELFSection(
     // only file-only metadata after it. Replace that allocation in place and
     // shift the metadata tail, avoiding an orphaned previous module graph.
     const compactedFile = replaceTailBunSection({
-      file: fs.readFileSync(binPath),
+      // Module-aware writes use the verified input snapshot, not a path that
+      // an updater could have replaced since parsing the graph.
+      file: sourceSnapshot ?? fs.readFileSync(binPath),
       bunFileOffset: bunSection.fileOffset,
       bunVirtualAddress: bunSection.virtualAddress,
       bunSize: bunSection.size,
@@ -1713,6 +1967,64 @@ export function repackNativeInstallation(
     moduleStructSize
   );
 
+  writeRepackedBunData(
+    binary,
+    binPath,
+    newBuffer,
+    outputPath,
+    sectionHeaderSize
+  );
+}
+
+/**
+ * Writes module replacements prepared from an extracted corpus. The input path
+ * must be the resolved native executable. Rejects stale digests and invalid
+ * targets before writing; outputPath may be a separate disposable executable.
+ * Source is never executed here. Existing platform writers handle permissions
+ * and atomic replacement. Throws on parse, validation, or write failure.
+ *
+ * Digest checks reject observed updates, but are not an installation lock.
+ * Callers doing in-place writes must serialize them with other installers;
+ * use a separate output path when the input can update concurrently.
+ */
+export function repackNativeInstallationModules(
+  binPath: string,
+  replacements: BunModuleReplacements,
+  outputPath: string
+): void {
+  const sourceSnapshot = fs.readFileSync(binPath);
+  if (
+    createHash('sha256').update(sourceSnapshot).digest('hex') !==
+    replacements.sourceSha256
+  ) {
+    throw new Error('Native binary changed since module extraction');
+  }
+  LIEF.logging.disable();
+  const binary = LIEF.parse(binPath);
+  const { bunData, sectionHeaderSize } = getBunData(binary);
+  const newBuffer = replaceBunModuleSources(bunData, replacements.modules);
+  if (binaryDigest(binPath) !== replacements.sourceSha256) {
+    throw new Error('Native binary changed during module repacking');
+  }
+  writeRepackedBunData(
+    binary,
+    binPath,
+    newBuffer,
+    outputPath,
+    sectionHeaderSize,
+    sourceSnapshot
+  );
+}
+
+/** Dispatches a validated Bun blob to the existing platform-specific writer. */
+function writeRepackedBunData(
+  binary: ReturnType<typeof LIEF.parse>,
+  binPath: string,
+  newBuffer: Buffer,
+  outputPath: string,
+  sectionHeaderSize: number | undefined,
+  sourceSnapshot?: Buffer
+): void {
   switch (binary.format) {
     case 'MachO':
       if (!sectionHeaderSize) {
@@ -1746,7 +2058,8 @@ export function repackNativeInstallation(
           binPath,
           newBuffer,
           outputPath,
-          sectionHeaderSize
+          sectionHeaderSize,
+          sourceSnapshot
         );
       } else {
         // Legacy overlay format

--- a/src/nativeInstallationLoader.ts
+++ b/src/nativeInstallationLoader.ts
@@ -8,6 +8,8 @@
 
 import type {
   extractClaudeJsFromNativeInstallation as ExtractFn,
+  extractClaudeJsModulesFromNativeInstallation as ExtractModulesFn,
+  repackNativeInstallationModules as RepackModulesFn,
   repackNativeInstallation as RepackFn,
   resolveNixBinaryWrapper as ResolveNixFn,
 } from './nativeInstallation';
@@ -16,6 +18,8 @@ import { debug } from './utils';
 
 interface NativeInstallationModule {
   extractClaudeJsFromNativeInstallation: typeof ExtractFn;
+  extractClaudeJsModulesFromNativeInstallation: typeof ExtractModulesFn;
+  repackNativeInstallationModules: typeof RepackModulesFn;
   repackNativeInstallation: typeof RepackFn;
   resolveNixBinaryWrapper: typeof ResolveNixFn;
 }
@@ -61,6 +65,33 @@ export async function extractClaudeJsFromNativeInstallation(
     return null;
   }
   return mod.extractClaudeJsFromNativeInstallation(nativeInstallationPath);
+}
+
+/**
+ * Reads the complete embedded corpus. The path must resolve any Nix wrapper.
+ * Returns null when native support is unavailable or the graph cannot be read.
+ */
+export async function extractClaudeJsModulesFromNativeInstallation(
+  nativeInstallationPath: string
+): Promise<ReturnType<typeof ExtractModulesFn>> {
+  const mod = await tryLoadNativeInstallationModule();
+  if (!mod) return null;
+  return mod.extractClaudeJsModulesFromNativeInstallation(
+    nativeInstallationPath
+  );
+}
+
+/**
+ * Writes identity-validated source replacements without loading native support
+ * until needed. Throws if support is unavailable or validation/writing fails.
+ * Callers must use the digest from the original corpus and resolved binary path.
+ */
+export async function repackNativeInstallationModules(
+  ...args: Parameters<typeof RepackModulesFn>
+): Promise<void> {
+  const mod = await tryLoadNativeInstallationModule();
+  if (!mod) throw new Error('Native module repacking requires node-lief');
+  mod.repackNativeInstallationModules(...args);
 }
 
 /**

--- a/src/nativeModuleReplacement.test.ts
+++ b/src/nativeModuleReplacement.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+
+const FOOTER_SIZE = 32 + Buffer.byteLength('\n---- Bun! ----\n');
+
+import {
+  detectModuleStructSize,
+  replaceBunModuleSources,
+} from './nativeInstallation';
+
+/** Builds a complete normalized graph with distinct payloads for every pointer. */
+function makeGraph(width: 36 | 52, count = 3, modernFlags = false) {
+  const tableLength = width * count;
+  const payloads: Buffer[] = [];
+  const records = Buffer.alloc(tableLength);
+  const hashes = modernFlags ? Buffer.alloc(count * 4, 0x17) : Buffer.alloc(0);
+  let cursor = tableLength + hashes.length;
+  const names: string[] = [];
+  for (let index = 0; index < count; index++) {
+    const name =
+      index === 0 ? '/$bunfs/root/cli' : `/$bunfs/root/chunk-${index}.js`;
+    names.push(name);
+    const strings = [
+      name,
+      `export const value = ${index};`,
+      `map-${index}`,
+      `bytecode-${index}`,
+      `module-info-${index}`,
+      `origin-${index}`,
+    ].slice(0, width === 52 ? 6 : 4);
+    strings.forEach((value, pointer) => {
+      const bytes = Buffer.from(value);
+      records.writeUInt32LE(cursor, index * width + pointer * 8);
+      records.writeUInt32LE(bytes.length, index * width + pointer * 8 + 4);
+      payloads.push(bytes, Buffer.alloc(1));
+      cursor += bytes.length + 1;
+    });
+    records.set([1, 1, 2, 0], index * width + width - 4);
+  }
+  const offsets = Buffer.alloc(32);
+  offsets.writeBigUInt64LE(BigInt(cursor), 0);
+  offsets.writeUInt32LE(0, 8);
+  offsets.writeUInt32LE(tableLength, 12);
+  offsets.writeUInt32LE(0, 16);
+  offsets.writeUInt32LE(modernFlags ? 5 | (1 << 4) | (1 << 5) : 5, 28);
+  return {
+    data: Buffer.concat([
+      records,
+      hashes,
+      ...payloads,
+      offsets,
+      Buffer.from('\n---- Bun! ----\n'),
+    ]),
+    names,
+    tableLength,
+  };
+}
+
+/** Reads the source pointer directly so expected output does not use the writer. */
+function sourceAt(data: Buffer, width: number, index: number): Buffer {
+  const pointer = index * width + 8;
+  const offset = data.readUInt32LE(pointer);
+  return data.subarray(offset, offset + data.readUInt32LE(pointer + 4));
+}
+
+describe('Bun module record detection', () => {
+  it.each([
+    [36, 13],
+    [52, 9],
+    [36, 1],
+    [52, 1],
+  ] as const)(
+    'recognizes %i-byte records with %i modules, including ambiguous lengths',
+    (width, count) => {
+      const graph = makeGraph(width, count);
+      expect(
+        detectModuleStructSize(graph.data, {
+          offset: 0,
+          length: graph.tableLength,
+        })
+      ).toBe(width);
+    }
+  );
+
+  it('rejects invalid table lengths and out-of-bounds pointers', () => {
+    const graph = makeGraph(52);
+    expect(() =>
+      detectModuleStructSize(graph.data, { offset: 0, length: 5 })
+    ).toThrow();
+    expect(() =>
+      detectModuleStructSize(graph.data, {
+        offset: graph.data.length,
+        length: 52,
+      })
+    ).toThrow();
+    graph.data.writeUInt32LE(0xffffffff, 8);
+    expect(() =>
+      detectModuleStructSize(graph.data, {
+        offset: 0,
+        length: graph.tableLength,
+      })
+    ).toThrow();
+  });
+});
+
+describe.each([36, 52] as const)(
+  'targeted source replacement (%i-byte records)',
+  width => {
+    it.each([
+      '',
+      'export const value = 9;',
+      'export const emoji = "🦆 café";\n'.repeat(50),
+    ])(
+      'replaces a non-entrypoint source, including empty, same-length and larger source',
+      value => {
+        const graph = makeGraph(width);
+        const original = Buffer.from(graph.data);
+        const output = replaceBunModuleSources(graph.data, [
+          { index: 1, name: graph.names[1], contents: Buffer.from(value) },
+        ]);
+        expect(sourceAt(output, width, 1).toString()).toBe(value);
+        expect(graph.data).toEqual(original);
+        // Unchanged records and all original payloads retain byte positions,
+        // preserving opaque bytecode alignment and its internal relative offsets.
+        expect(output.subarray(0, width)).toEqual(original.subarray(0, width));
+        expect(
+          output.subarray(width * 2, original.length - FOOTER_SIZE)
+        ).toEqual(original.subarray(width * 2, original.length - FOOTER_SIZE));
+        expect(output.subarray(width, width + 8)).toEqual(
+          original.subarray(width, width + 8)
+        );
+        expect(output.subarray(width + 16, width * 2 - 4)).toEqual(
+          Buffer.alloc(width - 20)
+        );
+        expect(output.subarray(width * 2 - 4, width * 2)).toEqual(
+          Buffer.from([0, 1, 2, 0])
+        );
+        const offsets = output.length - FOOTER_SIZE;
+        expect(output.readBigUInt64LE(offsets)).toBe(BigInt(offsets));
+        expect(output.subarray(offsets + 8)).toEqual(
+          original.subarray(original.length - FOOTER_SIZE + 8)
+        );
+      }
+    );
+
+    it('invalidates only changed source hashes and clears contiguous-source flags', () => {
+      const graph = makeGraph(width, 3, true);
+      const output = replaceBunModuleSources(graph.data, [
+        { index: 1, name: graph.names[1], contents: Buffer.from('export {};') },
+      ]);
+      expect(output.readUInt32LE(graph.tableLength)).toBe(0x17171717);
+      expect(output.readUInt32LE(graph.tableLength + 4)).toBe(0);
+      expect(output.readUInt32LE(graph.tableLength + 8)).toBe(0x17171717);
+      expect(output.readUInt32LE(output.length - FOOTER_SIZE + 28)).toBe(
+        5 | (1 << 5)
+      );
+    });
+
+    it('preserves every byte and cache on empty or byte-identical edits', () => {
+      const graph = makeGraph(width);
+      expect(replaceBunModuleSources(graph.data, [])).toBe(graph.data);
+      expect(
+        replaceBunModuleSources(graph.data, [
+          {
+            index: 1,
+            name: graph.names[1],
+            contents: sourceAt(graph.data, width, 1),
+          },
+        ])
+      ).toBe(graph.data);
+    });
+
+    it('replaces multiple modules without depending on replacement order', () => {
+      const graph = makeGraph(width);
+      const output = replaceBunModuleSources(graph.data, [
+        { index: 2, name: graph.names[2], contents: Buffer.from('export {};') },
+        {
+          index: 0,
+          name: graph.names[0],
+          contents: Buffer.from('console.log("new entry");'),
+        },
+      ]);
+      expect(sourceAt(output, width, 0).toString()).toBe(
+        'console.log("new entry");'
+      );
+      expect(sourceAt(output, width, 2).toString()).toBe('export {};');
+      expect(sourceAt(output, width, 1)).toEqual(
+        sourceAt(graph.data, width, 1)
+      );
+    });
+
+    it('rejects binary assets even when named like the Claude entrypoint', () => {
+      const graph = makeGraph(width);
+      graph.data[width - 3] = 5;
+      expect(() =>
+        replaceBunModuleSources(graph.data, [
+          {
+            index: 0,
+            name: graph.names[0],
+            contents: Buffer.from('export {};'),
+          },
+        ])
+      ).toThrow(/non-JavaScript/);
+    });
+
+    it('rejects invalid identities, duplicate targets, binary modules and encodings', () => {
+      const graph = makeGraph(width);
+      const replacement = {
+        index: 1,
+        name: graph.names[1],
+        contents: Buffer.from('export {};'),
+      };
+      expect(() =>
+        replaceBunModuleSources(graph.data, [{ ...replacement, index: -1 }])
+      ).toThrow();
+      expect(() =>
+        replaceBunModuleSources(graph.data, [{ ...replacement, index: 1.5 }])
+      ).toThrow();
+      expect(() =>
+        replaceBunModuleSources(graph.data, [{ ...replacement, index: 8 }])
+      ).toThrow();
+      expect(() =>
+        replaceBunModuleSources(graph.data, [
+          { ...replacement, name: 'chunk-1.js' },
+        ])
+      ).toThrow(/name mismatch/);
+      expect(() =>
+        replaceBunModuleSources(graph.data, [replacement, replacement])
+      ).toThrow(/Duplicate/);
+      expect(() =>
+        replaceBunModuleSources(graph.data, [
+          { ...replacement, contents: Buffer.from([0xff]) },
+        ])
+      ).toThrow(/UTF-8/);
+      expect(() =>
+        replaceBunModuleSources(graph.data, [
+          { ...replacement, contents: Buffer.from([0]) },
+        ])
+      ).toThrow(/NUL/);
+      graph.data[width * 2 - 3] = 5;
+      expect(() => replaceBunModuleSources(graph.data, [replacement])).toThrow(
+        /non-JavaScript/
+      );
+      graph.data[width * 2 - 3] = 1;
+      graph.data[width * 2 - 4] = 9;
+      expect(() => replaceBunModuleSources(graph.data, [replacement])).toThrow(
+        /encoding/
+      );
+    });
+  }
+);

--- a/src/nativeModuleRoundtrip.test.ts
+++ b/src/nativeModuleRoundtrip.test.ts
@@ -1,0 +1,154 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import {
+  extractClaudeJsModulesFromNativeInstallation as extract,
+  repackNativeInstallationModules as repack,
+} from './nativeInstallation';
+
+const hasBun = spawnSync('bun', ['--version'], { timeout: 5000 }).status === 0;
+
+// Bun is optional for development and CI. These tests compile only their own
+// source into a fresh temp directory; they never discover or alter installed CC.
+describe.skipIf(!hasBun)('compiled multi-module native round trip', () => {
+  let directory: string;
+  let input: string;
+
+  beforeAll(() => {
+    directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'tweakcc-native-modules-')
+    );
+    input = path.join(
+      directory,
+      process.platform === 'win32' ? 'original.exe' : 'original'
+    );
+    fs.writeFileSync(
+      path.join(directory, 'entry.js'),
+      'console.log((await import("./part.js")).value);'
+    );
+    fs.writeFileSync(
+      path.join(directory, 'part.js'),
+      'export const value = "original-value";'
+    );
+    const build = spawnSync(
+      'bun',
+      [
+        'build',
+        '--compile',
+        '--splitting',
+        '--bytecode',
+        '--format=esm',
+        '--no-compile-autoload-dotenv',
+        '--no-compile-autoload-bunfig',
+        '--outfile',
+        input,
+        path.join(directory, 'entry.js'),
+      ],
+      { encoding: 'utf8', timeout: 30000 }
+    );
+    expect(build.status, build.stderr).toBe(0);
+  }, 40000);
+
+  afterAll(() => {
+    // Only this test's exclusively created directory is eligible for cleanup.
+    if (directory) fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it('executes a changed chunk with new bindings, exports, await and Unicode', () => {
+    const before = extract(input);
+    expect(before).not.toBeNull();
+    const target = before!.modules.find(
+      module =>
+        module.isJavaScript &&
+        !module.isEntrypoint &&
+        module.contents.includes(Buffer.from('original-value'))
+    );
+    expect(target).toBeDefined();
+    const contents = Buffer.from(
+      'const text = await Promise.resolve("🦆 café"); export const value = text; export const extra = 42;'
+    );
+    const output = path.join(
+      directory,
+      process.platform === 'win32' ? 'patched.exe' : 'patched'
+    );
+    repack(
+      input,
+      {
+        sourceSha256: before!.sourceSha256,
+        modules: [{ index: target!.index, name: target!.name, contents }],
+      },
+      output
+    );
+    const after = extract(output)!;
+    expect(after.modules.length).toBe(before!.modules.length);
+    for (const module of before!.modules) {
+      const actual = after.modules[module.index];
+      expect(actual.name).toBe(module.name);
+      expect(actual.contents).toEqual(
+        module.index === target!.index ? contents : module.contents
+      );
+    }
+    expect(extract(input)!.sourceSha256).toBe(before!.sourceSha256);
+    const originalRun = spawnSync(input, [], {
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    const patchedRun = spawnSync(output, [], {
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    expect(originalRun.status, originalRun.stderr).toBe(0);
+    expect(originalRun.stdout.trim()).toBe('original-value');
+    expect(patchedRun.status, patchedRun.stderr).toBe(0);
+    expect(patchedRun.stdout.trim()).toBe('🦆 café');
+  }, 30000);
+
+  it.skipIf(process.platform !== 'linux')(
+    'uses the verified ELF snapshot if the input changes after the last check',
+    () => {
+      const mutableInput = path.join(directory, 'concurrently-updated');
+      fs.copyFileSync(input, mutableInput);
+      const before = extract(mutableInput)!;
+      const bytes = fs.readFileSync(mutableInput);
+      const output = path.join(directory, 'snapshot-output');
+      const read = fs.readFileSync;
+      let inputReads = 0;
+      // Simulate an updater replacing bytes immediately after the last digest
+      // read. A third raw read by the ELF writer would mix two executables.
+      const spy = vi.spyOn(fs, 'readFileSync').mockImplementation(((
+        ...args: Parameters<typeof fs.readFileSync>
+      ) => {
+        const result = Reflect.apply(read, fs, args);
+        if (args[0] === mutableInput && ++inputReads === 2) {
+          const changed = Buffer.from(bytes);
+          changed[0x100] ^= 0xff;
+          fs.writeFileSync(mutableInput, changed);
+        }
+        return result;
+      }) as typeof fs.readFileSync);
+      try {
+        repack(
+          mutableInput,
+          { sourceSha256: before.sourceSha256, modules: [] },
+          output
+        );
+        expect(inputReads).toBe(2);
+      } finally {
+        spy.mockRestore();
+      }
+      expect(fs.readFileSync(output)[0x100]).toBe(bytes[0x100]);
+      expect(fs.readFileSync(mutableInput)[0x100]).not.toBe(bytes[0x100]);
+    }
+  );
+
+  it('rejects a stale source digest without creating output', () => {
+    const output = path.join(directory, 'must-not-exist');
+    expect(() =>
+      repack(input, { sourceSha256: '0'.repeat(64), modules: [] }, output)
+    ).toThrow(/changed since/);
+    expect(fs.existsSync(output)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Recent Claude Code native releases split their JavaScript across embedded Bun modules. Extracting and replacing only the entrypoint cannot modify behavior located in an imported chunk. The automatic-update guard in #408 needs a way to change the actual installer module without rebuilding unrelated bytecode or losing graph metadata.

## What changed

- Add complete module-corpus extraction and `repackNativeInstallationModules`, with full embedded names, table indices, and a source-executable SHA-256 digest. Reject stale inputs, duplicate or missing targets, non-JavaScript records, and invalid replacement encoding.
- Append replacement source while preserving existing payload offsets and untouched module records. Clear the changed module's bytecode, analysis metadata, origin override, source map, and cached source hash. Clear the contiguous-source-layout flag after appending source.
- Use encoding tag `0` for UTF-8 replacement bytes. Bun 1.4.1 reuses the formerly unused tag `2` for UTF-16, so treating it as UTF-8 would corrupt executable source.
- Validate both supported module-record layouts structurally, including table lengths that fit both 36- and 52-byte records.
- Feed the verified source snapshot to the ELF tail writer instead of reopening a potentially replaced input path. Keep the existing single-entrypoint API available.

The module-aware API does not provide an installation lock. In-place callers must serialize writes with other installers; callers handling a concurrently updating input should write to a separate output path. Appended source can increase the executable size; byte-identical source edits preserve the original graph bytes.

## Validation

- `pnpm lint` — passing.
- `pnpm test` — 547 passed, 5 skipped.
- `pnpm build` — passing.
- `pnpm exec prettier --check src` — passing.
- `pnpm exec vitest run src/nativeModuleRoundtrip.test.ts` — compiled a split ESM/bytecode fixture with Bun 1.3.14, replaced an imported module, and executed the result. Covers added exports, bindings, top-level await, Unicode, stale-digest rejection, and input replacement after the final digest read. These tests skip when Bun is unavailable.

Also exercised an isolated, integrity-verified official Claude Code 2.1.261 Linux x64 executable (Bun 1.4.1). Added a binding, export, and top-level await in one imported chunk, repacked, re-extracted, compared every module, and executed `--version`:

```text
Before stdout: 2.1.261 (Claude Code)
After stdout: 2.1.261 (Claude Code)
After stderr: native-module-roundtrip: 🦆 café
Unchanged modules: 1817 / 1817
Stale digest rejected before write; original executable unchanged.
```

Linux executable round trips are verified. Mach-O and PE runtime round trips were not performed; their existing platform writers are reused. No installed Claude Code executable was modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting embedded JavaScript modules from compiled native installations.
  * Added validated replacement of module source code, including support for split bundles.
  * Added repacking of updated modules into native installations while preserving binary integrity.
  * Added lazy-loader APIs for module extraction and repacking.

* **Bug Fixes**
  * Improved validation of module metadata, encoding, source hashes, and binary offsets to prevent invalid replacements.

* **Tests**
  * Added coverage for module detection, replacement scenarios, validation failures, and end-to-end native executable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->